### PR TITLE
Add discoveryOptions to dashboard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.6.21
+	github.com/signalfx/signalfx-go v1.6.23-0.20200309203450-8c119f7da318
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.6.23-0.20200310142032-e5284afebef1
+	github.com/signalfx/signalfx-go v1.6.23
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.6.23-0.20200309203450-8c119f7da318
+	github.com/signalfx/signalfx-go v1.6.23-0.20200310142032-e5284afebef1
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.6.23-0.20200310142032-e5284afebef1 h1:R1aVeTIl1KAhQeeQfL0dko/rFy0ld9n4fE8VR/sScc8=
-github.com/signalfx/signalfx-go v1.6.23-0.20200310142032-e5284afebef1/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.6.23 h1:UH3t9mwKeTkKqQYETIb7yNnBlDNcY/qo7V0PirXYKLk=
+github.com/signalfx/signalfx-go v1.6.23/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.6.23-0.20200309203450-8c119f7da318 h1:Kq+F2GWc/DMf0p3MrW3N8kt/FvinoY7ehOJqRAu9FaQ=
-github.com/signalfx/signalfx-go v1.6.23-0.20200309203450-8c119f7da318/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.6.23-0.20200310142032-e5284afebef1 h1:R1aVeTIl1KAhQeeQfL0dko/rFy0ld9n4fE8VR/sScc8=
+github.com/signalfx/signalfx-go v1.6.23-0.20200310142032-e5284afebef1/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.6.21 h1:oHL2L99MsXQuNypdffGEfsTIe14zk1RBYVj8NxErP/w=
-github.com/signalfx/signalfx-go v1.6.21/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.6.23-0.20200309203450-8c119f7da318 h1:Kq+F2GWc/DMf0p3MrW3N8kt/FvinoY7ehOJqRAu9FaQ=
+github.com/signalfx/signalfx-go v1.6.23-0.20200309203450-8c119f7da318/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -242,9 +242,9 @@ func getPayloadDashboardGroup(d *schema.ResourceData) *dashboard_group.CreateUpd
 
 			if filterOver, ok := dash["filter_override"]; ok {
 				hasMirrors = true
-				tfFilters := filterOver.(*schema.Set).List()
-				filters := make([]*dashboard_group.Filter, len(tfFilters))
-				for i, f := range tfFilters {
+				filterOver := filterOver.(*schema.Set).List()
+				filters := make([]*dashboard_group.Filter, len(filterOver))
+				for i, f := range filterOver {
 					f := f.(map[string]interface{})
 					var values []string
 					tfValues := f["values"].(*schema.Set).List()
@@ -261,6 +261,7 @@ func getPayloadDashboardGroup(d *schema.ResourceData) *dashboard_group.CreateUpd
 						Values:   values,
 					}
 				}
+
 				filtersOverride.Sources = filters
 			}
 
@@ -308,9 +309,38 @@ func getPayloadDashboardGroup(d *schema.ResourceData) *dashboard_group.CreateUpd
 		}
 	}
 
