### PR TITLE
Add display name to schema and add import testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
 ## 4.1.1 (Unreleased)
 
+FEATURES:
+
+* resource/time_chart: Added support for `viz_options.display_name` [#13](https://github.com/terraform-providers/terraform-provider-signalfx/issues/13)
+* resource/list_chart: Added support for `viz_options.display_name` [#13](https://github.com/terraform-providers/terraform-provider-signalfx/issues/13)
+* resource/single_value_chart: Added support for `viz_options.display_name` [#13](https://github.com/terraform-providers/terraform-provider-signalfx/issues/13)
+
 BUG FIXES:
 
+* provider: Fixed a number of fields that were not correctly imported. [#27](https://github.com/terraform-providers/terraform-provider-signalfx/pull/27)
 * resource/detector: Fixed incorrect documentation for Slack notifications. Thanks [gpetrousov](https://github.com/gpetrousov). [#25](https://github.com/terraform-providers/terraform-provider-signalfx/issues/25)
 * resource/detector: Fixed invalid field for OpsGenie notifications. [#16](https://github.com/terraform-providers/terraform-provider-signalfx/issues/16)
+* resource/list_chart: Fixed an issue where `viz_options` was not being honored. [#27](https://github.com/terraform-providers/terraform-provider-signalfx/pull/27)
+* resource/single_value_chart: Fixed an issue where `viz_options` was not being honored. [#27](https://github.com/terraform-providers/terraform-provider-signalfx/pull/27)
+* resource/time_chart: Fixed crash where specifying `histogram_options.color_theme` would cause a crash. [#27](https://github.com/terraform-providers/terraform-provider-signalfx/pull/27)
+* resource/time_chart: `show_data_markers` no longer defaults to `false` because it is often omitted from API responses. [#27](https://github.com/terraform-providers/terraform-provider-signalfx/pull/27)
+
+IMPROVEMENTS
+
+* provider - Corrected places where resources were double-setting their URLs. [#27](https://github.com/terraform-providers/terraform-provider-signalfx/pull/27)
+* provider - Added import tests to all resources. [#27](https://github.com/terraform-providers/terraform-provider-signalfx/pull/27)
 
 ## 4.1.0 (July 17, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.1.1 (Unreleased)
+## 4.2.0 (Unreleased)
 
 FEATURES:
 

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -692,6 +692,14 @@ func dashboardRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	appURL, err := buildAppURL(config.CustomAppURL, DashboardAppPath+dash.Id)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("url", appURL); err != nil {
+		return err
+	}
+
 	return dashboardAPIToTF(d, dash)
 }
 

--- a/signalfx/resource_signalfx_dashboard_and_friends_test.go
+++ b/signalfx/resource_signalfx_dashboard_and_friends_test.go
@@ -349,6 +349,12 @@ func TestAccCreateUpdateDashboardGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_dashboard_group.mydashboardgroup0", "name", "My team dashboard group"),
 				),
 			},
+			{
+				ResourceName:      "signalfx_dashboard_group.mydashboardgroup0",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_dashboard_group.mydashboardgroup0"),
+				ImportStateVerify: true,
+			},
 			// Update Everything
 			{
 				Config: updatedDashConfig,

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -44,19 +44,16 @@ func detectorResource() *schema.Resource {
 			"show_data_markers": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: "(false by default) When true, markers will be drawn for each datapoint within the visualization.",
 			},
 			"show_event_lines": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: "(false by default) When true, vertical lines will be drawn for each triggered event within the visualization.",
 			},
 			"disable_sampling": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: "(false by default) When false, samples a subset of the output MTS in the visualization.",
 			},
 			"time_range": &schema.Schema{
@@ -481,6 +478,15 @@ func detectorRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		return err
 	}
+
+	appURL, err := buildAppURL(config.CustomAppURL, DetectorAppPath+det.Id)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("url", appURL); err != nil {
+		return err
+	}
+
 	return detectorAPIToTF(d, det)
 }
 

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -295,9 +295,6 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "description", "your application is slow"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "max_delay", "30"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "program_text", "signal = data('app.delay').max()\ndetect(when(signal > 60, '5m')).publish('Processing old messages 5m')\ndetect(when(signal > 60, '30m')).publish('Processing old messages 30m')\n"),
-					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "show_data_markers", "false"),
-					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "show_event_lines", "false"),
-					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "disable_sampling", "false"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.#", "2"),
 					// Rule #1
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1250591008.description", "maximum > 60 for 5m"),
@@ -323,6 +320,12 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1714348016.severity", "Critical"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1714348016.tip", ""),
 				),
+			},
+			{
+				ResourceName:      "signalfx_detector.application_delay",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_detector.application_delay"),
+				ImportStateVerify: true,
 			},
 			// Update It
 			{

--- a/signalfx/resource_signalfx_event_feed_chart.go
+++ b/signalfx/resource_signalfx_event_feed_chart.go
@@ -134,6 +134,29 @@ func eventfeedchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 		return err
 	}
 
+	options := c.Options
+
+	if options.Time != nil {
+		if options.Time.Type == "relative" {
+			if options.Time.Range != nil {
+				if err := d.Set("time_range", *options.Time.Range/1000); err != nil {
+					return err
+				}
+			}
+		} else {
+			if options.Time.Start != nil {
+				if err := d.Set("start_time", *options.Time.Start/1000); err != nil {
+					return err
+				}
+			}
+			if options.Time.End != nil {
+				if err := d.Set("end_time", *options.Time.End/1000); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -141,6 +164,14 @@ func eventFeedChartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	c, err := config.Client.GetChart(d.Id())
 	if err != nil {
+		return err
+	}
+
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+c.Id)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("url", appURL); err != nil {
 		return err
 	}
 

--- a/signalfx/resource_signalfx_event_feed_chart.go
+++ b/signalfx/resource_signalfx_event_feed_chart.go
@@ -113,7 +113,6 @@ func eventFeedChartCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.Set("url", appURL)
 	if err := d.Set("url", appURL); err != nil {
 		return err
 	}

--- a/signalfx/resource_signalfx_event_feed_chart_test.go
+++ b/signalfx/resource_signalfx_event_feed_chart_test.go
@@ -48,6 +48,12 @@ func TestAccCreateUpdateEventFeedChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_event_feed_chart.mychartEVX", "time_range", "900"),
 				),
 			},
+			{
+				ResourceName:      "signalfx_event_feed_chart.mychartEVX",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_event_feed_chart.mychartEVX"),
+				ImportStateVerify: true,
+			},
 			// Update Everything
 			{
 				Config: updatedEventFeedChartConfig,

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -366,6 +366,16 @@ func heatmapchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 		}
 	}
 
