### PR TITLE
Don't include empty strings in sets we make from slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 
+* resource/dashboard: Dashboard variables with no default value no longer cause unclean plans. [#68](https://github.com/terraform-providers/terraform-provider-signalfx/pull/68)
 * resource/time_chart: Corrected an error in the document that made `event_options` look to be nested under `viz_options`. It is not!
 
 ## 4.6.3 (August 21, 2019)

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -123,9 +123,11 @@ func flattenStringSliceToSet(slice []string) *schema.Set {
 	if len(slice) < 1 {
 		return nil
 	}
-	values := make([]interface{}, len(slice))
-	for i, v := range slice {
-		values[i] = v
+	var values []interface{}
+	for _, v := range slice {
+		if v != "" { // Ignore empty strings
+			values = append(values, v)
+		}
 	}
 	return schema.NewSet(schema.HashString, values)
 }

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -165,3 +165,11 @@ func TestBuildAppURL(t *testing.T) {
 	assert.NoError(t, error)
 	assert.Equal(t, "https://www.example.com/#/chart/abc123", u)
 }
+
+func TestFlattenStringSliceToSet(t *testing.T) {
+	set := flattenStringSliceToSet([]string{"a", "b"})
+	assert.Equal(t, 2, set.Len(), "Set missing arguments")
+
+	setWithEmptyStrings := flattenStringSliceToSet([]string{"a", "", "b"})
+	assert.Equal(t, 2, setWithEmptyStrings.Len(), "Set missing arguments")
+}


### PR DESCRIPTION
# Summary

Skip empty strings when flattening slices into `schema.Set`.

# Motivation

In #65 we are including empty strings — which the API returns for filters with no default value — so we need to filter those out.