### PR TITLE
[website] Update broken/old URL for SignalFlow docs

### DIFF
--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -122,7 +122,7 @@ notifications = ["Webhook,secret,url"]
 ## Argument Reference
 
 * `name` - (Required) Name of the detector.
-* `program_text` - (Required) Signalflow program text for the detector. More info at <https://developers.signalfx.com/docs/signalflow-overview>.
+* `program_text` - (Required) Signalflow program text for the detector. More info at <https://developers.signalfx.com/signalflow_analytics/signalflow_overview.html>.
 * `description` - (Optional) Description of the detector.
 * `authorized_writer_teams` - (Optional) Team IDs that have write access to this detector. Remember to use an admin's token if using this feature and to include that admin's team (or user id in `authorized_writer_teams`).
 * `authorized_writer_users` - (Optional) User IDs that have write access to this detector. Remember to use an admin's token if using this feature and to include that admin's user id (or team id in `authorized_writer_teams`).


### PR DESCRIPTION
Fix the broken link referencing SignalFlow documentation for the
detectors site.

Signed-off-by: Danny <danny@Dannys-MacBook-Pro.local>