### PR TITLE
Add a default to max delay, set it all the time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 IMPROVEMENTS:
 
 * resource/aws_integration: Fixed a problem that caused some services in AWS integrations to not work. [#167](https://github.com/terraform-providers/terraform-provider-signalfx/pull/167)
+* resource/aws_integration: Using `namespace_sync_rule` without filters no longer causes an unclean plan. [#170](https://github.com/terraform-providers/terraform-provider-signalfx/pull/170)
+* resource/detector: Unsetting the `max_delay` or setting it to `0` should now correctly reset on the max delay on `apply` rather than unhelpfully doing nothing and leaving an unclean plan. #[171](https://github.com/terraform-providers/terraform-provider-signalfx/pull/171)
 
 
 ## 4.18.0 (March 04, 2020)

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -39,6 +39,7 @@ func detectorResource() *schema.Resource {
 			"max_delay": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Default:      0,
 				Description:  "How long (in seconds) to wait for late datapoints. Max value 900 (15m)",
 				ValidateFunc: validation.IntBetween(0, 900),
 			},
@@ -308,9 +309,12 @@ func getPayloadDetector(d *schema.ResourceData) (*detector.CreateUpdateDetectorR
 		rulesList[i] = rule
 	}
 
+	maxDelay := int32(d.Get("max_delay").(int) * 1000)
+
 	cudr := &detector.CreateUpdateDetectorRequest{
 		Name:              d.Get("name").(string),
 		Description:       d.Get("description").(string),
+		MaxDelay:          &maxDelay,
 		ProgramText:       d.Get("program_text").(string),
 		Rules:             rulesList,
 		AuthorizedWriters: &detector.AuthorizedWriters{},
@@ -331,11 +335,6 @@ func getPayloadDetector(d *schema.ResourceData) (*detector.CreateUpdateDetectorR
 			users = append(users, v.(string))
 		}
 		cudr.AuthorizedWriters.Users = users
-	}
-
-	if val, ok := d.GetOk("max_delay"); ok {
-		maxDelay := int32(val.(int) * 1000)
-		cudr.MaxDelay = &maxDelay
 	}
 
 	cudr.VisualizationOptions = getVisualizationOptionsDetector(d)


### PR DESCRIPTION
# Summary
Set a default for Detector's `max_delay` and set it all the time.

# Motivation
Fixes a bug that if a detector every tried "unset" a `max_delay` by setting it to zero, the update didn't do anything and caused an unclean plan. :(