### PR TITLE
Convert on_chart_legend_dimension back to it's TF value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ BUG FIXES:
 
 * provider: Fixed the documentation sidebar which had a number of incorrect integration resource names. [#53](https://github.com/terraform-providers/terraform-provider-signalfx/pull/53)
 * resource/time_chart: Fix incorrect documentation around use of `time_range`. [#56](https://github.com/terraform-providers/terraform-provider-signalfx/pull/56)
+* resource/time_chart: Correct unclean plans when using `on_chart_legend_dimension`. [#58](https://github.com/terraform-providers/terraform-provider-signalfx/pull/58)
 
 IMPROVEMENTS:
 

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -912,7 +912,15 @@ func timechartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 	}
 
 	if options.OnChartLegendOptions != nil {
-		if err := d.Set("on_chart_legend_dimension", options.OnChartLegendOptions.DimensionInLegend); err != nil {
+		dil := options.OnChartLegendOptions.DimensionInLegend
+		onChartLegendDim := dil
+		// We use different names inside TF, so convert them back
+		if dil == "sf_originatingMetric" {
+			onChartLegendDim = "metric"
+		} else if dil == "sf_metric" {
+			onChartLegendDim = "plot_label"
+		}
+		if err := d.Set("on_chart_legend_dimension", onChartLegendDim); err != nil {
 			return err
 		}
 	}

--- a/signalfx/resource_signalfx_time_chart_test.go
+++ b/signalfx/resource_signalfx_time_chart_test.go
@@ -36,6 +36,8 @@ resource "signalfx_time_chart" "mychartXX" {
 		stacked = false
 		axes_precision = 4
 
+		on_chart_legend_dimension = "plot_label"
+
 		legend_options_fields {
 			property = "collector"
 			enabled  = false


### PR DESCRIPTION
# Summary

Properly sets `on_chart_legend_dimension` when reading back from the API.

# Motivation

The property `on_chart_legend_dimension` uses a more friendly value in this provider. Unfortunately the API->Terraform code wasn't considering that and caused unclean plans. We didn't catch it cuz it wasn't in the test.

This adds it to the test then fixes the bug!

Fixes #57