### PR TITLE
Add docs for multiple notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 4.3.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* resources/detector: Improved documentation around multiple notifications in a single rule. [#30](https://github.com/terraform-providers/terraform-provider-signalfx/issues/30)
+
 ## 4.2.0 (July 19, 2019)
 
 FEATURES:
@@ -34,8 +39,7 @@ BUG FIXES:
 * provider: Correct a number of fields that defaulted to 0, resulting unintentional "defaults". Should improve unclean plans.
 * resource/dashboard: Fix a crash when using `grid` with a new dashboard. [#20](https://github.com/terraform-providers/terraform-provider-signalfx/issues/20)
 
-
-IMPROVEMENTS
+IMPROVEMENTS:
 
 * provider - Resources that used `time_range` and still have strings in their state will now be upgraded instead of generating an error.
 

--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -46,7 +46,13 @@ variable "clusters" {
 
 ## Notification Format
 
-As SignalFx supports different notification mechanisms a comma-delimited string is used to provide inputs. This will likely be changed in a future iteration of the provider. For now, here are some example of how to configure each notification type:
+As SignalFx supports different notification mechanisms a comma-delimited string is used to provide inputs. If you'd like to specify multiple notifications, then each should be a member in the list, like so:
+
+```
+notifications = ["Email,foo-alerts@example.com", "Slack,credentialId,#channel"]
+```
+
+This will likely be changed in a future iteration of the provider. For now, here are some example of how to configure each notification type:
 
 ### Email
 
@@ -70,8 +76,10 @@ notifications = ["PagerDuty,credentialId"]
 
 ### Slack
 
+Include the `#` on the channel name!
+
 ```
-notifications = ["Slack,credentialId,channel"]
+notifications = ["Slack,credentialId,#channel"]
 ```
 
 ### Team


### PR DESCRIPTION
# Summary

Add documentation for handling multiple notifications.

# Motivation

None of the examples show multiple notifications, so add something to help future users and avoid ambiguity.