### PR TITLE
Updating docs for Opsgenie notifications. 

### DIFF
--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -52,7 +52,7 @@ As SignalFx supports different notification mechanisms a comma-delimited string 
 notifications = ["Email,foo-alerts@example.com", "Slack,credentialId,#channel"]
 ```
 
-This will likely be changed in a future iteration of the provider. For now, here are some example of how to configure each notification type:
+This will likely be changed in a future iteration of the provider. See [SignalFX Docs](https://developers.signalfx.com/detectors_reference.html#operation/Create%20Single%20Detector) for more information. For now, here are some example of how to configure each notification type:
 
 ### Email
 
@@ -62,10 +62,10 @@ notifications = ["Email,foo-alerts@bar.com"]
 
 ### Opsgenie
 
-Note that the `credentialId` is the SignalFx-provided ID shown after setting up your Opsgenie integration.
+Note that the `credentialId` is the SignalFx-provided ID shown after setting up your Opsgenie integration. `Team` here is hardcoded as the `responderType` as that is the only acceptable type as per the API docs.
 
 ```
-notifications = ["Opsgenie,credentialId,credentialName,responderName,responderId,responderType"]
+notifications = ["Opsgenie,credentialId,responderName,responderId,Team"]
 ```
 
 ### PagerDuty


### PR DESCRIPTION
From what I see in the code credentialName is not supported. `Team` is the only supported `responderType` as per the API docs. I linked the docs for detector creation as well