### PR TITLE
Don't allow more than one left or right axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ IMPROVEMENTS:
 
 * provider: Added AWS resource link to documentation sidebar. [#37](https://github.com/terraform-providers/terraform-provider-signalfx/pull/37)
 * resources/detector: Improved documentation for OpsGenie notifications. Thanks [austburn](https://github.com/austburn)! Thanks [#36](https://github.com/terraform-providers/terraform-provider-signalfx/pull/36).
+* resources/time_chart: `axis_left` and `axis_right` are now limited to single uses. This was always the case, but it's now enforced in the schema to prevent blissful ignorance.
 
 ## 4.3.0 (July 24, 2019)
 

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -167,6 +167,7 @@ func timeChartResource() *schema.Resource {
 			"axis_right": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					SchemaVersion: 1,
 					MigrateState:  resourceAxisMigrateState,
@@ -234,6 +235,7 @@ func timeChartResource() *schema.Resource {
 			"axis_left": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					SchemaVersion: 1,
 					MigrateState:  resourceAxisMigrateState,

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -933,7 +933,7 @@ func axisToMap(axis *chart.Axes) []*map[string]interface{} {
 		if axis.Max != nil {
 			max = float64(*axis.Max)
 		}
-		min := math.MaxFloat64
+		min := -math.MaxFloat64
 		if axis.Min != nil {
 			min = float64(*axis.Min)
 		}


### PR DESCRIPTION
# Summary
Sets `MaxItems` on `time_chart`'s `axis_left` and `axis_right`.

# Motivation
I realized you can set this, which is good cuz we would've ignored > 1. :)