### PR TITLE
Be more defensive with possible null times and validate detectors more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ BUG FIXES:
 * resource/heatmap_chart: No longer allows setting multiple `color_range` options. [#89](https://github.com/terraform-providers/terraform-provider-signalfx/pull/89)
 * resource/heatmap_chart: Many integer fields now verify that the value is >= 0 [#89](https://github.com/terraform-providers/terraform-provider-signalfx/pull/89)
 * resource/heatmap_chart: The `color_range.color` property was confusingly allowing both hex and non-hex colors. This has been standardized to hex colors. This may generate errors and ask you to change your colors if you used the old form. [#89](https://github.com/terraform-providers/terraform-provider-signalfx/pull/89)
+* resource/detector: Improved guards against null values from detectors that might cause a crash and added more property validation in the schema. Thanks to [@joshuaspence](https://github.com/joshuaspence) for flagging. [#91](https://github.com/terraform-providers/terraform-provider-signalfx/pull/91)
 
 ## 4.8.0 (September 19, 2019)
 

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -69,12 +69,14 @@ func detectorResource() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"time_range"},
 				Description:   "Seconds since epoch. Used for visualization",
+				ValidateFunc:  validation.IntAtLeast(0),
 			},
 			"end_time": &schema.Schema{
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ConflictsWith: []string{"time_range"},
 				Description:   "Seconds since epoch. Used for visualization",
+				ValidateFunc:  validation.IntAtLeast(0),
 			},
 			"teams": &schema.Schema{
 				Type:        schema.TypeList,
@@ -413,18 +415,20 @@ func detectorAPIToTF(d *schema.ResourceData, det *detector.Detector) error {
 		}
 
 		tr := viz.Time
-		// We divide by 1000 because the API uses millis, but this provider uses
-		// seconds
-		if tr.Range != nil {
-			if err := d.Set("time_range", *tr.Range/1000); err != nil {
+		if tr != nil {
+			// We divide by 1000 because the API uses millis, but this provider uses
+			// seconds
+			if tr.Range != nil {
+				if err := d.Set("time_range", *tr.Range/1000); err != nil {
+					return err
+				}
+			}
+			if err := d.Set("start_time", tr.Start); err != nil {
 				return err
 			}
-		}
-		if err := d.Set("start_time", tr.Start); err != nil {
-			return err
-		}
-		if err := d.Set("end_time", tr.End); err != nil {
-			return err
+			if err := d.Set("end_time", tr.End); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
# Summary

Guard against null detector times.

# Motivation

In #90 @joshuaspence noticed it's possible that the time on the detector is null. This is unlikely to happen with modern provider versions as we default the `time_range`, but it's good practice for importing.

Also added more validation of integer fields