### PR TITLE
Time Range Upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ BUG FIXES:
 
 * Bump [signalfx-go](https://github.com/signalfx/signalfx-go) dependency to [v1.1.0](https://github.com/signalfx/signalfx-go/blob/master/CHANGELOG.md#110-2019-07-15) which fixes a regression in creating "empty" dashboards with any new dashboard group. [#14](https://github.com/terraform-providers/terraform-provider-signalfx/issues/14)
 
+IMPROVEMENTS
+
+* provider - Resources that used `time_range` and still have strings in their state will now be upgraded instead of generating an error.
+
 ## 4.0.0 (July 08, 2019)
 
 NOTES:

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -3,6 +3,7 @@ package signalfx
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -396,4 +397,28 @@ func testAccDetectorDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testTimeRangeStateDataV0() map[string]interface{} {
+	return map[string]interface{}{
+		"time_range": "-1h",
+	}
+}
+
+func testTimeRangeStateDataV1() map[string]interface{} {
+	return map[string]interface{}{
+		"time_range": 3600,
+	}
+}
+
+func TestTimeRangeStateUpgradeV0(t *testing.T) {
+	expected := testTimeRangeStateDataV1()
+	actual, err := timeRangeStateUpgradeV0(testTimeRangeStateDataV0(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
 }

--- a/signalfx/resource_signalfx_event_feed_chart.go
+++ b/signalfx/resource_signalfx_event_feed_chart.go
@@ -29,7 +29,7 @@ func eventFeedChartResource() *schema.Resource {
 			"time_range": &schema.Schema{
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Description:   "Seconds to display in the visualization. This is a rolling range from the current time. Example: 8600 = `-1h`",
+				Description:   "Seconds to display in the visualization. This is a rolling range from the current time. Example: 3600 = `-1h`",
 				ConflictsWith: []string{"start_time", "end_time"},
 			},
 			"start_time": &schema.Schema{

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -444,6 +444,15 @@ func timeChartResource() *schema.Resource {
 			},
 		},
 
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    timeRangeV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: timeRangeStateUpgradeV0,
+				Version: 0,
+			},
+		},
+
 		Create: timechartCreate,
 		Read:   timechartRead,
 		Update: timechartUpdate,

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -149,7 +149,7 @@ func timeChartResource() *schema.Resource {
 			"time_range": &schema.Schema{
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Description:   "Seconds to display in the visualization. This is a rolling range from the current time. Example: 8600 = `-1h`",
+				Description:   "Seconds to display in the visualization. This is a rolling range from the current time. Example: 3600 = `-1h`",
 				ConflictsWith: []string{"start_time", "end_time"},
 			},
 			"start_time": &schema.Schema{


### PR DESCRIPTION
# Summary

Upgrade `time_range` fields in `resource/detector` and `resource/time_chart` to ints.

# Motivation

Uses of `time_range` in old state might break when trying to import them if they are strings.

Fixes #17 