-	if ok, iq := d.GetOk("import_qualifier"); ok {
-		var iqs := []*dashboard_group.ImportQualifier
-		tfValues := val.(*schema.Set).List()
+	if tfiq, ok := d.GetOk("import_qualifier"); ok {
+		tfIQs := tfiq.(*schema.Set).List()
+		iqs := make([]*dashboard_group.ImportQualifier, len(tfIQs))
+		for i, iq := range tfIQs {
+			iq := iq.(map[string]interface{})
+
+			filterOver := iq["filters"].(*schema.Set).List()
+			filters := make([]*dashboard_group.ImportFilter, len(filterOver))
+			for i, f := range filterOver {
+				f := f.(map[string]interface{})
+				var values []string
+				tfValues := f["values"].(*schema.Set).List()
+				if len(tfValues) > 0 {
+					values = []string{}
+					for _, v := range tfValues {
+						values = append(values, v.(string))
+					}
+				}
+
+				filters[i] = &dashboard_group.ImportFilter{
+					NOT:      f["negated"].(bool),
+					Property: f["property"].(string),
+					Values:   values,
+				}
+			}
+
+			iqs[i] = &dashboard_group.ImportQualifier{
+				Metric:  iq["metric"].(string),
+				Filters: filters,
+			}
+		}
+		cudgr.ImportQualifiers = iqs
 	}
 
 	return cudgr
@@ -418,6 +448,27 @@ func dashboardGroupAPIToTF(d *schema.ResourceData, dg *dashboard_group.Dashboard
 			if err := d.Set("dashboard", dConfigs); err != nil {
 				return err
 			}
+		}
+	}
+
+	if len(dg.ImportQualifiers) > 0 {
+		iqs := make([]map[string]interface{}, len(dg.ImportQualifiers))
+		for i, apiIQ := range dg.ImportQualifiers {
+			iq := make(map[string]interface{})
+			iq["metric"] = apiIQ.Metric
+			filters := make([]map[string]interface{}, len(apiIQ.Filters))
+			for j, apiFilter := range apiIQ.Filters {
+				filter := make(map[string]interface{})
+				filter["negated"] = apiFilter.NOT
+				filter["property"] = apiFilter.Property
+				filter["values"] = flattenStringSliceToSet(apiFilter.Values)
+				filters[j] = filter
+			}
+			iq["filters"] = filters
+			iqs[i] = iq
+		}
+		if err := d.Set("import_qualifier", iqs); err != nil {
+			return err
 		}
 	}
 

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -116,6 +116,44 @@ func dashboardGroupResource() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "User IDs that have write access to this dashboard",
 			},
+			"import_qualifier": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metric": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"filters": &schema.Schema{
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Description: "Filter to apply to each chart in the dashboard",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"property": &schema.Schema{
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "A metric time series dimension or property name",
+									},
+									"values": &schema.Schema{
+										Type:        schema.TypeSet,
+										Required:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: "List of strings (which will be treated as an OR filter on the property)",
+									},
+									"negated": &schema.Schema{
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     false,
+										Description: "(false by default) Whether this filter should be a \"not\" filter",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 
 		Create: dashboardgroupCreate,
@@ -268,6 +306,11 @@ func getPayloadDashboardGroup(d *schema.ResourceData) *dashboard_group.CreateUpd
 			log.Println("[DEBUG] SignalFx: We have mirrors, adding them")
 			cudgr.DashboardConfigs = dashConfigs
 		}
+	}
+
+	if ok, iq := d.GetOk("import_qualifier"); ok {
+		var iqs := []*dashboard_group.ImportQualifier
+		tfValues := val.(*schema.Set).List()
 	}
 
 	return cudgr

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -1,18 +1,23 @@
-# 1.6.22, Pending
-
-## Added
-
-## Updated
+# 1.6.23, Pending
 
 ## Bugfixes
+* Make the writer package work properly on 32-bit systems by aligning struct
+  fields on 64-bit boundaries.
 
-# 1.6.21, Pending
+# 1.6.22, 2020-03-09
+
+## Added
+* New package `realm` to help with constructing SignalFx ingest and API urls
+  from the realm name
+
+
+# 1.6.21, 2020-03-04
 
 ## Bugfixes
 
 * Fixed some errors in new AWS services
 
-# 1.6.20, Pending
+# 1.6.20, 2020-03-03
 
 ## Added
 

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -1,6 +1,9 @@
-# 1.6.23, Pending
+# 1.6.24, Pending
+
+# 1.6.23, 2020-03-10
 
 ## Bugfixes
+
 * Make the writer package work properly on 32-bit systems by aligning struct
   fields on 64-bit boundaries.
 
@@ -9,7 +12,6 @@
 ## Added
 * New package `realm` to help with constructing SignalFx ingest and API urls
   from the realm name
-
 
 # 1.6.21, 2020-03-04
 

