### PR TITLE
Fix incorrect detection of status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * provider: Added support for Azure integrations [#34](https://github.com/terraform-providers/terraform-provider-signalfx/pull/34)
 
+BUG FIXES:
+
+* provider: Fixed a problem where resources that had gone missing were not recreated, but instead threw errors. [#38](https://github.com/terraform-providers/terraform-provider-signalfx/pull/38)
+
 IMPROVEMENTS:
 
 * provider: Added AWS resource link to documentation sidebar. [#37](https://github.com/terraform-providers/terraform-provider-signalfx/pull/37)

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -677,7 +677,7 @@ func dashboardExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
 	_, err := config.Client.GetDashboard(d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "Bad status 404") {
+		if strings.Contains(err.Error(), "404") {
 			return false, nil
 		}
 		return false, err

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -121,7 +121,7 @@ func dashboardgroupExists(d *schema.ResourceData, meta interface{}) (bool, error
 	config := meta.(*signalfxConfig)
 	_, err := config.Client.GetDashboardGroup(d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "Bad status 404") {
+		if strings.Contains(err.Error(), "404") {
 			return false, nil
 		}
 		return false, err

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -461,7 +461,7 @@ func detectorExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
 	_, err := config.Client.GetDetector(d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "Bad status 404") {
+		if strings.Contains(err.Error(), "404") {
 			return false, nil
 		}
 		return false, err
@@ -473,7 +473,7 @@ func detectorRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	det, err := config.Client.GetDetector(d.Id())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "Bad status 404") {
+		if strings.HasPrefix(err.Error(), "404") {
 			d.SetId("")
 		}
 		return err

--- a/signalfx/resource_signalfx_integration_aws.go
+++ b/signalfx/resource_signalfx_integration_aws.go
@@ -178,7 +178,7 @@ func integrationAWSExists(d *schema.ResourceData, meta interface{}) (bool, error
 	config := meta.(*signalfxConfig)
 	_, err := config.Client.GetAWSCloudWatchIntegration(d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "Bad status 404") {
+		if strings.Contains(err.Error(), "404") {
 			return false, nil
 		}
 		return false, err
@@ -190,7 +190,7 @@ func integrationAWSRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	int, err := config.Client.GetAWSCloudWatchIntegration(d.Id())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "Bad status 404") {
+		if strings.HasPrefix(err.Error(), "404") {
 			d.SetId("")
 		}
 		return err

--- a/signalfx/resource_signalfx_integration_azure.go
+++ b/signalfx/resource_signalfx_integration_azure.go
@@ -89,7 +89,7 @@ func integrationAzureExists(d *schema.ResourceData, meta interface{}) (bool, err
 	config := meta.(*signalfxConfig)
 	_, err := config.Client.GetAzureIntegration(d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "Bad status 404") {
+		if strings.Contains(err.Error(), "404") {
 			return false, nil
 		}
 		return false, err
@@ -101,7 +101,7 @@ func integrationAzureRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	int, err := config.Client.GetAzureIntegration(d.Id())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "Bad status 404") {
+		if strings.HasPrefix(err.Error(), "404") {
 			d.SetId("")
 		}
 		return err

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -86,7 +86,7 @@ func chartExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
 	_, err := config.Client.GetChart(d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "Bad status 404") {
+		if strings.Contains(err.Error(), "404") {
 			return false, nil
 		}
 		return false, err


### PR DESCRIPTION
# Summary

Fixes incorrect detection of 404s

# Motivation

The `Exists` functions for resources was using a bad string for detecting status codes. Dropped everything but the 404.