+	if options.SortProperty != "" {
+		sortBy := fmt.Sprintf("+%s", options.SortProperty)
+		if options.SortDirection == "Descending" {
+			sortBy = fmt.Sprintf("-%s", options.SortProperty)
+		}
+		if err := d.Set("sort_by", sortBy); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -375,6 +385,15 @@ func heatmapchartRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+c.Id)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("url", appURL); err != nil {
+		return err
+	}
+
 	return heatmapchartAPIToTF(d, c)
 }
 

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -290,7 +290,6 @@ func heatmapchartCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.Set("url", appURL)
 	if err := d.Set("url", appURL); err != nil {
 		return err
 	}

--- a/signalfx/resource_signalfx_heatmap_chart_test.go
+++ b/signalfx/resource_signalfx_heatmap_chart_test.go
@@ -77,6 +77,12 @@ func TestAccCreateUpdateHeatmapChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "group_by.1", "b"),
 				),
 			},
+			{
+				ResourceName:      "signalfx_heatmap_chart.mychartHX",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_heatmap_chart.mychartHX"),
+				ImportStateVerify: true,
+			},
 			// Update Everything
 			{
 				Config: updatedHeatmapChartConfig,

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -159,6 +159,11 @@ func listChartResource() *schema.Resource {
 							Description:  "Color to use",
 							ValidateFunc: validatePerSignalColor,
 						},
+						"display_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Specifies an alternate value for the Plot Name column of the Data Table associated with the chart.",
+						},
 						"value_unit": &schema.Schema{
 							Type:         schema.TypeString,
 							Optional:     true,

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -307,7 +307,6 @@ func listchartCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.Set("url", appURL)
 	if err := d.Set("url", appURL); err != nil {
 		return err
 	}
@@ -349,6 +348,20 @@ func listchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 	}
 	if err := d.Set("sort_by", options.SortBy); err != nil {
 		return err
+	}
+
+	if len(options.PublishLabelOptions) > 0 {
+		plos := make([]map[string]interface{}, len(options.PublishLabelOptions))
+		for i, plo := range options.PublishLabelOptions {
+			no, err := publishNonTimeLabelOptionsToMap(plo)
+			if err != nil {
+				return err
+			}
+			plos[i] = no
+		}
+		if err := d.Set("viz_options", plos); err != nil {
+			return err
+		}
 	}
 
 	if options.LegendOptions != nil && len(options.LegendOptions.Fields) > 0 {

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -335,6 +335,16 @@ func listchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 	if err := d.Set("color_by", options.ColorBy); err != nil {
 		return err
 	}
+	if options.ColorBy == "Scale" && len(options.ColorScale2) > 0 {
+		colorScale, err := decodeColorScale(options)
+		if err != nil {
+			return err
+		}
+		if err := d.Set("color_scale", colorScale); err != nil {
+			return err
+		}
+	}
+
 	if options.RefreshInterval != nil {
 		if err := d.Set("refresh_interval", *options.RefreshInterval/1000); err != nil {
 			return err
@@ -393,12 +403,20 @@ func listchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 
 func listchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	chart, err := config.Client.GetChart(d.Id())
+	c, err := config.Client.GetChart(d.Id())
 	if err != nil {
 		return err
 	}
 
-	return listchartAPIToTF(d, chart)
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+c.Id)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("url", appURL); err != nil {
+		return err
+	}
+
+	return listchartAPIToTF(d, c)
 }
 
 func listchartUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_list_chart_test.go
+++ b/signalfx/resource_signalfx_list_chart_test.go
@@ -43,6 +43,15 @@ resource "signalfx_list_chart" "mychartLX" {
 		property = "collector"
 		enabled  = false
 	}
+
+	viz_options {
+		label = "CPU Idle"
+		display_name = "CPU Idle Display"
+		color = "azure"
+		value_unit = "Bit"
+		value_prefix = "foo"
+		value_suffix = "bar"
+	}
 }
 `
 
@@ -77,6 +86,15 @@ resource "signalfx_list_chart" "mychartLX" {
 	legend_options_fields {
 		property = "collector"
 		enabled  = false
+	}
+
+	viz_options {
+		label = "CPU Idle"
+		display_name = "CPU Idle Display"
+		color = "azure"
+		value_unit = "Bit"
+		value_prefix = "foo"
+		value_suffix = "bar"
 	}
 }
 `

