### PR TITLE
Add EpochSeconds to Data LInks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 
 * Remove some interpolation-only expressions, which are now deprecated. [#152](https://github.com/terraform-providers/terraform-provider-signalfx/issues/152)
+* resource/data_link: Add `"EpochSeconds"` as a value for `time_format`. [#156](https://github.com/terraform-providers/terraform-provider-signalfx/pull/156)
 
 ## 4.13.0 (February 13, 2020)
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.6.16
+	github.com/signalfx/signalfx-go v1.6.18
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.6.16 h1:L4DAbrzWfkgCD740KeLYtyTF5x9PEj9yu4lID5VABw8=
-github.com/signalfx/signalfx-go v1.6.16/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.6.18 h1:qp1Pm+S10Tfhv9uVh9KQfgOKLc1uZWFaZRS8dEllsD0=
+github.com/signalfx/signalfx-go v1.6.18/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/signalfx/resource_signalfx_data_link.go
+++ b/signalfx/resource_signalfx_data_link.go
@@ -83,7 +83,7 @@ func dataLinkResource() *schema.Resource {
 							Optional:    true,
 							Description: "Designates the format of minimumTimeWindow in the same data link target object.",
 							ValidateFunc: validation.StringInSlice([]string{
-								string(datalink.ISO8601), string(datalink.Epoch),
+								string(datalink.ISO8601), string(datalink.Epoch), string(datalink.EpochSeconds),
 							}, false),
 						},
 						"url": &schema.Schema{

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.6.17, Pending
+# 1.6.19, Pending
 
 ## Added
 
@@ -7,6 +7,18 @@
 ## Bugfixes
 
 ## Removed
+
+# 1.6.18, 2020-02-25
+
+## Added
+
+* New `datalink.EpochSeconds` for it's `TimeFormat`
+
+# 1.6.17, 2020-02-18
+
+## Added
+
+* New methods `GetDetectorEvents` and `GetDetectorIncidents`
 
 # 1.6.16, 2020-02-13
 

--- a/vendor/github.com/signalfx/signalfx-go/datalink/model_timeformat.go
+++ b/vendor/github.com/signalfx/signalfx-go/datalink/model_timeformat.go
@@ -5,6 +5,7 @@ type TimeFormat string
 
 // List of Time Format
 const (
-	ISO8601 TimeFormat = "ISO8601"
-	Epoch   TimeFormat = "Epoch"
+	ISO8601      TimeFormat = "ISO8601"
+	Epoch        TimeFormat = "Epoch"
+	EpochSeconds TimeFormat = "EpochSeconds"
 )

--- a/vendor/github.com/signalfx/signalfx-go/detector.go
+++ b/vendor/github.com/signalfx/signalfx-go/detector.go
@@ -167,3 +167,55 @@ func (c *Client) SearchDetectors(limit int, name string, offset int, tags string
 
 	return finalDetectors, err
 }
+
+// GetDetectorEvents gets a detector's events.
+func (c *Client) GetDetectorEvents(id string, from int, to int, offset int, limit int) ([]*detector.Event, error) {
+	params := url.Values{}
+	params.Add("from", strconv.Itoa(from))
+	params.Add("to", strconv.Itoa(to))
+	params.Add("offset", strconv.Itoa(offset))
+	params.Add("limit", strconv.Itoa(limit))
+	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id+"/events", params, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Bad status %d: %s", resp.StatusCode, message)
+	}
+
+	var events []*detector.Event
+
+	err = json.NewDecoder(resp.Body).Decode(&events)
+	if err != nil {
+		fmt.Printf("+%v", err)
+	}
+	return events, err
+}
+
+// GetDetectorIncidents gets a detector's incidents.
+func (c *Client) GetDetectorIncidents(id string, offset int, limit int) ([]*detector.Incident, error) {
+	params := url.Values{}
+	params.Add("offset", strconv.Itoa(offset))
+	params.Add("limit", strconv.Itoa(limit))
+	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id+"/incidents", params, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Bad status %d: %s", resp.StatusCode, message)
+	}
+
+	var incidents []*detector.Incident
+
+	err = json.NewDecoder(resp.Body).Decode(&incidents)
+	if err != nil {
+		fmt.Printf("+%v", err)
+	}
+	return incidents, err
+}

--- a/vendor/github.com/signalfx/signalfx-go/detector/model_event.go
+++ b/vendor/github.com/signalfx/signalfx-go/detector/model_event.go
@@ -1,0 +1,14 @@
+package detector
+
+type Event struct {
+	AnomalyState     string                  `json:"anomalyState,omitempty"`
+	DetectLabel      string                  `json:"detectLabel,omitempty"`
+	DetectorId       string                  `json:"detectorId,omitempty"`
+	DetectorName     string                  `json:"detectorName,omitempty"`
+	EventAnnotations *map[string]interface{} `json:"event_annotations,omitempty"`
+	Id               string                  `json:"id,omitempty"`
+	IncidentId       string                  `json:"incidentId,omitempty"`
+	Inputs           *map[string]interface{} `json:"inputs,omitempty"`
+	Severity         string                  `json:"severity,omitempty"`
+	Timestamp        int64                   `json:"timestamp,omitempty"`
+}

--- a/vendor/github.com/signalfx/signalfx-go/detector/model_incident.go
+++ b/vendor/github.com/signalfx/signalfx-go/detector/model_incident.go
@@ -1,0 +1,12 @@
+package detector
+
+type Incident struct {
+	Active       bool                    `json:"active,omitempty"`
+	AnomalyState string                  `json:"anomalyState,omitempty"`
+	DetectLabel  string                  `json:"detectLabel,omitempty"`
+	DetectorId   string                  `json:"detectorId,omitempty"`
+	Events       []*Event                `json:"events,omitempty"`
+	IncidentId   string                  `json:"incidentId,omitempty"`
+	Inputs       *map[string]interface{} `json:"inputs,omitempty"`
+	Severity     string                  `json:"severity,omitempty"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.6.16
+# github.com/signalfx/signalfx-go v1.6.18
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting
 github.com/signalfx/signalfx-go/chart

--- a/website/docs/r/data_link.html.markdown
+++ b/website/docs/r/data_link.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported in the resource block:
   * `name` (Required) User-assigned target name. Use this value to differentiate between the link targets for a data link object.
   * `is_default` - (Optional) Flag that designates a target as the default for a data link object. `true` by default.
   * `url`- (Required) URL string for a Splunk instance or external system data link target. [See the supported template variables](https://developers.signalfx.com/administration/data_links_overview.html#_external_link_targets).
-  * `time_format` - (Optional) [Designates the format](https://developers.signalfx.com/administration/data_links_overview.html#_minimum_time_window) of `minimum_time_window` in the same data link target object. Must be one of `"ISO8601"` or `"Epoch"` Defaults to `"ISO8601"`.
+  * `time_format` - (Optional) [Designates the format](https://developers.signalfx.com/administration/data_links_overview.html#_minimum_time_window) of `minimum_time_window` in the same data link target object. Must be one of `"ISO8601"`, `"EpochSeconds"` or `"Epoch"` (which is milliseconds). Defaults to `"ISO8601"`.
   * `minimum_time_window` - (Optional) The [minimum time window](https://developers.signalfx.com/administration/data_links_overview.html#_minimum_time_window) for a search sent to an external site. Defaults to `6000`
   * `property_key_mapping` - Describes the relationship between SignalFx metadata keys and external system properties when the key names are different.
 * `target_signalfx_dashboard` - (Optional) Link to a SignalFx dashboard

--- a/website/docs/r/data_link.html.markdown
+++ b/website/docs/r/data_link.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported in the resource block:
   * `name` (Required) User-assigned target name. Use this value to differentiate between the link targets for a data link object.
   * `is_default` - (Optional) Flag that designates a target as the default for a data link object. `true` by default.
   * `url`- (Required) URL string for a Splunk instance or external system data link target. [See the supported template variables](https://developers.signalfx.com/administration/data_links_overview.html#_external_link_targets).
-  * `time_format` - (Optional) [Designates the format](https://developers.signalfx.com/administration/data_links_overview.html#_minimum_time_window) of `minimum_time_window` in the same data link target object. Must be on of `"ISO8601"` or `"Epoch"` Defaults to `"ISO8601"`.
+  * `time_format` - (Optional) [Designates the format](https://developers.signalfx.com/administration/data_links_overview.html#_minimum_time_window) of `minimum_time_window` in the same data link target object. Must be one of `"ISO8601"` or `"Epoch"` Defaults to `"ISO8601"`.
   * `minimum_time_window` - (Optional) The [minimum time window](https://developers.signalfx.com/administration/data_links_overview.html#_minimum_time_window) for a search sent to an external site. Defaults to `6000`
   * `property_key_mapping` - Describes the relationship between SignalFx metadata keys and external system properties when the key names are different.
 * `target_signalfx_dashboard` - (Optional) Link to a SignalFx dashboard


### PR DESCRIPTION
# Summary

Adds `"EpochSeconds"` as a value for `resource_data_link`'s `time_format`.

# Motivation

Flagged in #149 