### PR TITLE
Verify that one of the color options is present for heatmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 4.8.4 (Unreleased)
+
+BUG FIXES:
+
+* resource/heatmap_chart: Now check that one of `color_range` or `color_scale` is set and emit an error if not. [#96](https://github.com/terraform-providers/terraform-provider-signalfx/pull/96)
+
 ## 4.8.3 (September 27, 2019)
 
 IMPROVEMENTS:

--- a/website/docs/r/heatmap_chart.html.markdown
+++ b/website/docs/r/heatmap_chart.html.markdown
@@ -27,6 +27,12 @@ resource "signalfx_heatmap_chart" "myheatmapchart0" {
     sort_by = "+host"
     group_by = ["hostname", "host"]
     hide_timestamp = true
+
+    color_range {
+		    min_value = 0
+		    max_value = 100
+		    color = "#ff0000"
+		}
 }
 ```
 

--- a/website/docs/r/heatmap_chart.html.markdown
+++ b/website/docs/r/heatmap_chart.html.markdown
@@ -28,6 +28,7 @@ resource "signalfx_heatmap_chart" "myheatmapchart0" {
     group_by = ["hostname", "host"]
     hide_timestamp = true
 
+    # You must specify one of `color_range` or `color_scale`
     color_range {
 		    min_value = 0
 		    max_value = 100
@@ -52,11 +53,11 @@ The following arguments are supported in the resource block:
 * `group_by` - (Optional) Properties to group by in the heatmap (in nesting order).
 * `sort_by` - (Optional) The property to use when sorting the elements. Must be prepended with `+` for ascending or `-` for descending (e.g. `-foo`).
 * `hide_timestamp` - (Optional) Whether to show the timestamp in the chart. `false` by default.
-* `color_range` - (Optional. Conflicts with `color_scale`) Values and color for the color range. Example: `color_range : { min : 0, max : 100, color : "#0000ff" }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+* `color_range` - (Required unless using `color_scale`. Conflicts with `color_scale`) Values and color for the color range. Example: `color_range : { min : 0, max : 100, color : "#0000ff" }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
     * `min_value` - (Optional) The minimum value within the coloring range.
     * `max_value` - (Optional) The maximum value within the coloring range.
     * `color` - (Required) The color range to use. The starting hex color value for data values in a heatmap chart. Specify the value as a 6-character hexadecimal value preceded by the '#' character, for example "#ea1849" (grass green).
-* `color_scale` - (Optional. Conflicts with `color_range`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt = 60, color = "blue" }, { lte = 60, color = "yellow" }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+* `color_scale` - (Required unless using `color_range`.  Conflicts with `color_range`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt = 60, color = "blue" }, { lte = 60, color = "yellow" }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
     * `gt` - (Optional) Indicates the lower threshold non-inclusive value for this range.
     * `gte` - (Optional) Indicates the lower threshold inclusive value for this range.
     * `lt` - (Optional) Indicates the upper threshold non-inculsive value for this range.


### PR DESCRIPTION
# Summary

Verify that one of `color_range` or `color_scale` are set for a heatmap.

# Motivation

Fixes #95