### PR TITLE
Bump dep and add AWS account ARN response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
+## 4.12.0 (Unreleased)
+
+IMPROVEMENTS:
+
+BUG FIXES:
+
 ## 4.11.1 (Unreleased)
 
 IMPROVEMENTS:
 
+* resource/aws_external_integration: Added field `signalfx_aws_account`, updated documentation. [#140](https://github.com/terraform-providers/terraform-provider-signalfx/pull/140)
 * resource/heatmap_chart: Began validating `unit_prefix`. [#139](https://github.com/terraform-providers/terraform-provider-signalfx/pull/139)
 * resource/list_chart: Added `time_range`, `start_time` and `end_time`. [#137](https://github.com/terraform-providers/terraform-provider-signalfx/pull/137)
 * resource/list_chart: Began validating `color_by`. [#138](https://github.com/terraform-providers/terraform-provider-signalfx/pull/138)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.4.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.6.10
+	github.com/signalfx/signalfx-go v1.6.12
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQ
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
 github.com/signalfx/signalfx-go v1.6.10 h1:per4zfJPExPkPDTbOn9jw5/dHR10dawg/+2L6r5Esz8=
 github.com/signalfx/signalfx-go v1.6.10/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.6.12 h1:dze8CmUycs7nGxK61p/Wm3y82AwoixMBkiaapcY+mVc=
+github.com/signalfx/signalfx-go v1.6.12/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,6 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.6.10 h1:per4zfJPExPkPDTbOn9jw5/dHR10dawg/+2L6r5Esz8=
-github.com/signalfx/signalfx-go v1.6.10/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/signalfx-go v1.6.12 h1:dze8CmUycs7nGxK61p/Wm3y82AwoixMBkiaapcY+mVc=
 github.com/signalfx/signalfx-go v1.6.12/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=

--- a/signalfx/resource_signalfx_aws_external_integration.go
+++ b/signalfx/resource_signalfx_aws_external_integration.go
@@ -23,7 +23,13 @@ func integrationAWSExternalResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Sensitive:   true,
-				Description: "The SignalFx-generated AWS account ID to use with an AWS integration.",
+				Description: "The SignalFx-generated AWS external ID to use with an AWS integration.",
+			},
+			"signalfx_aws_account": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The SignalFx AWS account ID to use with an AWS role.",
 			},
 		},
 
@@ -61,6 +67,9 @@ func integrationAWSExternalRead(d *schema.ResourceData, meta interface{}) error 
 			return err
 		}
 	}
+	if err := d.Set("signalfx_aws_account", int.SfxAwsAccountArn); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -97,6 +106,9 @@ func integrationAWSExternalCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	d.SetId(int.Id)
+	if err := d.Set("signalfx_aws_account", int.SfxAwsAccountArn); err != nil {
+		return err
+	}
 	if err := d.Set("external_id", int.ExternalId); err != nil {
 		return err
 	}

--- a/signalfx/resource_signalfx_aws_token_integration.go
+++ b/signalfx/resource_signalfx_aws_token_integration.go
@@ -23,7 +23,13 @@ func integrationAWSTokenResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Sensitive:   true,
-				Description: "The SignalFx-generated AWS account ID to use with an AWS integration.",
+				Description: "The SignalFx-generated AWS token to use with an AWS integration.",
+			},
+			"signalfx_aws_account": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The SignalFx AWS account ID to use with an AWS role.",
 			},
 		},
 
@@ -92,6 +98,9 @@ func integrationAWSTokenCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(int.Id)
 	if err := d.Set("name", int.Name); err != nil {
+		return err
+	}
+	if err := d.Set("signalfx_aws_account", int.SfxAwsAccountArn); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.6.11, Pending
+# 1.6.13, Pending
 
 ## Added
 
@@ -7,6 +7,18 @@
 ## Bugfixes
 
 ## Removed
+
+# 1.6.12, 2020-01-21
+
+## Added
+
+* Field `sfxAwsAccountArn` added to AWS response
+
+# 1.6.11, 2019-12-18
+
+## Added
+
+* Support for creating and deleting tokens using the Session API
 
 # 1.6.10, 2019-12-16
 

