### PR TITLE
Fix crash for some dashboard reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 4.10.2 (Unreleased)
+
+BUG FIXES:
+
+* resource/dashboard: Fixed a crash for dashboards that were missing an "event signal" section. [#120](https://github.com/terraform-providers/terraform-provider-signalfx/pull/120)
+
 ## 4.10.1 (November 14, 2019)
 
 BUG FIXES:

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -900,8 +900,10 @@ func dashboardAPIToTF(d *schema.ResourceData, dash *dashboard.Dashboard) error {
 				}
 				evOverlay["color"] = colorName
 			}
-			evOverlay["signal"] = v.EventSignal.EventSearchText
-			evOverlay["type"] = v.EventSignal.EventType
+			if v.EventSignal != nil {
+				evOverlay["signal"] = v.EventSignal.EventSearchText
+				evOverlay["type"] = v.EventSignal.EventType
+			}
 			evOverlays[i] = evOverlay
 
 			if len(v.Sources) > 0 {

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -928,8 +928,10 @@ func dashboardAPIToTF(d *schema.ResourceData, dash *dashboard.Dashboard) error {
 		sevs := make([]map[string]interface{}, len(dash.SelectedEventOverlays))
 		for i, s := range dash.SelectedEventOverlays {
 			evOverlay := make(map[string]interface{})
-			evOverlay["signal"] = s.EventSignal.EventSearchText
-			evOverlay["type"] = s.EventSignal.EventType
+			if s.EventSignal != nil {
+				evOverlay["signal"] = s.EventSignal.EventSearchText
+				evOverlay["type"] = s.EventSignal.EventType
+			}
 			sevs[i] = evOverlay
 
 			if len(s.Sources) > 0 {


### PR DESCRIPTION
# Summary

Fixes a crash for dashboards with no `EventSignal` field.

# Motivation

In #116 the crash was reported. Fixes that!