### PR TITLE
Doc `description` field in a signalfx detector 

### DIFF
--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -146,6 +146,7 @@ notifications = ["Webhook,,secret,url"]
 * `rule` - (Required) Set of rules used for alerting.
     * `detect_label` - (Required) A detect label which matches a detect label within `program_text`.
     * `severity` - (Required) The severity of the rule, must be one of: `"Critical"`, `"Major"`, `"Minor"`, `"Warning"`, `"Info"`.
+    * `description` - (Optional) Description for the rule. Displays as the alert condition in the Alert Rules tab of the detector editor in the web UI. 
     * `disabled` - (Optional) When true, notifications and events will not be generated for the detect label. `false` by default.
     * `notifications` - (Optional) List of strings specifying where notifications will be sent when an incident occurs. See <https://developers.signalfx.com/detectors_reference.html#operation/Create%20Single%20Detector> for more info.
     * `parameterized_body` - (Optional) Custom notification message body when an alert is triggered. See <https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#about-detectors#alert-settings> for more info.


### PR DESCRIPTION
This is a thing: https://github.com/terraform-providers/terraform-provider-signalfx/blob/master/signalfx/resource_signalfx_detector.go#L104

but it's not in the docs!
![image](https://user-images.githubusercontent.com/1700973/71219194-1829c800-2279-11ea-82b3-56abf9f3bf74.png)

I cribbed this description from https://developers.signalfx.com/detectors_reference.html#operation/Create%20Single%20Detector

![image](https://user-images.githubusercontent.com/1700973/71219209-24158a00-2279-11ea-9597-e799a0b03ad7.png)