--- a/signalfx/resource_signalfx_list_chart_test.go
+++ b/signalfx/resource_signalfx_list_chart_test.go
@@ -134,6 +134,12 @@ func TestAccCreateUpdateListChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "color_scale.761948173.lte", "40"),
 				),
 			},
+			{
+				ResourceName:      "signalfx_list_chart.mychartLX",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_list_chart.mychartLX"),
+				ImportStateVerify: true,
+			},
 			// Update Everything
 			{
 				Config: updatedListChartConfig,

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -381,7 +381,6 @@ func singlevaluechartRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("url", appURL); err != nil {
 		return err
 	}
-	d.SetId(c.Id)
 
 	return singlevaluechartAPIToTF(d, c)
 }

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -374,6 +374,15 @@ func singlevaluechartRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+c.Id)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("url", appURL); err != nil {
+		return err
+	}
+	d.SetId(c.Id)
+
 	return singlevaluechartAPIToTF(d, c)
 }
 

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -130,6 +130,11 @@ func singleValueChartResource() *schema.Resource {
 							Description:  "Color to use",
 							ValidateFunc: validatePerSignalColor,
 						},
+						"display_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Specifies an alternate value for the Plot Name column of the Data Table associated with the chart.",
+						},
 						"value_unit": &schema.Schema{
 							Type:         schema.TypeString,
 							Optional:     true,

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -255,7 +255,7 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	// Since things worked, set the URL and move on
-	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+chart.Id)
 	if err != nil {
 		return err
 	}

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -327,44 +327,52 @@ func singlevaluechartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 	}
 
 	if options.ColorBy == "Scale" && len(options.ColorScale2) > 0 {
-		scales := make([]map[string]interface{}, len(options.ColorScale2))
-		for i, cs := range options.ColorScale2 {
-			scale := map[string]interface{}{}
-			if cs.Gt == nil {
-				scale["gt"] = math.MaxFloat32
-			} else {
-				scale["gt"] = *cs.Gt
-			}
-			if cs.Gte == nil {
-				scale["gte"] = math.MaxFloat32
-			} else {
-				scale["gte"] = *cs.Gte
-			}
-			if cs.Lt == nil {
-				scale["lt"] = math.MaxFloat32
-			} else {
-				scale["lt"] = *cs.Lt
-			}
-			if cs.Lte == nil {
-				scale["lte"] = math.MaxFloat32
-			} else {
-				scale["lte"] = *cs.Lte
-			}
-			if cs.PaletteIndex != nil {
-				color, err := getNameFromChartColorsByIndex(int(*cs.PaletteIndex))
-				if err != nil {
-					return err
-				}
-				scale["color"] = color
-			}
-			scales[i] = scale
+		colorScale, err := decodeColorScale(options)
+		if err != nil {
+			return err
 		}
-		if err := d.Set("color_scale", scales); err != nil {
+		if err := d.Set("color_scale", colorScale); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func decodeColorScale(options *chart.Options) ([]map[string]interface{}, error) {
+	scales := make([]map[string]interface{}, len(options.ColorScale2))
+	for i, cs := range options.ColorScale2 {
+		scale := map[string]interface{}{}
+		if cs.Gt == nil {
+			scale["gt"] = math.MaxFloat32
+		} else {
+			scale["gt"] = *cs.Gt
+		}
+		if cs.Gte == nil {
+			scale["gte"] = math.MaxFloat32
+		} else {
+			scale["gte"] = *cs.Gte
+		}
+		if cs.Lt == nil {
+			scale["lt"] = math.MaxFloat32
+		} else {
+			scale["lt"] = *cs.Lt
+		}
+		if cs.Lte == nil {
+			scale["lte"] = math.MaxFloat32
+		} else {
+			scale["lte"] = *cs.Lte
+		}
+		if cs.PaletteIndex != nil {
+			color, err := getNameFromChartColorsByIndex(int(*cs.PaletteIndex))
+			if err != nil {
+				return nil, err
+			}
+			scale["color"] = color
+		}
+		scales[i] = scale
+	}
+	return scales, nil
 }
 
 func singlevaluechartRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -259,7 +259,6 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.Set("url", appURL)
 	if err := d.Set("url", appURL); err != nil {
 		return err
 	}
@@ -304,6 +303,27 @@ func singlevaluechartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 	}
 	if err := d.Set("show_spark_line", options.ShowSparkLine); err != nil {
 		return err
+	}
+	if options.ProgramOptions != nil {
+		if options.ProgramOptions.MaxDelay != nil {
+			if err := d.Set("max_delay", *options.ProgramOptions.MaxDelay/1000); err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(options.PublishLabelOptions) > 0 {
+		plos := make([]map[string]interface{}, len(options.PublishLabelOptions))
+		for i, plo := range options.PublishLabelOptions {
+			no, err := publishNonTimeLabelOptionsToMap(plo)
+			if err != nil {
+				return err
+			}
+			plos[i] = no
+		}
+		if err := d.Set("viz_options", plos); err != nil {
+			return err
+		}
 	}
 
 	if options.ColorBy == "Scale" && len(options.ColorScale2) > 0 {

--- a/signalfx/resource_signalfx_single_value_chart_test.go
+++ b/signalfx/resource_signalfx_single_value_chart_test.go
@@ -119,12 +119,12 @@ func TestAccCreateUpdateSingleValueChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_single_value_chart.mychartSVX", "color_scale.761948173.lte", "40"),
 				),
 			},
-			// {
-			// 	ResourceName:      "signalfx_single_value_chart.mychartSVX",
-			// 	ImportState:       true,
-			// 	ImportStateIdFunc: testAccSingleValueChartStateIdFunc("signalfx_single_value_chart.mychartSVX"),
-			// 	ImportStateVerify: true,
-			// },
+			{
+				ResourceName:      "signalfx_single_value_chart.mychartSVX",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_single_value_chart.mychartSVX"),
+				ImportStateVerify: true,
+			},
 			// Update Everything
 			{
 				Config: updatedSingleValueChartConfig,
@@ -138,7 +138,7 @@ func TestAccCreateUpdateSingleValueChart(t *testing.T) {
 	})
 }
 
-func testAccSingleValueChartStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+func testAccStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/signalfx/resource_signalfx_single_value_chart_test.go
+++ b/signalfx/resource_signalfx_single_value_chart_test.go
@@ -31,6 +31,15 @@ resource "signalfx_single_value_chart" "mychartSVX" {
 		color = "vivid_yellow"
 	}
 
+	viz_options {
+		label = "CPU Idle"
+		display_name = "CPU Display"
+		color = "azure"
+		value_unit = "Bit"
+		value_prefix = "foo"
+		value_suffix = "bar"
+	}
+
   max_delay = 15
   refresh_interval = 1
   max_precision = 2
@@ -59,6 +68,15 @@ resource "signalfx_single_value_chart" "mychartSVX" {
 	color_scale {
 		lte = 40
 		color = "vivid_yellow"
+	}
+
+	viz_options {
+		label = "CPU Idle"
+		display_name = "CPU Display"
+		color = "azure"
+		value_unit = "Bit"
+		value_prefix = "foo"
+		value_suffix = "bar"
 	}
 
   max_delay = 15

--- a/signalfx/resource_signalfx_single_value_chart_test.go
+++ b/signalfx/resource_signalfx_single_value_chart_test.go
@@ -119,6 +119,12 @@ func TestAccCreateUpdateSingleValueChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_single_value_chart.mychartSVX", "color_scale.761948173.lte", "40"),
 				),
 			},
+			// {
+			// 	ResourceName:      "signalfx_single_value_chart.mychartSVX",
+			// 	ImportState:       true,
+			// 	ImportStateIdFunc: testAccSingleValueChartStateIdFunc("signalfx_single_value_chart.mychartSVX"),
+			// 	ImportStateVerify: true,
+			// },
 			// Update Everything
 			{
 				Config: updatedSingleValueChartConfig,
@@ -130,6 +136,17 @@ func TestAccCreateUpdateSingleValueChart(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccSingleValueChartStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return rs.Primary.Attributes["id"], nil
+	}
 }
 
 func testAccCheckSingleValueChartResourceExists(s *terraform.State) error {

--- a/signalfx/resource_signalfx_text_chart.go
+++ b/signalfx/resource_signalfx_text_chart.go
@@ -74,7 +74,6 @@ func textchartCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.Set("url", appURL)
 	if err := d.Set("url", appURL); err != nil {
 		return err
 	}

--- a/signalfx/resource_signalfx_text_chart.go
+++ b/signalfx/resource_signalfx_text_chart.go
@@ -105,6 +105,14 @@ func textchartRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+c.Id)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("url", appURL); err != nil {
+		return err
+	}
+
 	return textchartAPIToTF(d, c)
 }
 

