### PR TITLE
Add new color features to heatmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 ## 4.8.1 (Unreleased)
+
+FEATURES:
+
+* resource/heatmap_chart: Now supports the `color_scale` option. [#89](https://github.com/terraform-providers/terraform-provider-signalfx/pull/89)
+
+BUG FIXES:
+
+* resource/heatmap_chart: No longer allows setting multiple `color_range` options. [#89](https://github.com/terraform-providers/terraform-provider-signalfx/pull/89)
+* resource/heatmap_chart: Many integer fields now verify that the value is >= 0 [#89](https://github.com/terraform-providers/terraform-provider-signalfx/pull/89)
+* resource/heatmap_chart: The `color_range.color` property was confusingly allowing both hex and non-hex colors. This has been standardized to hex colors. This may generate errors and ask you to change your colors if you used the old form. [#89](https://github.com/terraform-providers/terraform-provider-signalfx/pull/89)
+
+
 ## 4.8.0 (September 19, 2019)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ BUG FIXES:
 * resource/heatmap_chart: Many integer fields now verify that the value is >= 0 [#89](https://github.com/terraform-providers/terraform-provider-signalfx/pull/89)
 * resource/heatmap_chart: The `color_range.color` property was confusingly allowing both hex and non-hex colors. This has been standardized to hex colors. This may generate errors and ask you to change your colors if you used the old form. [#89](https://github.com/terraform-providers/terraform-provider-signalfx/pull/89)
 
-
 ## 4.8.0 (September 19, 2019)
 
 FEATURES:

--- a/signalfx/resource_signalfx_dashboard_and_friends_test.go
+++ b/signalfx/resource_signalfx_dashboard_and_friends_test.go
@@ -44,6 +44,16 @@ resource "signalfx_heatmap_chart" "myheatmapchart0" {
     program_text = <<-EOF
         data("cpu.total.idle").publish()
         EOF
+
+		color_scale {
+			gt = 40
+			color = "cerise"
+		}
+
+		color_scale {
+			lte = 40
+			color = "vivid_yellow"
+		}
 }
 
 resource "signalfx_text_chart" "mytextchart0" {
@@ -180,6 +190,16 @@ resource "signalfx_heatmap_chart" "myheatmapchart0" {
     program_text = <<-EOF
         data("cpu.total.idle").publish()
         EOF
+
+		color_scale {
+			gt = 40
+			color = "cerise"
+		}
+
+		color_scale {
+			lte = 40
+			color = "vivid_yellow"
+		}
 }
 
 resource "signalfx_text_chart" "mytextchart0" {

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	detector "github.com/signalfx/signalfx-go/detector"
 )
 
@@ -38,8 +39,8 @@ func detectorResource() *schema.Resource {
 			"max_delay": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Description:  "How long (in seconds) to wait for late datapoints. Max value 900s (15m)",
-				ValidateFunc: validateMaxDelayValue,
+				Description:  "How long (in seconds) to wait for late datapoints. Max value 900 (15m)",
+				ValidateFunc: validation.IntBetween(0, 900),
 			},
 			"show_data_markers": &schema.Schema{
 				Type:        schema.TypeBool,

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	chart "github.com/signalfx/signalfx-go/chart"
 )
 
@@ -39,20 +40,22 @@ func heatmapChartResource() *schema.Resource {
 				Description: "(Metric by default) Must be \"Metric\" or \"Binary\"",
 			},
 			"minimum_resolution": &schema.Schema{
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The minimum resolution (in seconds) to use for computing the underlying program",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  "The minimum resolution (in seconds) to use for computing the underlying program",
 			},
 			"max_delay": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 900),
 				Description:  "How long (in seconds) to wait for late datapoints",
-				ValidateFunc: validateMaxDelayValue,
 			},
 			"refresh_interval": &schema.Schema{
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "How often (in seconds) to refresh the values of the heatmap",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  "How often (in seconds) to refresh the values of the heatmap",
 			},
 			"disable_sampling": &schema.Schema{
 				Type:        schema.TypeBool,
@@ -73,16 +76,17 @@ func heatmapChartResource() *schema.Resource {
 				Description:  "The property to use when sorting the elements. Must be prepended with + for ascending or - for descending (e.g. -foo)",
 			},
 			"color_range": &schema.Schema{
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Description: "Values and color for the color range. Example: colorRange : { min : 0, max : 100, color : \"#0000ff\" }",
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ConflictsWith: []string{"color_scale"},
+				Description:   "Values and color for the color range. Example: colorRange : { min : 0, max : 100, color : \"#0000ff\" }",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"color": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
+							ValidateFunc: validation.StringMatch(validHexColor, "does not look like a hex color, similar to #0000ff"),
 							Description:  "The color range to use. The starting hex color value for data values in a heatmap chart. Specify the value as a 6-character hexadecimal value preceded by the '#' character, for example \"#ea1849\" (grass green).",
-							ValidateFunc: validateHeatmapColorRange,
 						},
 						"min_value": &schema.Schema{
 							Type:        schema.TypeFloat,
@@ -100,9 +104,10 @@ func heatmapChartResource() *schema.Resource {
 				},
 			},
 			"color_scale": &schema.Schema{
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Description: "Single color range including both the color to display for that range and the borders of the range",
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ConflictsWith: []string{"color_range"},
+				Description:   "Single color range including both the color to display for that range and the borders of the range",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"color": &schema.Schema{
@@ -426,14 +431,6 @@ func heatmapchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
 	return config.Client.DeleteChart(d.Id())
-}
-
-func validateHeatmapColorRange(v interface{}, k string) (we []string, errors []error) {
-	value := v.(string)
-	if !validHexColor.MatchString(value) {
-		errors = append(errors, fmt.Errorf("%s does not look like a hex color, similar to #0000ff", value))
-	}
-	return
 }
 
 /*

--- a/signalfx/resource_signalfx_heatmap_chart_test.go
+++ b/signalfx/resource_signalfx_heatmap_chart_test.go
@@ -27,7 +27,7 @@ resource "signalfx_heatmap_chart" "mychartHX" {
 	color_range {
 		min_value = 1
 		max_value = 100
-		color = "magenta"
+		color = "#ff0000"
 	}
 }
 `
@@ -46,7 +46,7 @@ resource "signalfx_heatmap_chart" "mychartHX" {
 	color_range {
 		min_value = 1
 		max_value = 100
-		color = "magenta"
+		color = "#ff0000"
 	}
 }
 `
@@ -69,9 +69,6 @@ func TestAccCreateUpdateHeatmapChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "hide_timestamp", "true"),
 					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "sort_by", "-foo"),
 					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "color_range.#", "1"),
-					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "color_range.452638366.color", "magenta"),
-					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "color_range.452638366.max_value", "100"),
-					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "color_range.452638366.min_value", "1"),
 					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "group_by.#", "2"),
 					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "group_by.0", "a"),
 					resource.TestCheckResourceAttr("signalfx_heatmap_chart.mychartHX", "group_by.1", "b"),

--- a/signalfx/resource_signalfx_heatmap_chart_test.go
+++ b/signalfx/resource_signalfx_heatmap_chart_test.go
@@ -139,17 +139,3 @@ func TestValidateHeatmapChartColorsFail(t *testing.T) {
 	_, err := validateHeatmapChartColor("whatever", "color")
 	assert.Equal(t, 1, len(err))
 }
-
-func TestValidateHeatmapColorRange(t *testing.T) {
-	_, err := validateHeatmapColorRange("fart", "color_range")
-	assert.Equal(t, 1, len(err))
-
-	_, err2 := validateHeatmapColorRange("f0f0f0", "color_range")
-	assert.Equal(t, 1, len(err2))
-
-	_, err3 := validateHeatmapColorRange("#nothex", "color_range")
-	assert.Equal(t, 1, len(err3))
-
-	_, noerr := validateHeatmapColorRange("#f0F9f0", "color_range")
-	assert.Equal(t, 0, len(noerr))
-}

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	chart "github.com/signalfx/signalfx-go/chart"
 )
 
@@ -43,7 +44,7 @@ func listChartResource() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Description:  "How long (in seconds) to wait for late datapoints",
-				ValidateFunc: validateMaxDelayValue,
+				ValidateFunc: validation.IntBetween(0, 900),
 			},
 			"disable_sampling": &schema.Schema{
 				Type:        schema.TypeBool,

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -251,7 +251,6 @@ func getListChartOptions(d *schema.ResourceData) *chart.Options {
 			if colorScaleOptions := getColorScaleOptions(d); len(colorScaleOptions) > 0 {
 				options.ColorScale2 = colorScaleOptions
 			}
-
 		}
 	}
 

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	chart "github.com/signalfx/signalfx-go/chart"
 )
 
@@ -43,7 +44,7 @@ func singleValueChartResource() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Description:  "How long (in seconds) to wait for late datapoints",
-				ValidateFunc: validateMaxDelayValue,
+				ValidateFunc: validation.IntBetween(0, 900),
 			},
 			"refresh_interval": &schema.Schema{
 				Type:        schema.TypeInt,

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/hashicorp/terraform/terraform"
 
 	chart "github.com/signalfx/signalfx-go/chart"
@@ -132,7 +133,7 @@ func timeChartResource() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Description:  "How long (in seconds) to wait for late datapoints",
-				ValidateFunc: validateMaxDelayValue,
+				ValidateFunc: validation.IntBetween(0, 900),
 			},
 			"timezone": &schema.Schema{
 				Type:        schema.TypeString,

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -170,24 +170,6 @@ func getNameFromChartColorsByIndex(index int) (string, error) {
 	return "", fmt.Errorf("Unknown color index %d", index)
 }
 
-func getHexFromChartColorsByName(name string) (string, error) {
-	for _, v := range ChartColorsSlice {
-		if v.name == name {
-			return v.hex, nil
-		}
-	}
-	return "", fmt.Errorf("Unknown color name %s", name)
-}
-
-func getNameFromChartColorsByHex(hex string) (string, error) {
-	for _, v := range ChartColorsSlice {
-		if v.hex == hex {
-			return v.name, nil
-		}
-	}
-	return "", fmt.Errorf("Unknown color hex %s", hex)
-}
-
 /*
 	Get Color Scale Options
 */

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -133,17 +133,6 @@ func flattenStringSliceToSet(slice []string) *schema.Set {
 }
 
 /*
-  Validates max_delay field; it must be between 0 and 900 seconds (15m in).
-*/
-func validateMaxDelayValue(v interface{}, k string) (we []string, errors []error) {
-	value := v.(int)
-	if value < 0 || value > 900 {
-		errors = append(errors, fmt.Errorf("%d not allowed; max_delay must be >= 0 && <= 900", value))
-	}
-	return
-}
-
-/*
   Validates that sort_by field start with either + or -.
 */
 func validateSortBy(v interface{}, k string) (we []string, errors []error) {

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -44,26 +44,6 @@ func TestGetNameFromChartColorsByIndex(t *testing.T) {
 	assert.Error(t, err, "Expected error for missing color index")
 }
 
-func TestGetHexFromChartColorsByName(t *testing.T) {
-	hex, err := getHexFromChartColorsByName("cerise")
-	assert.Equal(t, "#e9008a", hex, "Expected color hex")
-	assert.NoError(t, err, "Expected no error for known color")
-
-	hex, err = getHexFromChartColorsByName("fart")
-	assert.Equal(t, "", hex, "Expected empty string for missing index")
-	assert.Error(t, err, "Expected error for missing color index")
-}
-
-func TestGetNameFromChartColorsByHex(t *testing.T) {
-	name, err := getNameFromChartColorsByHex("#bd468d")
-	assert.Equal(t, "magenta", name, "Expected color name")
-	assert.NoError(t, err, "Expected no error for known hex")
-
-	name, err = getHexFromChartColorsByName("#f00f00")
-	assert.Equal(t, "", name, "Expected empty string for missing hex")
-	assert.Error(t, err, "Expected error for missing color hex")
-}
-
 func TestGetNameFromPaletteColorsByIndex(t *testing.T) {
 	name, err := getNameFromPaletteColorsByIndex(2)
 	assert.Equal(t, "azure", name, "Expected color name")

--- a/website/docs/r/heatmap_chart.html.markdown
+++ b/website/docs/r/heatmap_chart.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported in the resource block:
     * `min_value` - (Optional) The minimum value within the coloring range.
     * `max_value` - (Optional) The maximum value within the coloring range.
     * `color` - (Required) The color range to use. The starting hex color value for data values in a heatmap chart. Specify the value as a 6-character hexadecimal value preceded by the '#' character, for example "#ea1849" (grass green).
-* `color_scale` - (Optional. Conflicts with `color_scale`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt = 60, color = "blue" }, { lte = 60, color = "yellow" }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+* `color_scale` - (Optional. Conflicts with `color_range`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt = 60, color = "blue" }, { lte = 60, color = "yellow" }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
     * `gt` - (Optional) Indicates the lower threshold non-inclusive value for this range.
     * `gte` - (Optional) Indicates the lower threshold inclusive value for this range.
     * `lt` - (Optional) Indicates the upper threshold non-inculsive value for this range.

--- a/website/docs/r/heatmap_chart.html.markdown
+++ b/website/docs/r/heatmap_chart.html.markdown
@@ -46,11 +46,11 @@ The following arguments are supported in the resource block:
 * `group_by` - (Optional) Properties to group by in the heatmap (in nesting order).
 * `sort_by` - (Optional) The property to use when sorting the elements. Must be prepended with `+` for ascending or `-` for descending (e.g. `-foo`).
 * `hide_timestamp` - (Optional) Whether to show the timestamp in the chart. `false` by default.
-* `color_range` - (Optional. Conflicts with color_scale) Values and color for the color range. Example: `color_range : { min : 0, max : 100, color : "#0000ff" }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+* `color_range` - (Optional. Conflicts with `color_scale`) Values and color for the color range. Example: `color_range : { min : 0, max : 100, color : "#0000ff" }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
     * `min_value` - (Optional) The minimum value within the coloring range.
     * `max_value` - (Optional) The maximum value within the coloring range.
     * `color` - (Required) The color range to use. The starting hex color value for data values in a heatmap chart. Specify the value as a 6-character hexadecimal value preceded by the '#' character, for example "#ea1849" (grass green).
-* `color_scale` - (Optional. `color_by` must be `"Scale"`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt = 60, color = "blue" }, { lte = 60, color = "yellow" }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+* `color_scale` - (Optional. Conflicts with `color_scale`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt = 60, color = "blue" }, { lte = 60, color = "yellow" }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
     * `gt` - (Optional) Indicates the lower threshold non-inclusive value for this range.
     * `gte` - (Optional) Indicates the lower threshold inclusive value for this range.
     * `lt` - (Optional) Indicates the upper threshold non-inculsive value for this range.

--- a/website/docs/r/heatmap_chart.html.markdown
+++ b/website/docs/r/heatmap_chart.html.markdown
@@ -50,3 +50,9 @@ The following arguments are supported in the resource block:
     * `min_value` - (Optional) The minimum value within the coloring range.
     * `max_value` - (Optional) The maximum value within the coloring range.
     * `color` - (Required) The color range to use. The starting hex color value for data values in a heatmap chart. Specify the value as a 6-character hexadecimal value preceded by the '#' character, for example "#ea1849" (grass green).
+* `color_scale` - (Optional. `color_by` must be `"Scale"`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt = 60, color = "blue" }, { lte = 60, color = "yellow" }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+    * `gt` - (Optional) Indicates the lower threshold non-inclusive value for this range.
+    * `gte` - (Optional) Indicates the lower threshold inclusive value for this range.
+    * `lt` - (Optional) Indicates the upper threshold non-inculsive value for this range.
+    * `lte` - (Optional) Indicates the upper threshold inclusive value for this range.
+    * `color` - (Required) The color range to use. Must be either gray, blue, navy, orange, yellow, magenta, purple, violet, lilac, green, aquamarine.


### PR DESCRIPTION
# Summary

Add support for `color_scale` to heatmaps.

# Motivation

This was flagged in #88 and along the way I decided to fix up the validation to use helpers.