### PR TITLE
List charts complain if color scales are specified without the correct color_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BUG FIXES:
 
 * resource/heatmap_chart: Now check that one of `color_range` or `color_scale` is set and emit an error if not. [#96](https://github.com/terraform-providers/terraform-provider-signalfx/pull/96)
 
+IMPROVEMENTS
+
+* resource/list_chart: An error is now emitted if `color_scale` is used without a `color_by = "Scale"`. [#99](https://github.com/terraform-providers/terraform-provider-signalfx/pull/99)
+
 ## 4.8.3 (September 27, 2019)
 
 IMPROVEMENTS:

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"math"
 
@@ -38,7 +39,7 @@ func listChartResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "Dimension",
-				Description: "(Metric by default) Must be \"Metric\" or \"Dimension\"",
+				Description: "(Metric by default) Must be \"Scale\", \"Metric\" or \"Dimension\"",
 			},
 			"max_delay": &schema.Schema{
 				Type:         schema.TypeInt,
@@ -210,14 +211,17 @@ func listChartResource() *schema.Resource {
 /*
   Use Resource object to construct json payload in order to create a list chart
 */
-func getPayloadListChart(d *schema.ResourceData) *chart.CreateUpdateChartRequest {
+func getPayloadListChart(d *schema.ResourceData) (*chart.CreateUpdateChartRequest, error) {
 	payload := &chart.CreateUpdateChartRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
 		ProgramText: d.Get("program_text").(string),
 	}
 
-	viz := getListChartOptions(d)
+	viz, err := getListChartOptions(d)
+	if err != nil {
+		return nil, err
+	}
 	// There are two ways to maniplate the legend. The first is keyed from
 	// `legend_fields_to_hide`. Anything in this is marked as hidden. Unspecified
 	// fields default to showing up in SFx's UI.
@@ -235,10 +239,10 @@ func getPayloadListChart(d *schema.ResourceData) *chart.CreateUpdateChartRequest
 	}
 	payload.Options = viz
 
-	return payload
+	return payload, nil
 }
 
-func getListChartOptions(d *schema.ResourceData) *chart.Options {
+func getListChartOptions(d *schema.ResourceData) (*chart.Options, error) {
 	options := &chart.Options{
 		Type: "List",
 	}
@@ -250,6 +254,10 @@ func getListChartOptions(d *schema.ResourceData) *chart.Options {
 		if val == "Scale" {
 			if colorScaleOptions := getColorScaleOptions(d); len(colorScaleOptions) > 0 {
 				options.ColorScale2 = colorScaleOptions
+			}
+		} else {
+			if val, ok := d.GetOk("color_scale"); ok && val != nil {
+				return nil, fmt.Errorf("Using `color_scale` without `color_by = \"Range\"` has no effect")
 			}
 		}
 	}
@@ -288,12 +296,15 @@ func getListChartOptions(d *schema.ResourceData) *chart.Options {
 		}
 	}
 
-	return options
+	return options, nil
 }
 
 func listchartCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	payload := getPayloadListChart(d)
+	payload, err := getPayloadListChart(d)
+	if err != nil {
+		return err
+	}
 
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create List Chart Payload: %s", string(debugOutput))
@@ -421,7 +432,10 @@ func listchartRead(d *schema.ResourceData, meta interface{}) error {
 
 func listchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	payload := getPayloadListChart(d)
+	payload, err := getPayloadListChart(d)
+	if err != nil {
+		return err
+	}
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update List Chart Payload: %s", string(debugOutput))
 

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -257,7 +257,7 @@ func getListChartOptions(d *schema.ResourceData) (*chart.Options, error) {
 			}
 		} else {
 			if val, ok := d.GetOk("color_scale"); ok && val != nil {
-				return nil, fmt.Errorf("Using `color_scale` without `color_by = \"Range\"` has no effect")
+				return nil, fmt.Errorf("Using `color_scale` without `color_by = \"Scale\"` has no effect")
 			}
 		}
 	}

--- a/website/docs/r/list_chart.html.markdown
+++ b/website/docs/r/list_chart.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported in the resource block:
 * `program_text` - (Required) Signalflow program text for the chart. More info at <https://developers.signalfx.com/docs/signalflow-overview>.
 * `description` - (Optional) Description of the chart.
 * `unit_prefix` - (Optional) Must be `"Metric"` or `"Binary`". `"Metric"` by default.
-* `color_by` - (Optional) Must be `"Dimension"` or `"Metric"`. `"Dimension"` by default.
+* `color_by` - (Optional) Must be one of `"Scale"`, `"Dimension"` or `"Metric"`. `"Dimension"` by default.
 * `max_delay` - (Optional) How long (in seconds) to wait for late datapoints.
 * `disable_sampling` - (Optional) If `false`, samples a subset of the output MTS, which improves UI performance. `false` by default.
 * `refresh_interval` - (Optional) How often (in seconds) to refresh the values of the list.


### PR DESCRIPTION
# Summary

If `color_scale` is used with a `color_by` other than `Scale`, complain.

# Motivation

Raised as an idea in #97.