### PR TITLE
Fix validation of heatmaps color_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ BUG FIXES:
 
 * resource/dashboard: Dashboard variables with no default value no longer cause unclean plans. [#68](https://github.com/terraform-providers/terraform-provider-signalfx/pull/68)
 * resource/time_chart: Corrected an error in the document that made `event_options` look to be nested under `viz_options`. It is not!
+* resource/heatmap_chart: Correctly validate `color_range` and adjust docs to demonstrate proper input of hex colors. [#76](https://github.com/terraform-providers/terraform-provider-signalfx/pull/76)
 
 IMPROVEMENTS:
 

--- a/signalfx/resource_signalfx_heatmap_chart_test.go
+++ b/signalfx/resource_signalfx_heatmap_chart_test.go
@@ -139,3 +139,17 @@ func TestValidateHeatmapChartColorsFail(t *testing.T) {
 	_, err := validateHeatmapChartColor("whatever", "color")
 	assert.Equal(t, 1, len(err))
 }
+
+func TestValidateHeatmapColorRange(t *testing.T) {
+	_, err := validateHeatmapColorRange("fart", "color_range")
+	assert.Equal(t, 1, len(err))
+
+	_, err2 := validateHeatmapColorRange("f0f0f0", "color_range")
+	assert.Equal(t, 1, len(err2))
+
+	_, err3 := validateHeatmapColorRange("#nothex", "color_range")
+	assert.Equal(t, 1, len(err3))
+
+	_, noerr := validateHeatmapColorRange("#f0F9f0", "color_range")
+	assert.Equal(t, 0, len(noerr))
+}

--- a/website/docs/r/heatmap_chart.html.markdown
+++ b/website/docs/r/heatmap_chart.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported in the resource block:
 * `group_by` - (Optional) Properties to group by in the heatmap (in nesting order).
 * `sort_by` - (Optional) The property to use when sorting the elements. Must be prepended with `+` for ascending or `-` for descending (e.g. `-foo`).
 * `hide_timestamp` - (Optional) Whether to show the timestamp in the chart. `false` by default.
-* `color_range` - (Optional. Conflict with color_scale) Values and color for the color range. Example: `color_range : { min : 0, max : 100, color : blue }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+* `color_range` - (Optional. Conflicts with color_scale) Values and color for the color range. Example: `color_range : { min : 0, max : 100, color : "#0000ff" }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
     * `min_value` - (Optional) The minimum value within the coloring range.
     * `max_value` - (Optional) The maximum value within the coloring range.
-    * `color` - (Required) The color range to use. Must be either gray, blue, navy, orange, yellow, magenta, purple, violet, lilac, green, aquamarine.
+    * `color` - (Required) The color range to use. The starting hex color value for data values in a heatmap chart. Specify the value as a 6-character hexadecimal value preceded by the '#' character, for example "#ea1849" (grass green).


### PR DESCRIPTION
# Summary

Correctly validate heatmap's `color_range`.

# Motivation

The existing docs and validation for heatmap's `color_range` say to use a color "name", which is not correct. This causes charts to fail! Fixes #73 