### PR TITLE
#157 fix webhhook typo in documentation

### DIFF
--- a/website/signalfx.erb
+++ b/website/signalfx.erb
@@ -82,8 +82,8 @@
             <li<%= sidebar_current("docs-signalfx-resource-victor-ops-integration") %>>
               <a href="/docs/providers/signalfx/r/victor_ops_integration.html">signalfx_victor_ops_integration</a>
             </li>
-            <li<%= sidebar_current("docs-signalfx-resource-webhhook-integration") %>>
-              <a href="/docs/providers/signalfx/r/webhhook_integration.html">signalfx_webhhook_integration</a>
+            <li<%= sidebar_current("docs-signalfx-resource-webhook-integration") %>>
+              <a href="/docs/providers/signalfx/r/webhook_integration.html">signalfx_webhook_integration</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Hello!
There is a little typo in the index page which leads to a "Page Not Found" error.
My two cents contribution