### PR TITLE
Fix notification webhook validation

### DIFF
--- a/signalfx/notifications_test.go
+++ b/signalfx/notifications_test.go
@@ -67,8 +67,14 @@ func TestNotifyStringFromAPI(t *testing.T) {
 			Value: &notification.WebhookNotification{
 				Type:         WebhookNotificationType,
 				CredentialId: "XXX",
-				Secret:       "YYY",
-				Url:          "http://www.example.com",
+			},
+		},
+		&notification.Notification{
+			Type: WebhookNotificationType,
+			Value: &notification.WebhookNotification{
+				Type:   WebhookNotificationType,
+				Secret: "YYY",
+				Url:    "http://www.example.com",
 			},
 		},
 		&notification.Notification{
@@ -117,7 +123,8 @@ func TestNotifyStringFromAPI(t *testing.T) {
 		"Slack,XXX,foobar",
 		"Team,ABC123",
 		"TeamEmail,ABC124",
-		"Webhook,XXX,YYY,http://www.example.com",
+		"Webhook,XXX,,",
+		"Webhook,,YYY,http://www.example.com",
 		"BigPanda,XXX",
 		"Office365,XXX",
 		"ServiceNow,XXX",
@@ -149,6 +156,8 @@ func TestNotifyValidationBad(t *testing.T) {
 		"FARTS,lol",
 		"TeamEmailABC123",
 		"Webhook,XXX,YYY,notaurl",
+		"Webhook,XXX,YYY,http://www.example.com",
+		"Webhook,,,",
 		"BigPanda",
 		"Office365",
 		"ServiceNow",

--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -117,8 +117,16 @@ notifications = ["TeamEmail,teamId"]
 
 ### Webhook
 
+~> **NOTE** You need to include all the commas even if you only use a credential id below.
+
+You can either configure a Webhook to use an existing integration's credential id:
 ```
-notifications = ["Webhook,secret,url"]
+notifications = ["Webhook,credentialId,,"]
+```
+
+or configure one inline:
+```
+notifications = ["Webhook,,secret,url"]
 ```
 
 ## Argument Reference


### PR DESCRIPTION
# Summary
Improves Webhook validation for notifications

# Motivation
In #128  it was reported that Webhooks can be specified as either a credential ID — which uses an existing Webhook "integration" — or defined inline with a URL and secret. Neither of these scenarios worked because the validation required 4 "parts" to the input.

This PR changes this behavior to check for both scenarios. It also attempts to complain helpfully.

# Notes

This should really be replaced with a `notification` resource that specifies and validates these silly fields rather than this goofball comma thing that is a pain for users.