--- a/vendor/github.com/signalfx/signalfx-go/client.go
+++ b/vendor/github.com/signalfx/signalfx-go/client.go
@@ -67,6 +67,10 @@ func HTTPClient(httpClient *http.Client) ClientParam {
 }
 
 func (c *Client) doRequest(method string, path string, params url.Values, body io.Reader) (*http.Response, error) {
+	return c.doRequestWithToken(method, path, params, body, c.authToken)
+}
+
+func (c *Client) doRequestWithToken(method string, path string, params url.Values, body io.Reader, token string) (*http.Response, error) {
 	destURL, err := url.Parse(c.baseURL)
 	if err != nil {
 		return nil, err
@@ -77,7 +81,9 @@ func (c *Client) doRequest(method string, path string, params url.Values, body i
 		destURL.RawQuery = params.Encode()
 	}
 	req, err := http.NewRequest(method, destURL.String(), body)
-	req.Header.Set(AuthHeaderKey, c.authToken)
+	if token != "" {
+		req.Header.Set(AuthHeaderKey, token)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/signalfx/signalfx-go/integration/model_aws_cloud_watch_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/integration/model_aws_cloud_watch_integration.go
@@ -48,6 +48,8 @@ type AwsCloudWatchIntegration struct {
 	RoleArn string `json:"roleArn,omitempty"`
 	// Array of AWS services that you want SignalFx to monitor. Each element is a string designating an AWS service
 	Services []AwsService `json:"services,omitempty"`
+	// The account ARN used with this AWS integration.
+	SfxAwsAccountArn string `json:"sfxAwsAccountArn,omitempty"`
 	// If you specify `\"authMethod\": \"SecurityToken\"` in your request to create an AWS integration object, use this property to specify the token.
 	Token string `json:"token,omitempty"`
 	// Flag that controls how SignalFx checks for large amounts of data for this AWS integration. If `true`, SignalFx checks to see if the integration is returning a large amount of data.

--- a/vendor/github.com/signalfx/signalfx-go/sessiontoken.go
+++ b/vendor/github.com/signalfx/signalfx-go/sessiontoken.go
@@ -1,0 +1,57 @@
+package signalfx
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/signalfx/signalfx-go/sessiontoken"
+)
+
+// SessionTokenAPIURL is the base URL for interacting with org tokens.
+const SessionTokenAPIURL = "/v2/session"
+
+// CreateOrgToken creates a org token.
+func (c *Client) CreateSessionToken(tokenRequest *sessiontoken.CreateTokenRequest) (*sessiontoken.Token, error) {
+	payload, err := json.Marshal(tokenRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// we need to explicitly pass an empty token (which means it wont get set in the header)
+	// the API accepts either no token or a valid token, but not an empty token.
+	resp, err := c.doRequestWithToken("POST", SessionTokenAPIURL, nil, bytes.NewReader(payload), "")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Bad status %d: %s", resp.StatusCode, message)
+	}
+
+	sessionToken := &sessiontoken.Token{}
+
+	err = json.NewDecoder(resp.Body).Decode(sessionToken)
+
+	return sessionToken, err
+}
+
+// DeleteOrgToken deletes a token.
+func (c *Client) DeleteSessionToken(token string) error {
+	resp, err := c.doRequestWithToken("DELETE", SessionTokenAPIURL, nil, nil, token)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	return nil
+}

--- a/vendor/github.com/signalfx/signalfx-go/sessiontoken/model_create_token_request.go
+++ b/vendor/github.com/signalfx/signalfx-go/sessiontoken/model_create_token_request.go
@@ -1,0 +1,9 @@
+package sessiontoken
+
+// Properties of a session token request.
+type CreateTokenRequest struct {
+	// The email address you used to join the organization for which you want a session token. Only used for Create Token requests
+	Email string `json:"email"`
+	// The password you provided to SignalFx when you accepted an invitation to join an organization. Only used for Create Token requests
+	Password string `json:"password"`
+}

--- a/vendor/github.com/signalfx/signalfx-go/sessiontoken/model_token.go
+++ b/vendor/github.com/signalfx/signalfx-go/sessiontoken/model_token.go
@@ -1,0 +1,33 @@
+package sessiontoken
+
+// Properties of a session token, in the form of a JSON object
+type Token struct {
+	// The user session token used for API requests
+	AccessToken    string      `json:"accessToken"`
+	// unknown (not documented)
+	AuthMethod     string      `json:"authMethod"`
+	// The internal user ID of the user who created the token
+	CreatedBy      string	   `json:"createdBy"`
+	// The date and time that the token was created, in Unix time This property is set by the system, and you can't change it.
+	CreatedMs      int64         `json:"createdMs"`
+	// Indicates if the token is disabled or not. When you first create a token, the value of disabled is false.
+	Disabled       bool        `json:"disabled"`
+	// The email address submitted in the request to create the token
+	Email          string      `json:"email"`
+	// The date and time that the token will expire, in Unix time
+	ExpiryMs       int64       `json:"expiryMs"`
+	// The SignalFx identifier of this access token
+	ID             string      `json:"id"`
+	// The SignalFx identifier of the organization that the user belongs to
+	OrganizationID string      `json:"organizationId"`
+	// unknown (not documented)
+	PersonaID      string      `json:"personaId"`
+	// unknown (not documented)
+	ReadOnly       bool        `json:"readOnly"`
+	// Always set to ORG_USER
+	SessionType    string      `json:"sessionType"`
+	// The date and time that the token was updated, in Unix time For a successful "create token" request, this value is the same as that for createdMs. This value is set by the system, and you can't change it.
+	UpdatedMs      int         `json:"updatedMs"`
+	// The SignalFx identifier of the user who created the token
+	UserID         string      `json:"userId"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.6.10
+# github.com/signalfx/signalfx-go v1.6.12
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting
 github.com/signalfx/signalfx-go/chart
@@ -223,6 +223,7 @@ github.com/signalfx/signalfx-go/metrics_metadata
 github.com/signalfx/signalfx-go/notification
 github.com/signalfx/signalfx-go/organization
 github.com/signalfx/signalfx-go/orgtoken
+github.com/signalfx/signalfx-go/sessiontoken
 github.com/signalfx/signalfx-go/signalflow
 github.com/signalfx/signalfx-go/signalflow/messages
 github.com/signalfx/signalfx-go/team

--- a/website/docs/r/aws_external_integration.html.markdown
+++ b/website/docs/r/aws_external_integration.html.markdown
@@ -17,41 +17,122 @@ SignalFx AWS CloudWatch integrations using Role ARNs. For help with this integra
 ## Example Usage
 
 ```terraform
-// This resource returns an external id in `external_id`…
-resource "signalfx_aws_external_integration" "aws_myteam_external" {
-    name = "AWSFoo"
+resource "signalfx_aws_external_integration" "aws_myteam_extern" {
+   name = "AWSFooNEW"
 }
 
-// Make yourself an AWS IAM role here, use `signalfx_aws_external_integration.aws_myteam_external.external_id`
-resource "aws_iam_role" "aws_sfx_role" {
-  // Stuff here that uses the external and account ID
+data "aws_iam_policy_document" "signalfx_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+			identifiers = [signalfx_aws_external_integration.aws_myteam_extern.signalfx_aws_account]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [signalfx_aws_external_integration.aws_myteam_extern.external_id]
+    }
+  }
 }
+
+resource "aws_iam_role" "aws_sfx_role" {
+	name               = "signalfx-reads-from-cloudwatch2"
+  description        = "signalfx integration to read out data and send it to signalfxs aws account"
+	assume_role_policy = data.aws_iam_policy_document.signalfx_assume_policy.json
+}
+
+resource "aws_iam_policy" "aws_read_permissions" {
+	name = "SignalFxReadPermissionsPolicy"
+	description = "farts"
+	policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Action": [
+				"dynamodb:ListTables",
+		    "dynamodb:DescribeTable",
+		    "dynamodb:ListTagsOfResource",
+		    "ec2:DescribeInstances",
+		    "ec2:DescribeInstanceStatus",
+		    "ec2:DescribeVolumes",
+		    "ec2:DescribeReservedInstances",
+		    "ec2:DescribeReservedInstancesModifications",
+		    "ec2:DescribeTags",
+		    "organizations:DescribeOrganization",
+		    "cloudwatch:ListMetrics",
+		    "cloudwatch:GetMetricData",
+		    "cloudwatch:GetMetricStatistics",
+		    "cloudwatch:DescribeAlarms",
+		    "sqs:ListQueues",
+		    "sqs:GetQueueAttributes",
+		    "sqs:ListQueueTags",
+		    "elasticmapreduce:ListClusters",
+		    "elasticmapreduce:DescribeCluster",
+		    "kinesis:ListShards",
+		    "kinesis:ListStreams",
+		    "kinesis:DescribeStream",
+		    "kinesis:ListTagsForStream",
+		    "rds:DescribeDBInstances",
+		    "rds:ListTagsForResource",
+		    "elasticloadbalancing:DescribeLoadBalancers",
+		    "elasticloadbalancing:DescribeTags",
+		    "elasticache:describeCacheClusters",
+		    "redshift:DescribeClusters",
+		    "lambda:GetAlias",
+		    "lambda:ListFunctions",
+		    "lambda:ListTags",
+		    "autoscaling:DescribeAutoScalingGroups",
+		    "s3:ListAllMyBuckets",
+		    "s3:ListBucket",
+		    "s3:GetBucketLocation",
+		    "s3:GetBucketTagging",
+		    "ecs:ListServices",
+		    "ecs:ListTasks",
+		    "ecs:DescribeTasks",
+		    "ecs:DescribeServices",
+		    "ecs:ListClusters",
+		    "ecs:DescribeClusters",
+		    "ecs:ListTaskDefinitions",
+		    "ecs:ListTagsForResource",
+		    "apigateway:GET",
+		    "cloudfront:ListDistributions",
+		    "cloudfront:ListTagsForResource",
+		    "tag:GetResources",
+		    "es:ListDomainNames",
+		    "es:DescribeElasticsearchDomain"
+			],
+			"Effect": "Allow",
+			"Resource": "*"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "sfx-read-attach" {
+	role = aws_iam_role.aws_sfx_role.name
+	policy_arn = aws_iam_policy.aws_read_permissions.arn
+}
+
 
 resource "signalfx_aws_integration" "aws_myteam" {
-    enabled = true
+   enabled = true
 
-    integration_id = "${signalfx_aws_external_integration.aws_myteam_external.id}"
-    external_id = "${signalfx_aws_external_integration.aws_myteam_external.external_id}"
-		role_arn = "${aws_iam_role.aws_sfx_role.arn}"
+		integration_id = signalfx_aws_external_integration.aws_myteam_extern.id
+		external_id = signalfx_aws_external_integration.aws_myteam_extern.external_id
+		role_arn = aws_iam_role.aws_sfx_role.arn
+		# token = "abc123"
+		# key = "abc123"
 		regions = ["us-east-1"]
 		poll_rate = 300
 		import_cloud_watch = true
 		enable_aws_usage = true
-
-		custom_namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "fart"
-		}
-
-		namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "AWS/EC2"
-		}
 }
+
 ```
 
 ## Argument Reference
@@ -64,3 +145,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of this integration, used with `signalfx_aws_integration`
 * `external_id` - The external ID to use with your IAM role and with `signalfx_aws_integration`.
+* `signalfx_aws_account` - The AWS Account ARN to use with your policies/roles, provided by SignalFx.

--- a/website/docs/r/aws_token_integration.html.markdown
+++ b/website/docs/r/aws_token_integration.html.markdown
@@ -62,3 +62,4 @@ resource "signalfx_aws_integration" "aws_myteam" {
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the integration to use with `signalfx_aws_integration`
+* `signalfx_aws_account` - The AWS Account ARN to use with your policies/roles, provided by SignalFx.


### PR DESCRIPTION
# Summary

Adds field `signalfx_aws_account` to AWS external and token integration resources.

# Motivation

SignalFx's CloudWatch integration uses AWS' AssumeRole and therefore needs an account ARN. This ARN is not fixed, and specifically differs between regions. As such it was not possible to fully Terraform this set of resources without a fixed ARN. This patch adds support for a new field that is returned by the API such that users can use that value as a variable and fully automate integrations!