### PR TITLE
Bump GCP to use client and turn on testing with enabled false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-* resource/gcp_integration: Added `Exists` functionality, enabled acceptance tests, and use the new `*GCPIntegration` methods from signalfx-go. [XX](https://www.example.com)
+* resource/gcp_integration: Added `Exists` functionality, enabled acceptance tests, and use the new `*GCPIntegration` methods from signalfx-go. [#50](https://github.com/terraform-providers/terraform-provider-signalfx/pull/50)
 
 ## 4.5.0 (August 09, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 4.5.1 (Unreleased)
+## 4.6.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* resource/gcp_integration: Added `Exists` functionality, enabled acceptance tests, and use the new `*GCPIntegration` methods from signalfx-go. [XX](https://www.example.com)
+
 ## 4.5.0 (August 09, 2019)
 
 FEATURES:
@@ -8,7 +13,7 @@ FEATURES:
 IMPROVEMENTS:
 
 * provider: Bumped Terraform dependency to v0.12.6 [#47](https://github.com/terraform-providers/terraform-provider-signalfx/pull/47)
-* resource/integration_gcp: Improve the GCP documentation example. Thanks [a-staebler](https://github.com/a-staebler) [#41](https://github.com/terraform-providers/terraform-provider-signalfx/pull/41)
+* resource/gcp_integration: Improve the GCP documentation example. Thanks [a-staebler](https://github.com/a-staebler) [#41](https://github.com/terraform-providers/terraform-provider-signalfx/pull/41)
 * resource/detector: Notifications are now validated to prevent crashes and problems. [#46](https://github.com/terraform-providers/terraform-provider-signalfx/pull/46)
 * resource/detector: Fixed a bug in Webhook notification specifications, it was missing a `credentialId`.
 * resource/detector: Corrected documentation that disagreed on whether to include `#` in Slack channel names. In a word: don't.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform v0.12.6
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/signalfx/golib v2.4.0+incompatible // indirect
-	github.com/signalfx/signalfx-go v1.5.1-0.20190808201309-79a3e969a4c6
+	github.com/signalfx/signalfx-go v1.5.1-0.20190813152720-b115c0f8d31b
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,10 @@ github.com/signalfx/golib v2.4.0+incompatible h1:VtCORl7AdhkCIy3rS0m3WLpcNmqGcWo
 github.com/signalfx/golib v2.4.0+incompatible/go.mod h1:nWYefOwlUKWm/SpN/LgVSBnyH1T9NpT1ANlmgRIi1Cs=
 github.com/signalfx/signalfx-go v1.5.1-0.20190808201309-79a3e969a4c6 h1:ODi+6HZpd140s4viwoiNg+emHmNmHa2iupkm06QU7U8=
 github.com/signalfx/signalfx-go v1.5.1-0.20190808201309-79a3e969a4c6/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
+github.com/signalfx/signalfx-go v1.5.1-0.20190813151742-a8f81368dd71 h1:jmwEQIp8QH8mME5w10Ie1ZBjurGiFJNNsbmdJtlEjHo=
+github.com/signalfx/signalfx-go v1.5.1-0.20190813151742-a8f81368dd71/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
+github.com/signalfx/signalfx-go v1.5.1-0.20190813152720-b115c0f8d31b h1:PhqKkqWghwMEb776yX7qf2bfFw/y+Uh116T+LZeX1Lg=
+github.com/signalfx/signalfx-go v1.5.1-0.20190813152720-b115c0f8d31b/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
 github.com/signalfx/signalfx-go v1.5.1 h1:bsxqPwDiYrREOYoORu6OLPhi604voYaJGFsU63rgVI0=
 github.com/signalfx/signalfx-go v1.5.1/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=

--- a/signalfx/resource_signalfx_integration.go
+++ b/signalfx/resource_signalfx_integration.go
@@ -122,8 +122,6 @@ func getPayloadIntegration(d *schema.ResourceData) ([]byte, error) {
 		payload, err = getPagerDutyPayloadIntegration(d)
 	case "Slack":
 		payload, err = getSlackPayloadIntegration(d)
-	case "GCP":
-		payload, err = getGCPPayloadIntegration(d)
 	default:
 		err = fmt.Errorf("Unknown integration type: %s", integrationType)
 	}
@@ -183,35 +181,6 @@ func integrationDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return resourceDelete(url, config.AuthToken, d)
-}
-
-func expandServices(services []interface{}) []string {
-	if len(services) == 0 {
-		return []string{}
-	}
-	payload := make([]string, 0, len(services))
-	for _, service := range services {
-		if service != nil {
-			payload = append(payload, service.(string))
-		}
-	}
-	return payload
-}
-
-func expandProjectServiceKeys(projects []interface{}) []map[string]string {
-	if len(projects) == 0 {
-		return []map[string]string{}
-	}
-	payload := make([]map[string]string, 0, len(projects))
-	for _, project := range projects {
-		m := project.(map[string]interface{})
-		config := map[string]string{
-			"projectId":  m["project_id"].(string),
-			"projectKey": m["project_key"].(string),
-		}
-		payload = append(payload, config)
-	}
-	return payload
 }
 
 func validatePollRate(value interface{}, key string) (warns []string, errors []error) {

--- a/signalfx/resource_signalfx_integration_test.go
+++ b/signalfx/resource_signalfx_integration_test.go
@@ -23,38 +23,6 @@ func TestValidatePollRateNotAllowed(t *testing.T) {
 	assert.Equal(t, 1, len(errors))
 }
 
-func TestExpandServicesSuccess(t *testing.T) {
-	values := []interface{}{"compute", "appengine"}
-	expected := []string{"compute", "appengine"}
-	result := expandServices(values)
-	assert.ElementsMatch(t, expected, result)
-}
-
-func TestExpandProjectServiceKeysSuccess(t *testing.T) {
-	values := []interface{}{
-		map[string]interface{}{
-			"project_id":  "test_project",
-			"project_key": "{\"type\":\"service_account\", \"project_id\": \"test_project\"}",
-		},
-		map[string]interface{}{
-			"project_id":  "test_project_2",
-			"project_key": "{\"type\":\"service_account\", \"project_id\": \"test_project_2\"}",
-		},
-	}
-	expected := []map[string]string{
-		map[string]string{
-			"projectId":  "test_project",
-			"projectKey": "{\"type\":\"service_account\", \"project_id\": \"test_project\"}",
-		},
-		map[string]string{
-			"projectId":  "test_project_2",
-			"projectKey": "{\"type\":\"service_account\", \"project_id\": \"test_project_2\"}",
-		},
-	}
-	result := expandProjectServiceKeys(values)
-	assert.ElementsMatch(t, expected, result)
-}
-
 const newIntegrationConfig = `
 resource "signalfx_integration" "slack_myteam" {
     name = "Slack - My Team"

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -1,8 +1,16 @@
 # 1.6.0, Unreleased
 
+## Added
+
+* Added `*GCPIntegration` methods
+* Added `*OpsGenie` methods
+* Added `*PagerDutyIntegration` methods
+* Added `*SlackIntegration` methods
+
 ## Updated
 
 * `Detector.Rules` now uses `Notification` as it's type instead of an untyped `[]map[string]interface{}`.
+* Renamed `integration.GcpIntegration` and it's sub-types to `GCP`, fixing case.
 
 # 1.5.0, 2019-08-05
 

--- a/vendor/github.com/signalfx/signalfx-go/gcp_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/gcp_integration.go
@@ -1,0 +1,101 @@
+package signalfx
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/signalfx/signalfx-go/integration"
+)
+
+// CreateGCPIntegration creates a GCP integration.
+func (c *Client) CreateGCPIntegration(gcpi *integration.GCPIntegration) (*integration.GCPIntegration, error) {
+	payload, err := json.Marshal(gcpi)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.GCPIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// GetGCPIntegration retrieves a GCP integration.
+func (c *Client) GetGCPIntegration(id string) (*integration.GCPIntegration, error) {
+	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.GCPIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// UpdateGCPIntegration updates a GCP integration.
+func (c *Client) UpdateGCPIntegration(id string, gcpi *integration.GCPIntegration) (*integration.GCPIntegration, error) {
+	payload, err := json.Marshal(gcpi)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.GCPIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// DeleteGCPIntegration deletes a GCP integration.
+func (c *Client) DeleteGCPIntegration(id string) error {
+	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	return err
+}

--- a/vendor/github.com/signalfx/signalfx-go/integration/model_gcp_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/integration/model_gcp_integration.go
@@ -10,7 +10,7 @@
 package integration
 
 // Specifies the data collection integration between Google Cloud Platform and SignalFx, in the form of a JSON object.
-type GcpIntegration struct {
+type GCPIntegration struct {
 	// The creation date and time for the integration object, in Unix time UTC-relative. The system sets this value, and you can't modify it.
 	Created int64 `json:"created,omitempty"`
 	// SignalFx-assigned user ID of the user that created the integration object. If the system created the object, the value is \"AAAAAAAAAA\". The system sets this value, and you can't modify it.
@@ -24,13 +24,13 @@ type GcpIntegration struct {
 	// SignalFx-assigned ID of the last user who updated the integration. If the last update was by the system, the value is \"AAAAAAAAAA\". This value is \"read-only\".
 	LastUpdatedBy string `json:"lastUpdatedBy,omitempty"`
 	// A human-readable label for the integration. This property helps you identify a specific integration when you're using multiple integrations for the same service.
-	Name     string   `json:"name,omitempty"`
-	Type     Type     `json:"type"`
-	PollRate PollRate `json:"pollRate,omitempty"`
+	Name     string    `json:"name,omitempty"`
+	Type     Type      `json:"type"`
+	PollRate *PollRate `json:"pollRate,omitempty"`
 	// Array of GCP services that you want SignalFx to monitor. SignalFx only supports certain services, and if you specify an unsupported one, you receive an API error. The supported services are: <br>   * appengine   * bigquery   * bigtable   * cloudfunctions   * cloudiot   * cloudsql   * cloudtasks   * compute   * container   * dataflow   * datastore   * firebasedatabase   * firebasehosting   * interconnect   * loadbalancing   * logging   * ml   * monitoring   * pubsub   * router   * serviceruntime   * spanner   * storage   * vpn
 	Services []string `json:"services,omitempty"`
 	// List of GCP project that you want SignalFx to monitor, in the form of a JSON array of objects
-	ProjectServiceKeys []*GcpProject `json:"projectServiceKeys,omitempty"`
+	ProjectServiceKeys []*GCPProject `json:"projectServiceKeys,omitempty"`
 	// List of GCP metadata names that you want SignalFx to collect from the data incoming from the GCP integration, in the form of a JSON array. Refer to Google's GCP documentation to find out the names you want to whitelist.
 	Whitelist []string `json:"whitelist,omitempty"`
 }

--- a/vendor/github.com/signalfx/signalfx-go/integration/model_gcp_project.go
+++ b/vendor/github.com/signalfx/signalfx-go/integration/model_gcp_project.go
@@ -10,7 +10,7 @@
 package integration
 
 // Properties of a GCP project, in the form of a JSON object. Contains the GCP project ID and GCP service account key for a GCP project that you want SignalFx to monitor.
-type GcpProject struct {
+type GCPProject struct {
 	// GCP project ID you specified when you created your GCP project
 	ProjectId string `json:"projectId,omitempty"`
 	// Google Service Account Key generated for the project. This property is a JSON string; you must properly escape special characters before you send it to SignalFx.<br> **NOTE:** To ensure security, SignalFx doesn't return the value of this property in a response object.

--- a/vendor/github.com/signalfx/signalfx-go/integration/model_opsgenie_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/integration/model_opsgenie_integration.go
@@ -10,7 +10,7 @@
 package integration
 
 // Specifies the properties of a notification service integration between Opsgenie and SignalFx, in the form of a JSON object
-type OpsgenieIntegrationModel struct {
+type OpsgenieIntegration struct {
 	// The creation date and time for the integration object, in Unix time UTC-relative. The system sets this value, and you can't modify it.
 	Created int64 `json:"created,omitempty"`
 	// SignalFx-assigned user ID of the user that created the integration object. If the system created the object, the value is \"AAAAAAAAAA\". The system sets this value, and you can't modify it.

--- a/vendor/github.com/signalfx/signalfx-go/opsgenie_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/opsgenie_integration.go
@@ -1,0 +1,101 @@
+package signalfx
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/signalfx/signalfx-go/integration"
+)
+
+// CreateOpsgenieIntegration creates an Opsgenie integration.
+func (c *Client) CreateOpsgenieIntegration(oi *integration.OpsgenieIntegration) (*integration.OpsgenieIntegration, error) {
+	payload, err := json.Marshal(oi)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.OpsgenieIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// GetOpsgenieIntegration retrieves an Opsgenie integration.
+func (c *Client) GetOpsgenieIntegration(id string) (*integration.OpsgenieIntegration, error) {
+	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.OpsgenieIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// UpdateOpsgenieIntegration updates an Opsgenie integration.
+func (c *Client) UpdateOpsgenieIntegration(id string, oi *integration.OpsgenieIntegration) (*integration.OpsgenieIntegration, error) {
+	payload, err := json.Marshal(oi)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.OpsgenieIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// DeleteOpsgenieIntegration deletes an Opsgenie integration.
+func (c *Client) DeleteOpsgenieIntegration(id string) error {
+	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	return err
+}

--- a/vendor/github.com/signalfx/signalfx-go/pagerduty_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/pagerduty_integration.go
@@ -1,0 +1,101 @@
+package signalfx
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/signalfx/signalfx-go/integration"
+)
+
+// CreatePagerDutyIntegration creates a PagerDuty integration.
+func (c *Client) CreatePagerDutyIntegration(pdi *integration.PagerDutyIntegration) (*integration.PagerDutyIntegration, error) {
+	payload, err := json.Marshal(pdi)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.PagerDutyIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// GetPagerDutyIntegration retrieves a PagerDuty integration.
+func (c *Client) GetPagerDutyIntegration(id string) (*integration.PagerDutyIntegration, error) {
+	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.PagerDutyIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// UpdatePagerDutyIntegration updates a PagerDuty integration.
+func (c *Client) UpdatePagerDutyIntegration(id string, pdi *integration.PagerDutyIntegration) (*integration.PagerDutyIntegration, error) {
+	payload, err := json.Marshal(pdi)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.PagerDutyIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// DeletePagerDutyIntegration deletes a PagerDuty integration.
+func (c *Client) DeletePagerDutyIntegration(id string) error {
+	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	return err
+}

--- a/vendor/github.com/signalfx/signalfx-go/slack_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/slack_integration.go
@@ -1,0 +1,101 @@
+package signalfx
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/signalfx/signalfx-go/integration"
+)
+
+// CreateSlackIntegration creates a Slack integration.
+func (c *Client) CreateSlackIntegration(si *integration.SlackIntegration) (*integration.SlackIntegration, error) {
+	payload, err := json.Marshal(si)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.SlackIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// GetSlackIntegration retrieves a Slack integration.
+func (c *Client) GetSlackIntegration(id string) (*integration.SlackIntegration, error) {
+	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.SlackIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// UpdateSlackIntegration updates a Slack integration.
+func (c *Client) UpdateSlackIntegration(id string, si *integration.SlackIntegration) (*integration.SlackIntegration, error) {
+	payload, err := json.Marshal(si)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	finalIntegration := integration.SlackIntegration{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}
+
+// DeleteSlackIntegration deletes a Slack integration.
+func (c *Client) DeleteSlackIntegration(id string) error {
+	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	return err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -213,7 +213,7 @@ github.com/posener/complete/match
 github.com/satori/go.uuid
 # github.com/signalfx/golib v2.4.0+incompatible
 github.com/signalfx/golib/pointer
-# github.com/signalfx/signalfx-go v1.5.1-0.20190808201309-79a3e969a4c6
+# github.com/signalfx/signalfx-go v1.5.1-0.20190813152720-b115c0f8d31b
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/chart
 github.com/signalfx/signalfx-go/dashboard


### PR DESCRIPTION
# Summary

Converts GCP over to new way of doing things.

# Motivation

We needed an `Exists` method so we updated this to use all the new hotness from signalfx-go