### PR TITLE
Validate color by and handle case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.11.1 (Unreleased)
 
+IMPROVEMENTS:
+
+* resource/single_value_chart: Began validating `color_by`. [#136](https://github.com/terraform-providers/terraform-provider-signalfx/pull/136)
+
 BUG FIXES:
 
 * docs: Fix bad example of poll rate for GCP integration.

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"math"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -39,6 +40,9 @@ func singleValueChartResource() *schema.Resource {
 				Optional:    true,
 				Default:     "Metric",
 				Description: "(Metric by default) Must be \"Metric\", \"Dimension\", or \"Scale\". \"Scale\" maps to Color by Value in the UI",
+				ValidateFunc: validation.StringInSlice([]string{
+					"metric", "dimension", "scale",
+				}, true),
 			},
 			"max_delay": &schema.Schema{
 				Type:         schema.TypeInt,
@@ -200,8 +204,9 @@ func getSingleValueChartOptions(d *schema.ResourceData) *chart.Options {
 		options.UnitPrefix = val.(string)
 	}
 	if val, ok := d.GetOk("color_by"); ok {
-		options.ColorBy = val.(string)
-		if val == "Scale" {
+		cb := val.(string)
+		options.ColorBy = strings.Title(cb)
+		if strings.EqualFold(cb, "scale") {
 			if colorScaleOptions := getColorScaleOptions(d); len(colorScaleOptions) > 0 {
 				options.ColorScale2 = colorScaleOptions
 			}

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"log"
 	"math"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -41,8 +40,8 @@ func singleValueChartResource() *schema.Resource {
 				Default:     "Metric",
 				Description: "(Metric by default) Must be \"Metric\", \"Dimension\", or \"Scale\". \"Scale\" maps to Color by Value in the UI",
 				ValidateFunc: validation.StringInSlice([]string{
-					"metric", "dimension", "scale",
-				}, true),
+					"Metric", "Dimension", "Scale",
+				}, false),
 			},
 			"max_delay": &schema.Schema{
 				Type:         schema.TypeInt,
@@ -205,8 +204,8 @@ func getSingleValueChartOptions(d *schema.ResourceData) *chart.Options {
 	}
 	if val, ok := d.GetOk("color_by"); ok {
 		cb := val.(string)
-		options.ColorBy = strings.Title(cb)
-		if strings.EqualFold(cb, "scale") {
+		options.ColorBy = cb
+		if cb == "Scale" {
 			if colorScaleOptions := getColorScaleOptions(d); len(colorScaleOptions) > 0 {
 				options.ColorScale2 = colorScaleOptions
 			}


### PR DESCRIPTION
# Summary
Validate `color_by` in single value charts.

# Motivation
The code was requiring literally a title cased string, but not validating it. :(