### PR TITLE
Adjust behavior of layouts to allow more than one instance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BUG FIXES:
 
 * resource/dashboard: Corrected validation of chart widths, allowing 12. Thanks [@ImDevinC](https://github.com/ImDevinC) [#100](https://github.com/terraform-providers/terraform-provider-signalfx/pull/100)
 
+IMPROVEMENTS:
+
+* resource/dashboard: Multiple instances of `column` and `grid` can now be used. [#102](https://github.com/terraform-providers/terraform-provider-signalfx/pull/102)
+
 ## 4.9.0 (October 10, 2019)
 
 FEATURES:

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -107,10 +107,11 @@ The following arguments are supported in the resource block:
 
 **Every SignalFx dashboard is shown as a grid of 12 columns and potentially infinite number of rows.** The dimension of the single column depends on the screen resolution.
 
-When you define a dashboard resource, you need to specify which charts (by `chart_id`) should be displayed in the dashboard, along with layout information determining where on the dashboard the charts should be displayed. You have to assign to every chart a **width** in terms of number of column to cover up (from 1 to 12) and a **height** in terms of number of rows (more or equal than 1). You can also assign a position in the dashboard grid where you like the graph to stay. In order to do that, you assign a **row** that represent the topmost row of the chart and a **column** that represent the leftmost column of the chart. If by mistake, you wrote a configuration where there are not enough columns to accommodate your charts in a specific row, they will be split in different rows. In case a **row** was specified with value higher than 1, if all the rows above are not filled by other charts, the chart will be placed the **first empty row**.
+When you define a dashboard resource, you need to specify which charts (by `chart_id`) should be displayed in the dashboard, along with layout information determining where on the dashboard the charts should be displayed. You have to assign to every chart a **width** in terms of number of columns to cover up (from 1 to 12) and a **height** in terms of number of rows (more or equal than 1). You can also assign a position in the dashboard grid where you like the graph to stay. In order to do that, you assign a **row** that represents the topmost row of the chart and a **column** that represent the leftmost column of the chart. If by mistake, you wrote a configuration where there are not enough columns to accommodate your charts in a specific row, they will be split in different rows. In case a **row** was specified with value higher than 1, if all the rows above are not filled by other charts, the chart will be placed the **first empty row**.
 
 The are a bunch of use cases where this layout makes things too verbose and hard to work with loops. For those you can now use one of these two layouts: grids and columns.
 
+~> **WARNING** These other layouts are not supported by the SignalFx API and are purely Terraform-side constructs. As such the provider cannot import them and cannot properly reconcile API-side changes. In other words, if someone changes the charts in the UI it will not be reconciled at the next apply. Also, you may only use one of `chart`, `column`, or `grid` when laying out dashboards. You can, however, use multiple instances of each (e.g. multiple `grid`s) for fancy layout.
 
 ### Grid
 
@@ -134,7 +135,6 @@ resource "signalfx_dashboard" "grid_example" {
 }
 ```
 
-
 ### Column
 
 The dashboard is divided into equal-sized charts (defined by `width` and `height`). The charts are placed in the grid by column (column number is called `column`).
@@ -152,41 +152,6 @@ resource "signalfx_dashboard" "load" {
         chart_ids = ["${signalfx_time_chart.cpu_capacity.*.id}"]
         column = 2
         width = 4
-    }
-    chart {
-        chart_id = "${signalfx_single_value_chart.loadbalancer_rps.id}"
-        width = 2
-        height = 1
-        row = 0
-        column = 6
-    }
-    chart {
-        chart_id = "${signalfx_time_chart.cpu_idle.id}"
-        width = 4
-        height = 1
-        row = 0
-        column = 8
-    }
-    chart {
-        chart_id = "${signalfx_time_chart.network.id}"
-        width = 6
-        height = 3
-        row = 1
-        column = 6
-    }
-    chart {
-        chart_id = "${signalfx_single_value_chart.disk.id}"
-        width = 2
-        height = 1
-        row = 5
-        column = 6
-    }
-    chart {
-        chart_id = "${signalfx_time_chart.mem.id}"
-        width = 4
-        height = 1
-        row = 5
-        column = 8
     }
 }
 ```


### PR DESCRIPTION
# Summary

Allow more than one `grid` and `column`.

# Motivation

Fixes #80 and #101

# Notes

This violates normal Terraform behavior, as it doesn't really examine the charts upon receiving the API response. This is a tradeoff to allow much more convenient layout. This is a necessity to retain this feature.

The exclusivity of each type (`layout`, `grid`, and `chart`) is retained, as the API has no way to sort them out.