### PR TITLE
Fix column width in grid schema

### DIFF
--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -120,7 +120,7 @@ func dashboardResource() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      12,
-							ValidateFunc: validation.IntBetween(1, 11),
+							ValidateFunc: validation.IntBetween(1, 12),
 							Description:  "Number of columns (out of a total of 12, one-based) each chart should take up. (between 1 and 12)",
 						},
 						"height": &schema.Schema{

--- a/signalfx/resource_signalfx_dashboard_test.go
+++ b/signalfx/resource_signalfx_dashboard_test.go
@@ -1,10 +1,42 @@
 package signalfx
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/stretchr/testify/assert"
 )
+
+const widthTestDashConfig = `
+resource "signalfx_time_chart" "mytimechartX0" {
+    name = "CPU Total Idle"
+    description = "Very cool Time Chart"
+    program_text = <<-EOF
+        data("cpu.total.idle").publish(label="CPU Idle")
+        EOF
+}
+
+resource "signalfx_dashboard_group" "mydashboardgroupX0" {
+    name = "My team dashboard group"
+    description = "Cool dashboard group"
+		// No teams test cuz there's no teams resource yet!
+}
+
+resource "signalfx_dashboard" "mydashboardX0" {
+    name = "My Dashboard Test 1"
+		description = "Cool dashboard"
+    dashboard_group = "${signalfx_dashboard_group.mydashboardgroupX0.id}"
+
+    time_range = "-30m"
+
+	grid {
+		chart_ids = ["${signalfx_time_chart.mytimechartX0.id}"]
+		height = 2
+		width = %d
+	}
+}
+`
 
 func TestValidateChartsResolutionAllowed(t *testing.T) {
 	for _, value := range []string{"default", "low", "high", "highest"} {
@@ -16,4 +48,30 @@ func TestValidateChartsResolutionAllowed(t *testing.T) {
 func TestValidateChartsResolutionNotAllowed(t *testing.T) {
 	_, errors := validateChartsResolution("whatever", "charts_resolution")
 	assert.Equal(t, len(errors), 1)
+}
+
+func TestChartWidthAllowed(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDashboardGroupDestroy,
+		Steps: []resource.TestStep{
+			// Create resource with minimum value
+			{
+				Config: fmt.Sprintf(widthTestDashConfig, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("signalfx_dashboard.mydashboardX0", "grid.#", "1"),
+					resource.TestCheckResourceAttr("signalfx_dashboard.mydashboardX0", "grid.0.width", "1"),
+				),
+			},
+			// Update resource with maximum value
+			{
+				Config: fmt.Sprintf(widthTestDashConfig, 12),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("signalfx_dashboard.mydashboardX0", "grid.#", "1"),
+					resource.TestCheckResourceAttr("signalfx_dashboard.mydashboardX0", "grid.0.width", "12"),
+				),
+			},
+		},
+	})
 }


### PR DESCRIPTION
Fixes the column width setting. Documentation says that 1-12 is supported, but code only supports 1-11. Also added a unit test for this.