### PR TITLE
Change validation of on chart legend options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## 4.12.2 (Unreleased)
+
+IMPROVEMENTS:
+
 ## 4.12.1 (January 29, 2020)
 
-* IMPROVEMENTS
+* resource/time_chart: Fix accidental overzealous validation of `on_chart_legend_dimension` from last release. Sorry! [#145](https://github.com/terraform-providers/terraform-provider-signalfx/pull/145)
+
+IMPROVEMENTS:
 
 * resource/time_chart: Added validation for `on_chart_legend_dimension` to prevent unclean plans. [#143](https://github.com/terraform-providers/terraform-provider-signalfx/pull/143)
 

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -321,9 +321,6 @@ func timeChartResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Dimension to show in the on-chart legend. On-chart legend is off unless a dimension is specified. Allowed: 'metric', 'plot_label' and any dimension.",
-				ValidateFunc: validation.StringInSlice([]string{
-					"metric", "plot_label",
-				}, false),
 			},
 			"legend_fields_to_hide": &schema.Schema{
 				Type:          schema.TypeSet,
@@ -1007,9 +1004,10 @@ func timechartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 		dil := options.OnChartLegendOptions.DimensionInLegend
 		onChartLegendDim := dil
 		// We use different names inside TF, so convert them back
-		if dil == "sf_originatingMetric" {
+		currDim := d.Get("on_chart_legend_dimension").(string)
+		if dil == "sf_originatingMetric" && currDim != "sf_originatingMetric" {
 			onChartLegendDim = "metric"
-		} else if dil == "sf_metric" {
+		} else if dil == "sf_metric" && currDim != "sf_metric" {
 			onChartLegendDim = "plot_label"
 		}
 		if err := d.Set("on_chart_legend_dimension", onChartLegendDim); err != nil {


### PR DESCRIPTION
# Summary

Drop validation of `on_chart_legend_dimension`, fix the stale thing another way.

# Motivation

In #143 I forgot that this field is used for arbitrary dimensions. This removes the validation and fixes the bug a different (useful) way.

Sorry!