### PR TITLE
Don't validate subscriptions like services

### DIFF
--- a/signalfx/resource_signalfx_azure_integration.go
+++ b/signalfx/resource_signalfx_azure_integration.go
@@ -62,8 +62,7 @@ func integrationAzureResource() *schema.Resource {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validateAzureService,
+					Type: schema.TypeString,
 				},
 				Description: "List of Azure subscriptions that SignalFx should monitor.",
 			},


### PR DESCRIPTION
# Summary

Subscriptions were being validated like services, which is clearly wrong. Oops!

# Motivation

Fixes #112