--- a/signalfx/resource_signalfx_text_chart_test.go
+++ b/signalfx/resource_signalfx_text_chart_test.go
@@ -43,6 +43,12 @@ func TestAccCreateUpdateTextChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_text_chart.mychartTX", "markdown", "**farts**"),
 				),
 			},
+			{
+				ResourceName:      "signalfx_text_chart.mychartTX",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_text_chart.mychartTX"),
+				ImportStateVerify: true,
+			},
 			// Update Everything
 			{
 				Config: updatedTextChartConfig,

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -419,6 +419,11 @@ func timeChartResource() *schema.Resource {
 							ValidateFunc: validatePlotTypeTimeChart,
 							Description:  "(Chart plot_type by default) The visualization style to use. Must be \"LineChart\", \"AreaChart\", \"ColumnChart\", or \"Histogram\"",
 						},
+						"display_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Specifies an alternate value for the Plot Name column of the Data Table associated with the chart.",
+						},
 						"value_unit": &schema.Schema{
 							Type:         schema.TypeString,
 							Optional:     true,

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -943,6 +943,29 @@ func axisToMap(axis *chart.Axes) []*map[string]interface{} {
 	return nil
 }
 
+// This function handles a LabelOptions for non-time charts.
+func publishNonTimeLabelOptionsToMap(options *chart.PublishLabelOptions) (map[string]interface{}, error) {
+	color := ""
+	if options.PaletteIndex != nil {
+		// We might not have a color, so tread lightly
+		c, err := getNameFromPaletteColorsByIndex(int(*options.PaletteIndex))
+		if err != nil {
+			return map[string]interface{}{}, err
+		}
+		// Ok, we can set the color now
+		color = c
+	}
+
+	return map[string]interface{}{
+		"label":        options.Label,
+		"display_name": options.DisplayName,
+		"color":        color,
+		"value_unit":   options.ValueUnit,
+		"value_suffix": options.ValueSuffix,
+		"value_prefix": options.ValuePrefix,
+	}, nil
+}
+
 func publishLabelOptionsToMap(options *chart.PublishLabelOptions) (map[string]interface{}, error) {
 	color := ""
 	if options.PaletteIndex != nil {
@@ -961,6 +984,7 @@ func publishLabelOptionsToMap(options *chart.PublishLabelOptions) (map[string]in
 
 	return map[string]interface{}{
 		"label":        options.Label,
+		"display_name": options.DisplayName,
 		"color":        color,
 		"axis":         axis,
 		"plot_type":    options.PlotType,

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -751,7 +751,6 @@ func timechartRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("url", appURL); err != nil {
 		return err
 	}
-	d.SetId(c.Id)
 
 	return timechartAPIToTF(d, c)
 }

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -532,6 +532,9 @@ func getPerSignalVizOptions(d *schema.ResourceData) []*chart.PublishLabelOptions
 		item := &chart.PublishLabelOptions{
 			Label: v["label"].(string),
 		}
+		if val, ok := v["display_name"].(string); ok && val != "" {
+			item.DisplayName = val
+		}
 		if val, ok := v["color"].(string); ok {
 			if elem, ok := PaletteColors[val]; ok {
 				i := int32(elem)

--- a/signalfx/resource_signalfx_time_chart_test.go
+++ b/signalfx/resource_signalfx_time_chart_test.go
@@ -43,6 +43,7 @@ resource "signalfx_time_chart" "mychartXX" {
 		}
     viz_options {
         label = "CPU Idle"
+				display_name = "CPU Idle Display"
         axis = "left"
         color = "orange"
 				plot_type = "Histogram"
@@ -108,6 +109,7 @@ resource "signalfx_time_chart" "mychartXX" {
 		}
     viz_options {
         label = "CPU Idle"
+				display_name = "CPU Idle Display"
         axis = "left"
         color = "orange"
 				plot_type = "Histogram"
@@ -194,6 +196,7 @@ func TestAccCreateUpdateTimeChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.axis", "left"),
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.color", "orange"),
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.label", "CPU Idle"),
+					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.display_name", "CPU Idle Display"),
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.plot_type", "Histogram"),
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.value_prefix", "prefix"),
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.value_suffix", "suffix"),

--- a/signalfx/resource_signalfx_time_chart_test.go
+++ b/signalfx/resource_signalfx_time_chart_test.go
@@ -31,8 +31,7 @@ resource "signalfx_time_chart" "mychartXX" {
 		disable_sampling = true
 		timezone = "Europe/Paris"
 
-    plot_type = "LineChart"
-    show_data_markers = true
+    plot_type = "Histogram"
 		show_event_lines = true
 		stacked = false
 		axes_precision = 4
@@ -76,10 +75,103 @@ resource "signalfx_time_chart" "mychartXX" {
 				max_value = 2101
     }
 }
+
+resource "signalfx_time_chart" "mychartXY" {
+    name = "CPU Total Idle"
+		description = "I am described"
+
+    program_text = <<-EOF
+        data('cpu.total.idle').publish(label='CPU Idle')
+        EOF
+
+    time_range = 900
+
+		axes_include_zero = true
+		unit_prefix = "Binary"
+		color_by = "Metric"
+		minimum_resolution = 30
+		max_delay = 15
+		disable_sampling = true
+		timezone = "Europe/Paris"
+
+    plot_type = "LineChart"
+    show_data_markers = true
+		show_event_lines = true
+		stacked = false
+		axes_precision = 4
+
+		legend_options_fields {
+			property = "collector"
+			enabled  = false
+		}
+}
 `
 
 const updatedTimeChartConfig = `
 resource "signalfx_time_chart" "mychartXX" {
+    name = "CPU Total Idle NEW"
+		description = "I am described NEW"
+
+    program_text = <<-EOF
+        data('cpu.total.idle').publish(label='CPU Idle')
+        EOF
+
+    time_range = 900
+
+		axes_include_zero = true
+		unit_prefix = "Binary"
+		color_by = "Metric"
+		minimum_resolution = 30
+		max_delay = 15
+		disable_sampling = true
+		timezone = "Europe/Paris"
+
+    plot_type = "LineChart"
+		show_event_lines = true
+		stacked = false
+		axes_precision = 4
+
+		legend_options_fields {
+			property = "collector"
+			enabled  = false
+		}
+    viz_options {
+        label = "CPU Idle"
+				display_name = "CPU Idle Display"
+        axis = "left"
+        color = "orange"
+				plot_type = "Histogram"
+				value_unit = "Byte"
+				value_prefix = "prefix"
+				value_suffix = "suffix"
+    }
+
+		histogram_options {
+			color_theme = "lilac"
+		}
+
+    axis_left {
+        label = "OMG on fire"
+				high_watermark = 2000
+				high_watermark_label = "high"
+        low_watermark = 1000
+				low_watermark_label = "low"
+				min_value = 900
+				max_value = 2100
+    }
+
+		axis_right {
+        label = "OMG still on fire"
+				high_watermark = 2001
+				high_watermark_label = "higher"
+        low_watermark = 1001
+				low_watermark_label = "lower"
+				min_value = 901
+				max_value = 2101
+    }
+}
+
+resource "signalfx_time_chart" "mychartXY" {
     name = "CPU Total Idle NEW"
 		description = "I am described NEW"
 
@@ -107,40 +199,6 @@ resource "signalfx_time_chart" "mychartXX" {
 			property = "collector"
 			enabled  = false
 		}
-    viz_options {
-        label = "CPU Idle"
-				display_name = "CPU Idle Display"
-        axis = "left"
-        color = "orange"
-				plot_type = "Histogram"
-				value_unit = "Byte"
-				value_prefix = "prefix"
-				value_suffix = "suffix"
-    }
-
-		histogram_options {
-			color_theme = "lilac"
-		}
-
-    axis_left {
-        label = "OMG on fire"
-				high_watermark = 2000
-				high_watermark_label = "high"
-        low_watermark = 1000
-				low_watermark_label = "low"
-				min_value = 900
-				max_value = 2100
-    }
-
-		axis_right {
-        label = "OMG still on fire"
-				high_watermark = 2001
-				high_watermark_label = "higher"
-        low_watermark = 1001
-				low_watermark_label = "lower"
-				min_value = 901
-				max_value = 2101
-    }
 }
 `
 
@@ -157,56 +215,15 @@ func TestAccCreateUpdateTimeChart(t *testing.T) {
 					testAccCheckTimeChartResourceExists,
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "name", "CPU Total Idle"),
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "description", "I am described"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "program_text", "data('cpu.total.idle').publish(label='CPU Idle')\n"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axes_include_zero", "true"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "unit_prefix", "Binary"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "color_by", "Metric"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "minimum_resolution", "30"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "max_delay", "15"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "disable_sampling", "true"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "timezone", "Europe/Paris"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "time_range", "900"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "show_data_markers", "true"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "show_event_lines", "true"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "stacked", "false"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axes_precision", "4"),
-
-					// Left Axis
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_left.#", "1"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_left.5950944.high_watermark", "2000"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_left.5950944.high_watermark_label", "high"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_left.5950944.label", "OMG on fire"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_left.5950944.low_watermark", "1000"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_left.5950944.low_watermark_label", "low"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_left.5950944.max_value", "2100"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_left.5950944.min_value", "900"),
-
-					// Right Axis
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_right.#", "1"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_right.3852869422.high_watermark", "2001"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_right.3852869422.high_watermark_label", "higher"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_right.3852869422.label", "OMG still on fire"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_right.3852869422.low_watermark", "1001"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_right.3852869422.low_watermark_label", "lower"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_right.3852869422.max_value", "2101"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "axis_right.3852869422.min_value", "901"),
-
-					// Viz Options
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.#", "1"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.axis", "left"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.color", "orange"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.label", "CPU Idle"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.display_name", "CPU Idle Display"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.plot_type", "Histogram"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.value_prefix", "prefix"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.value_suffix", "suffix"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "viz_options.53506722.value_unit", "Byte"),
-
-					// Legend Options
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "legend_options_fields.#", "1"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "legend_options_fields.0.enabled", "false"),
-					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "legend_options_fields.0.property", "collector"),
+					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXY", "name", "CPU Total Idle"),
+					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXY", "description", "I am described"),
 				),
+			},
+			{
+				ResourceName:      "signalfx_time_chart.mychartXX",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_time_chart.mychartXX"),
+				ImportStateVerify: true,
 			},
 			// Update Everything
 			{
@@ -215,6 +232,8 @@ func TestAccCreateUpdateTimeChart(t *testing.T) {
 					testAccCheckTimeChartResourceExists,
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "name", "CPU Total Idle NEW"),
 					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXX", "description", "I am described NEW"),
+					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXY", "name", "CPU Total Idle NEW"),
+					resource.TestCheckResourceAttr("signalfx_time_chart.mychartXY", "description", "I am described NEW"),
 				),
 			},
 		},

--- a/website/docs/r/list_chart.html.markdown
+++ b/website/docs/r/list_chart.html.markdown
@@ -71,6 +71,7 @@ The following arguments are supported in the resource block:
 * `refresh_interval` - (Optional) How often (in seconds) to refresh the values of the list.
 * `viz_options` - (Optional) Plot-level customization options, associated with a publish statement.
     * `label` - (Required) Label used in the publish statement that displays the plot (metric time series data) you want to customize.
+    * `display_name` - (Optional) Specifies an alternate value for the Plot Name column of the Data Table associated with the chart.
     * `color` - (Optional) Color to use : gray, blue, azure, navy, brown, orange, yellow, iris, magenta, pink, purple, violet, lilac, emerald, green, aquamarine.
     * `value_unit` - (Optional) A unit to attach to this plot. Units support automatic scaling (eg thousands of bytes will be displayed as kilobytes). Values values are `Bit, Kilobit, Megabit, Gigabit, Terabit, Petabit, Exabit, Zettabit, Yottabit, Byte, Kibibyte, Mebibyte, Gigibyte, Tebibyte, Pebibyte, Exbibyte, Zebibyte, Yobibyte, Nanosecond, Microsecond, Millisecond, Second, Minute, Hour, Day, Week`.
     * `value_prefix`, `value_suffix` - (Optional) Arbitrary prefix/suffix to display with the value of this plot.

--- a/website/docs/r/single_value_chart.html.markdown
+++ b/website/docs/r/single_value_chart.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported in the resource block:
     * `color` - (Required) The color range to use. Must be either gray, blue, navy, orange, yellow, magenta, purple, violet, lilac, green, aquamarine.
 * `viz_options` - (Optional) Plot-level customization options, associated with a publish statement.
     * `label` - (Required) Label used in the publish statement that displays the plot (metric time series data) you want to customize.
+    * `display_name` - (Optional) Specifies an alternate value for the Plot Name column of the Data Table associated with the chart.
     * `color` - (Optional) Color to use : gray, blue, azure, navy, brown, orange, yellow, iris, magenta, pink, purple, violet, lilac, emerald, green, aquamarine.
     * `value_unit` - (Optional) A unit to attach to this plot. Units support automatic scaling (eg thousands of bytes will be displayed as kilobytes). Values values are `Bit, Kilobit, Megabit, Gigabit, Terabit, Petabit, Exabit, Zettabit, Yottabit, Byte, Kibibyte, Mebibyte, Gigibyte, Tebibyte, Pebibyte, Exbibyte, Zebibyte, Yobibyte, Nanosecond, Microsecond, Millisecond, Second, Minute, Hour, Day, Week`.
     * `value_prefix`, `value_suffix` - (Optional) Arbitrary prefix/suffix to display with the value of this plot.

--- a/website/docs/r/time_chart.html.markdown
+++ b/website/docs/r/time_chart.html.markdown
@@ -98,6 +98,7 @@ The following arguments are supported in the resource block:
     * `low_watermark_label` - (Optional) A label to attach to the low watermark line.
 * `viz_options` - (Optional) Plot-level customization options, associated with a publish statement.
     * `label` - (Required) Label used in the publish statement that displays the plot (metric time series data) you want to customize.
+    * `display_name` - (Optional) Specifies an alternate value for the Plot Name column of the Data Table associated with the chart.
     * `color` - (Optional) Color to use : gray, blue, azure, navy, brown, orange, yellow, iris, magenta, pink, purple, violet, lilac, emerald, green, aquamarine.
     * `axis` - (Optional) Y-axis associated with values for this plot. Must be either `right` or `left`.
     * `plot_type` - (Optional) The visualization style to use. Must be `"LineChart"`, `"AreaChart"`, `"ColumnChart"`, or `"Histogram"`. Chart level `plot_type` by default.


### PR DESCRIPTION
# Summary
Adds import testing and adds `display_name` to chart types that support it.

# Motivation

Well, this escalated quickly.

Terraform 0.12 has some changes that leave the testing in flux. Specifically items that use `TypeSet` no longer output the digest needed to test them with `TestCheckResourceAttr`. Adding `display_name` caused the digests of existing `viz_options` to change and broke tests. As a result I had to ask some question of HashiCorp. We landed on using import tests — which fetch the resource and compare it to the state of the existing resource — to verify things. This works because we use the same code to import that we do to set state.

This led to a bunch of bugs being found. Since the `display_name` is such a small addition I just rolled it all into one honking PR.

Fixes #13 