### PR TITLE
Add errors, use Contains more, and add docs for admin tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.6.4 (Unreleased)
 
+FEATURES:
+
+provider: Errors related to 4xx statuses when manipulating integrations now hint that you might need to use an admin token. Also added notes to the docs for same. [#70](https://github.com/terraform-providers/terraform-provider-signalfx/pull/70)
+
 BUG FIXES:
 
 * resource/dashboard: Dashboard variables with no default value no longer cause unclean plans. [#68](https://github.com/terraform-providers/terraform-provider-signalfx/pull/68)

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -186,7 +186,7 @@ func integrationAWSRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	int, err := config.Client.GetAWSCloudWatchIntegration(d.Id())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "404") {
+		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
 		}
 		return err
@@ -446,6 +446,9 @@ func integrationAWSCreate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.CreateAWSCloudWatchIntegration(payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)
@@ -468,6 +471,9 @@ func integrationAWSUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.UpdateAWSCloudWatchIntegration(d.Id(), payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)

--- a/signalfx/resource_signalfx_azure_integration.go
+++ b/signalfx/resource_signalfx_azure_integration.go
@@ -101,7 +101,7 @@ func integrationAzureRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	int, err := config.Client.GetAzureIntegration(d.Id())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "404") {
+		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
 		}
 		return err
@@ -209,6 +209,9 @@ func integrationAzureCreate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.CreateAzureIntegration(payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)
@@ -228,6 +231,9 @@ func integrationAzureUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.UpdateAzureIntegration(d.Id(), payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -358,7 +358,7 @@ func detectorRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	det, err := config.Client.GetDetector(d.Id())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "404") {
+		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
 		}
 		return err

--- a/signalfx/resource_signalfx_gcp_integration.go
+++ b/signalfx/resource_signalfx_gcp_integration.go
@@ -85,7 +85,7 @@ func integrationGCPRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	int, err := config.Client.GetGCPIntegration(d.Id())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "404") {
+		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
 		}
 		return err
@@ -175,6 +175,9 @@ func integrationGCPCreate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.CreateGCPIntegration(payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)
@@ -191,6 +194,9 @@ func integrationGCPUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.UpdateGCPIntegration(d.Id(), payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)

--- a/signalfx/resource_signalfx_opsgenie_integration.go
+++ b/signalfx/resource_signalfx_opsgenie_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"strings"
 
@@ -75,7 +76,7 @@ func integrationOpsgenieRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	int, err := config.Client.GetOpsgenieIntegration(d.Id())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "404") {
+		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
 		}
 		return err
@@ -107,6 +108,9 @@ func integrationOpsgenieCreate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.CreateOpsgenieIntegration(payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)
@@ -123,6 +127,9 @@ func integrationOpsgenieUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.UpdateOpsgenieIntegration(d.Id(), payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)

--- a/signalfx/resource_signalfx_pagerduty_integration.go
+++ b/signalfx/resource_signalfx_pagerduty_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"strings"
 
@@ -102,6 +103,9 @@ func integrationPagerDutyCreate(d *schema.ResourceData, meta interface{}) error 
 
 	int, err := config.Client.CreatePagerDutyIntegration(payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)
@@ -117,6 +121,9 @@ func integrationPagerDutyUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	int, err := config.Client.UpdatePagerDutyIntegration(d.Id(), payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 

--- a/signalfx/resource_signalfx_slack_integration.go
+++ b/signalfx/resource_signalfx_slack_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"strings"
 
@@ -101,6 +102,9 @@ func integrationSlackCreate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.CreateSlackIntegration(payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)
@@ -117,6 +121,9 @@ func integrationSlackUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	int, err := config.Client.UpdateSlackIntegration(d.Id(), payload)
 	if err != nil {
+		if strings.Contains(err.Error(), "40") {
+			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+		}
 		return err
 	}
 	d.SetId(int.Id)

--- a/website/docs/r/aws_integration.html.markdown
+++ b/website/docs/r/aws_integration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 SignalFx AWS CloudWatch integrations. For help with this integration see [Monitoring Amazon Web Services](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html#monitor-amazon-web-services).
 
+**Note:** When managing integrations you'll need to use an admin token to authenticate the SignalFx provider.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/azure_integration.html.markdown
+++ b/website/docs/r/azure_integration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 SignalFx Azure integrations. For help with this integration see [Monitoring Microsoft Azure](https://docs.signalfx.com/en/latest/integrations/azure-info.html).
 
+**Note:** When managing integrations you'll need to use an admin token to authenticate the SignalFx provider. Otherwise you'll receive a 4xx error.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/gcp_integration.html.markdown
+++ b/website/docs/r/gcp_integration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 SignalFx GCP Integration
 
+**Note:** When managing integrations you'll need to use an admin token to authenticate the SignalFx provider. Otherwise you'll receive a 4xx error.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsgenie_integration.html.markdown
+++ b/website/docs/r/opsgenie_integration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 SignalFx Opsgenie integration.
 
+**Note:** When managing integrations you'll need to use an admin token to authenticate the SignalFx provider. Otherwise you'll receive a 4xx error.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/pagerduty_integration.html.markdown
+++ b/website/docs/r/pagerduty_integration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 SignalFx PagerDuty integrations
 
+**Note:** When managing integrations you'll need to use an admin token to authenticate the SignalFx provider. Otherwise you'll receive a 4xx error.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/slack_integration.html.markdown
+++ b/website/docs/r/slack_integration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 SignalFx Slack integration.
 
+**Note:** When managing integrations you'll need to use an admin token to authenticate the SignalFx provider. Otherwise you'll receive a 4xx error.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
# Summary

Add special errors for `40x` errors and document admin keys.

# Motivation

It's common for users to miss the requirement of needing an admin token for managing integrations so let's give 'em a little help!