### PR TITLE
Support event publish label options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 4.6.2 (Unreleased)
+
+FEATURES:
+
+* resource/time_chart: Added `event_options` to support cutomization of events
+
 ## 4.6.1 (August 16, 2019)
 
 BUG FIXES:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform v0.12.6
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/signalfx/golib v2.4.0+incompatible // indirect
-	github.com/signalfx/signalfx-go v1.6.1
+	github.com/signalfx/signalfx-go v1.6.2-0.20190819163103-e185d73d1d10
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5k
 github.com/signalfx/golib v2.3.4+incompatible/go.mod h1:nWYefOwlUKWm/SpN/LgVSBnyH1T9NpT1ANlmgRIi1Cs=
 github.com/signalfx/golib v2.4.0+incompatible h1:VtCORl7AdhkCIy3rS0m3WLpcNmqGcWosXQ9xX2QepXw=
 github.com/signalfx/golib v2.4.0+incompatible/go.mod h1:nWYefOwlUKWm/SpN/LgVSBnyH1T9NpT1ANlmgRIi1Cs=
-github.com/signalfx/signalfx-go v1.6.1 h1:z1TKxiFxKbMLMoOQUn9KOLfsv5Z4Bess0z6AbpB759U=
-github.com/signalfx/signalfx-go v1.6.1/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
+github.com/signalfx/signalfx-go v1.6.2-0.20190819163103-e185d73d1d10 h1:3KbJU8esNSLH7mfOur9P8wJ/QRfUj+Zq2jykLPiIItI=
+github.com/signalfx/signalfx-go v1.6.2-0.20190819163103-e185d73d1d10/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.0 h1:UVQPSSmc3qtTi+zPPkCXvZX9VvW/xT/NsRvKfwY81a8=

--- a/signalfx/resource_signalfx_time_chart_test.go
+++ b/signalfx/resource_signalfx_time_chart_test.go
@@ -18,7 +18,8 @@ resource "signalfx_time_chart" "mychartXX" {
 		description = "I am described"
 
     program_text = <<-EOF
-        data('cpu.total.idle').publish(label='CPU Idle')
+data('cpu.total.idle').publish(label='CPU Idle')
+events(eventType='some.testing').publish(label='testing events')
         EOF
 
     time_range = 900
@@ -52,6 +53,11 @@ resource "signalfx_time_chart" "mychartXX" {
 				value_prefix = "prefix"
 				value_suffix = "suffix"
     }
+		event_options {
+			label = "testing events"
+			display_name = "farts"
+			color = "azure"
+		}
 
 		histogram_options {
 			color_theme = "lilac"
@@ -115,7 +121,8 @@ resource "signalfx_time_chart" "mychartXX" {
 		description = "I am described NEW"
 
     program_text = <<-EOF
-        data('cpu.total.idle').publish(label='CPU Idle')
+data('cpu.total.idle').publish(label='CPU Idle')
+events(eventType='some.testing').publish(label='testing events')
         EOF
 
     time_range = 900
@@ -147,6 +154,11 @@ resource "signalfx_time_chart" "mychartXX" {
 				value_prefix = "prefix"
 				value_suffix = "suffix"
     }
+		event_options {
+			label = "testing events"
+			display_name = "farts"
+			color = "azure"
+		}
 
 		histogram_options {
 			color_theme = "lilac"

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Updated
 
+* Adjusted `EventPublishLabelOptions.PalleteIndex` to an `*int32` to match other uses.
+
 ## Bugfixes
 
 ## Removed
@@ -12,7 +14,7 @@
 
 ## Updated
 
-Adjusted detector.CreateUpdateDetectorRequest to use pointer for Rules
+* Adjusted detector.CreateUpdateDetectorRequest to use pointer for Rules
 
 # 1.6.0, 2019-08-16
 

--- a/vendor/github.com/signalfx/signalfx-go/chart/model_event_publish_label_options.go
+++ b/vendor/github.com/signalfx/signalfx-go/chart/model_event_publish_label_options.go
@@ -3,5 +3,5 @@ package chart
 type EventPublishLabelOptions struct {
 	DisplayName  string `json:"displayName,omitempty"`
 	Label        string `json:"label,omitempty"`
-	PaletteIndex *int   `json:"paletteIndex,omitempty"`
+	PaletteIndex *int32 `json:"paletteIndex,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -213,7 +213,7 @@ github.com/posener/complete/match
 github.com/satori/go.uuid
 # github.com/signalfx/golib v2.4.0+incompatible
 github.com/signalfx/golib/pointer
-# github.com/signalfx/signalfx-go v1.6.1
+# github.com/signalfx/signalfx-go v1.6.2-0.20190819163103-e185d73d1d10
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/chart
 github.com/signalfx/signalfx-go/dashboard

--- a/website/docs/r/time_chart.html.markdown
+++ b/website/docs/r/time_chart.html.markdown
@@ -104,6 +104,10 @@ The following arguments are supported in the resource block:
     * `plot_type` - (Optional) The visualization style to use. Must be `"LineChart"`, `"AreaChart"`, `"ColumnChart"`, or `"Histogram"`. Chart level `plot_type` by default.
     * `value_unit` - (Optional) A unit to attach to this plot. Units support automatic scaling (eg thousands of bytes will be displayed as kilobytes). Values values are `Bit, Kilobit, Megabit, Gigabit, Terabit, Petabit, Exabit, Zettabit, Yottabit, Byte, Kibibyte, Mebibyte, Gigibyte, Tebibyte, Pebibyte, Exbibyte, Zebibyte, Yobibyte, Nanosecond, Microsecond, Millisecond, Second, Minute, Hour, Day, Week`.
     * `value_prefix`, `value_suffix` - (Optional) Arbitrary prefix/suffix to display with the value of this plot.
+  * `event_options` - (Optional) Event customization options, associated with a publish statement. You will need to use this to change settings for any `events(…)` statements you use.
+      * `label` - (Required) Label used in the publish statement that displays the event query you want to customize.
+      * `display_name` - (Optional) Specifies an alternate value for the Plot Name column of the Data Table associated with the chart.
+      * `color` - (Optional) Color to use : gray, blue, azure, navy, brown, orange, yellow, iris, magenta, pink, purple, violet, lilac, emerald, green, aquamarine.
 * `histogram_options` - (Optional) Only used when `plot_type` is `"Histogram"`. Histogram specific options.
     * `color_theme` - (Optional) Color to use : gray, blue, azure, navy, brown, orange, yellow, iris, magenta, pink, purple, violet, lilac, emerald, green, aquamarine, red, gold, greenyellow, chartreuse, jade
 * `legend_fields_to_hide` - (Optional) List of properties that should not be displayed in the chart legend (i.e. dimension names). All the properties are visible by default. Deprecated, please use `legend_options_fields`.


### PR DESCRIPTION
# Summary

Adds `event_options` to support event publish label options.

# Motivation

Fixes #61 