--- a/vendor/github.com/signalfx/signalfx-go/dashboard/model_create_update_dashboard_request.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard/model_create_update_dashboard_request.go
@@ -15,6 +15,8 @@ type CreateUpdateDashboardRequest struct {
 	Charts            []*DashboardChart     `json:"charts,omitempty"`
 	// Description of the dashboard. The system displays the value in the dashboard tab tooltip in the dashboard group in the web UI.
 	Description string `json:"description,omitempty"`
+
+	DiscoveryOptions *DiscoveryOptions `json:"discoveryOptions,omitempty"`
 	// Array of event overlay definitions that you can apply to all of the charts of this dashboard. When you apply the overlays, the system displays all the active events that match the specified search term and any specified filter on all the charts in the dashboard. The display uses the color you specify for the overlay and, if selected, vertical lines that mark the event.<br> **Note:** The objects in this array correspond to the *suggested* event overlays specified in the web UI, and they're not automatically applied as active overlays. To set default active event overlays, use the `selectedEventOverlays` property instead.
 	EventOverlays []*ChartEventOverlay `json:"eventOverlays,omitempty"`
 	Filters       *ChartsFilters       `json:"filters,omitempty"`

--- a/vendor/github.com/signalfx/signalfx-go/dashboard/model_dashboard.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard/model_dashboard.go
@@ -21,7 +21,8 @@ type Dashboard struct {
 	// Custom properties for the dashboard, in the form of a JSON object that contains key-value pairs. Custom properties must follow these syntax restrictions:<br> **Key:**<br>   * ASCII characters only   * Length <= 128 characters   * Can only contain upper and lower case alphanumeric characters,     underscores (\"_\"), and hyphens (\"-\")   * Must start with an alphabetic character, upper or lower case.   * Can't start with any of the following strings, which are     reserved for system use: \"_\", \"sf_\", \"aws_\", or \"gcp_\". <br> **Value:**<br>   * Must be present if you specify a key   * Must not be empty   * ASCII characters only   * Length <= 256 characters
 	CustomProperties map[string]interface{} `json:"customProperties,omitempty"`
 	// Description of the dashboard. The system displays the value in the dashboard tab tooltip in the dashboard group in the web UI.
-	Description string `json:"description,omitempty"`
+	Description      string            `json:"description,omitempty"`
+	DiscoveryOptions *DiscoveryOptions `json:"discoveryOptions,omitempty"`
 	// Array of event overlay definitions that you can apply to all of the charts of this dashboard. When you apply the overlays, the system displays all the active events that match the specified search term and any specified filter on all the charts in the dashboard. The display uses the color you specify for the overlay and, if selected, vertical lines that mark the event.<br> **Note:** The objects in this array correspond to the *suggested* event overlays specified in the web UI, and they're not automatically applied as active overlays. To set default active event overlays, use the `selectedEventOverlays` property instead.
 	EventOverlays []*ChartEventOverlay `json:"eventOverlays,omitempty"`
 	Filters       *ChartsFilters       `json:"filters,omitempty"`

--- a/vendor/github.com/signalfx/signalfx-go/dashboard/model_discovery_options.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard/model_discovery_options.go
@@ -1,0 +1,6 @@
+package dashboard
+
+type DiscoveryOptions struct {
+	Query     string    `json:"query,omitempty"`
+	Selectors *[]string `json:"selectors,omitempty"`
+}

--- a/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_create_update_dashboard_group_request.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_create_update_dashboard_group_request.go
@@ -17,7 +17,7 @@ type CreateUpdateDashboardGroupRequest struct {
 	// Description of the dashboard group. This value appears in the tooltip for the dashboard group on the Dashboards page in the web UI.
 	Description string `json:"description,omitempty"`
 
-	ImportQualifiers *[]ImportQualifier `json:"importQualifier,omitempty"`
+	ImportQualifiers []*ImportQualifier `json:"importQualifiers,omitempty"`
 	// Name of the dashboard group. This value identifies the dashboard group in the web UI. It appears on the dashboards page and in the catalog. It also appears at the top left corner of the screen whenever you're viewing a dashboard that the group contains.
 	Name string `json:"name"`
 	// Array of existing team object ID. The dashboard group appears on the team landing page for any team in the list.

--- a/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_create_update_dashboard_group_request.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_create_update_dashboard_group_request.go
@@ -16,6 +16,8 @@ type CreateUpdateDashboardGroupRequest struct {
 	DashboardConfigs []*DashboardConfig `json:"dashboardConfigs,omitempty"`
 	// Description of the dashboard group. This value appears in the tooltip for the dashboard group on the Dashboards page in the web UI.
 	Description string `json:"description,omitempty"`
+
+	ImportQualifiers *[]ImportQualifier `json:"importQualifier,omitempty"`
 	// Name of the dashboard group. This value identifies the dashboard group in the web UI. It appears on the dashboards page and in the catalog. It also appears at the top left corner of the screen whenever you're viewing a dashboard that the group contains.
 	Name string `json:"name"`
 	// Array of existing team object ID. The dashboard group appears on the team landing page for any team in the list.

--- a/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_dashboard_group.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_dashboard_group.go
@@ -23,7 +23,7 @@ type DashboardGroup struct {
 	// The SignalFx-assigned ID for this dashboard.
 	Id string `json:"id,omitempty"`
 
-	ImportQualifiers *[]ImportQualifier `json:"importQualifier,omitempty"`
+	ImportQualifiers []*ImportQualifier `json:"importQualifiers,omitempty"`
 	// The last time the dashboard group was updated, in the form of a Unix timestamp (milliseconds since the Unix epoch 1970-01-01 00:00:00 UTC+0) This value is \"read-only\".
 	LastUpdated int64 `json:"lastUpdated,omitempty"`
 	// SignalFx-assigned ID of the last user who updated the dashboard group. If the last update was by the system, the value is \"AAAAAAAAAA\". This value is \"read-only\".

--- a/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_dashboard_group.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_dashboard_group.go
@@ -22,6 +22,8 @@ type DashboardGroup struct {
 	Description string `json:"description,omitempty"`
 	// The SignalFx-assigned ID for this dashboard.
 	Id string `json:"id,omitempty"`
+
+	ImportQualifiers *[]ImportQualifier `json:"importQualifier,omitempty"`
 	// The last time the dashboard group was updated, in the form of a Unix timestamp (milliseconds since the Unix epoch 1970-01-01 00:00:00 UTC+0) This value is \"read-only\".
 	LastUpdated int64 `json:"lastUpdated,omitempty"`
 	// SignalFx-assigned ID of the last user who updated the dashboard group. If the last update was by the system, the value is \"AAAAAAAAAA\". This value is \"read-only\".

--- a/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_import_filter.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_import_filter.go
@@ -1,0 +1,11 @@
+package dashboard_group
+
+// A single filter object to apply to the charts in the dashboard. The filter specifies a default or user-defined dimension or custom property. You can either include or exclude all the data that matches the dimension or custom property.
+type ImportFilter struct {
+	// Flag that indicates how the filter should operate. If `true`, data that matches the criteria is _excluded_ from charts; otherwise, data that matches the criteria is included.
+	NOT bool `json:"NOT,omitempty"`
+	// Name of the dimension or custom property to match to the data.<br> **Note:** If the dimension or custom property doesn't exist in any of the charts for the dashboard, and `ChartsFilterObject.NOT` is `true`, the system doesn't display any data in the charts.
+	Property string `json:"property"`
+	// A list of values to compare to the value of the dimension or custom property specified in `ChartsFilterObject.property`. If the list contains more than one value, the filter becomes a set of queries between the value of `property` and each element of `value`. The system joins these queries with an implicit OR.
+	Values []string `json:"values,omitempty"`
+}

--- a/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_import_qualifier.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_import_qualifier.go
@@ -1,6 +1,6 @@
 package dashboard_group
 
 type ImportQualifier struct {
-	Metric  string    `json:"metric,omitempty"`
-	Filters []*Filter `json:"filters,omitempty"`
+	Metric  string          `json:"metric,omitempty"`
+	Filters []*ImportFilter `json:"filters,omitempty"`
 }

--- a/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_import_qualifier.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard_group/model_import_qualifier.go
@@ -1,0 +1,6 @@
+package dashboard_group
+
+type ImportQualifier struct {
+	Metric  string    `json:"metric,omitempty"`
+	Filters []*Filter `json:"filters,omitempty"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.6.21
+# github.com/signalfx/signalfx-go v1.6.23-0.20200309203450-8c119f7da318
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting
 github.com/signalfx/signalfx-go/chart

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.6.23-0.20200310142032-e5284afebef1
+# github.com/signalfx/signalfx-go v1.6.23
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting
 github.com/signalfx/signalfx-go/chart

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.6.23-0.20200309203450-8c119f7da318
+# github.com/signalfx/signalfx-go v1.6.23-0.20200310142032-e5284afebef1
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting
 github.com/signalfx/signalfx-go/chart


### PR DESCRIPTION
# Summary

Add `discoveryOptions` and `importQualifiers` features.

# Motivation

Want to support SignalFx's "built-in" content.