### PR TITLE
Remove credentialName field from OpsGenie notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 BUG FIXES:
 
 * resource/detector: Fixed incorrect documentation for Slack notifications. Thanks [gpetrousov](https://github.com/gpetrousov). [#25](https://github.com/terraform-providers/terraform-provider-signalfx/issues/25)
-
+* resource/detector: Fixed invalid field for OpsGenie notifications. [#16](https://github.com/terraform-providers/terraform-provider-signalfx/issues/16)
 
 ## 4.1.0 (July 17, 2019)
 

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -337,10 +337,9 @@ func getNotifications(tf_notifications []interface{}) []map[string]interface{} {
 			item["team"] = vars[1]
 		case "Opsgenie":
 			item["credentialId"] = vars[1]
-			item["credentialName"] = vars[2]
-			item["responderName"] = vars[3]
-			item["responderId"] = vars[4]
-			item["responderType"] = vars[5]
+			item["responderName"] = vars[2]
+			item["responderId"] = vars[3]
+			item["responderType"] = vars[4]
 		case "VictorOps":
 			item["credentialId"] = vars[1]
 			item["routingKey"] = vars[2]
@@ -369,10 +368,6 @@ func getNotifyStringFromAPI(notification map[string]interface{}) (string, error)
 		if !ok {
 			return "", fmt.Errorf("Missing credentialId field from notification body")
 		}
-		credName, ok := notification["credentialName"].(string)
-		if !ok {
-			return "", fmt.Errorf("Missing credentialName field from notification body")
-		}
 		respName, ok := notification["responderName"].(string)
 		if !ok {
 			return "", fmt.Errorf("Missing responderName field from notification body")
@@ -385,7 +380,7 @@ func getNotifyStringFromAPI(notification map[string]interface{}) (string, error)
 		if !ok {
 			return "", fmt.Errorf("Missing responderType field from notification body")
 		}
-		return fmt.Sprintf("%s,%s,%s,%s,%s,%s", nt, cred, credName, respName, respId, respType), nil
+		return fmt.Sprintf("%s,%s,%s,%s,%s", nt, cred, respName, respId, respType), nil
 
 	case "PagerDuty", "BigPanda", "Office365", "ServiceNow", "XMatters":
 		cred, ok := notification["credentialId"].(string)

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -21,12 +21,11 @@ func TestNotifyStringFromAPI(t *testing.T) {
 			"email": "foo@example.com",
 		},
 		{
-			"type":           "Opsgenie",
-			"credentialId":   "XXX",
-			"credentialName": "YYY",
-			"responderName":  "Foo",
-			"responderId":    "ABC123",
-			"responderType":  "Team",
+			"type":          "Opsgenie",
+			"credentialId":  "XXX",
+			"responderName": "Foo",
+			"responderId":   "ABC123",
+			"responderType": "Team",
 		},
 		{
 			"type":         "PagerDuty",
@@ -76,7 +75,7 @@ func TestNotifyStringFromAPI(t *testing.T) {
 
 	expected := []string{
 		"Email,foo@example.com",
-		"Opsgenie,XXX,YYY,Foo,ABC123,Team",
+		"Opsgenie,XXX,Foo,ABC123,Team",
 		"PagerDuty,XXX",
 		"Slack,XXX,#foobar",
 		"Team,ABC123",
@@ -101,7 +100,7 @@ func TestGetNotifications(t *testing.T) {
 		"Email,test@yelp.com",
 		"PagerDuty,credId",
 		"Webhook,test,https://foo.bar.com?user=test&action=alert",
-		"Opsgenie,credId,credName,respName,respId,respType",
+		"Opsgenie,credId,respName,respId,respType",
 		"Slack,credId,#channel",
 		"Team,teamId",
 		"TeamEmail,teamId",
@@ -127,12 +126,11 @@ func TestGetNotifications(t *testing.T) {
 			"url":    "https://foo.bar.com?user=test&action=alert",
 		},
 		map[string]interface{}{
-			"type":           "Opsgenie",
-			"credentialId":   "credId",
-			"credentialName": "credName",
-			"responderName":  "respName",
-			"responderId":    "respId",
-			"responderType":  "respType",
+			"type":          "Opsgenie",
+			"credentialId":  "credId",
+			"responderName": "respName",
+			"responderId":   "respId",
+			"responderType": "respType",
 		},
 		map[string]interface{}{
 			"type":         "Slack",


### PR DESCRIPTION
# Summary

Remove `credentialName` field from OpsGenie

# Motivation

This field didn't really exist! Fixes #16 