### PR TITLE
Use correct types for various chart features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 4.18.3 (Unreleased)
 
-
 IMPROVEMENTS
 
 * resource/aws_integration: Added some missing AWS services. [#173](https://github.com/terraform-providers/terraform-provider-signalfx/pull/173)
+* resource/time_chart: Fix some unclean plans caused by type conversions gone mad. [#174](https://github.com/terraform-providers/terraform-provider-signalfx/pull/174)
+
 
 ## 4.18.2 (March 13, 2020)
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.6.26
+	github.com/signalfx/signalfx-go v1.6.27
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.6.26 h1:ludvVdW3fDsTK7j+PKAMpjaOPoIROtlFIxRy1m9Nu18=
-github.com/signalfx/signalfx-go v1.6.26/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.6.27 h1:khwQLvKTGfOIOYjbQvAwBA8ubHbO47HE/79lmMd7q+0=
+github.com/signalfx/signalfx-go v1.6.27/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -890,7 +890,7 @@ func timechartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 		// We need to verify that there are real axes and not just nil
 		// or zeroed structs, so we do comparison before setting each.
 		if (axisLeft == nil || *axisLeft == chart.Axes{}) {
-			log.Printf("[DEBUG] SignalFx: Axis Right is nil or zero, skipping")
+			log.Printf("[DEBUG] SignalFx: Axis Left is nil or zero, skipping")
 		} else {
 			if err := d.Set("axis_left", axisToMap(axisLeft)); err != nil {
 				return err

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -178,11 +178,11 @@ func getColorScaleOptions(d *schema.ResourceData) []*chart.SecondaryVisualizatio
 	return getColorScaleOptionsFromSlice(colorScale)
 }
 
-func getValueUsingMaxFloatAsDefault(v float64) *float32 {
+func getValueUsingMaxFloatAsDefault(v float64) *float64 {
 	if v >= math.MaxFloat32 || v <= -math.MaxFloat32 {
 		return nil
 	}
-	vf := float32(v)
+	vf := float64(v)
 	return &vf
 }
 

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -1,10 +1,15 @@
-# 1.6.27, Pending
+# 1.6.28, Pending
 
-# 1.6.26, Pending
+# 1.6.27, 2020-03-16
 
 ## Bugfixes
 
-* Add some more AWS Services
+* Chart Axes' `HighWatermark`, `LowWatermark`, `Max`, and `Min` are now correctly typed as `float64`. Same for `ColorScale.Thresholds` and `SecondaryVisualization`'s fields (`Gt`, `Gte`, `Lt`, and `Lte`). [#75](https://github.com/signalfx/signalfx-go/pull/75).
+
+## Improvements
+
+* `Computation`s internal errors are now richer, allowing users to get to the code, message and type. Thanks [rma-stripe](https://github.com/rma-stripe)! [#74](https://github.com/signalfx/signalfx-go/pull/74)
+
 
 # 1.6.25, 2020-03-13
 

--- a/vendor/github.com/signalfx/signalfx-go/chart/model_axes.go
+++ b/vendor/github.com/signalfx/signalfx-go/chart/model_axes.go
@@ -11,17 +11,17 @@ package chart
 
 type Axes struct {
 	// A point on the Y axis at which the chart displays a horizontal line, indicating the max Y value of interest. Points with a Y value that exceeds the high water mark still appear.<br> **Notes:**   * SignalFx only uses this value for time series charts.   * Value must be less than or equal to `options.axes.max` and greater than     `options.axes.lowWaterMark` for the corresponding axis.
-	HighWatermark *float32 `json:"highWatermark,omitempty"`
+	HighWatermark *float64 `json:"highWatermark,omitempty"`
 	// A label that's displayed beside the horizontal line indicating the high water mark.<br> **Notes:**   * SignalFx only uses this value for time series charts.   * If `options.axes.highWaterMark` isn't specified, this label is ignored.
 	HighWatermarkLabel string `json:"highWatermarkLabel,omitempty"`
 	// Label that's displayed for the Y axis of the chart. It appears to the left of axis values on the left axis and to the right of axis values on the right axis.<br> **Note:** SignalFx only uses this value for time series charts.
 	Label string `json:"label,omitempty"`
 	// A point on the Y axis at which the chart displays a horizontal line, indicating the minimum Y value of interest. Points with a Y value that is less than the low water mark still appear.<br> **Notes:**   * SignalFx only uses this value for time series charts.   * Value must be greater than or equal to `options.axes.min` and less than     `options.axes.highWaterMark` for the corresponding axis.
-	LowWatermark *float32 `json:"lowWatermark,omitempty"`
+	LowWatermark *float64 `json:"lowWatermark,omitempty"`
 	// A label that's displayed beside the horizontal line indicating the low water mark.<br> **Notes:**   * SignalFx only uses this value for time series charts.   * If `options.axes.lowWaterMark` isn't specified, this label is ignored.
 	LowWatermarkLabel string `json:"lowWatermarkLabel,omitempty"`
 	// Specifies the largest data value to display on the chart. Overrides options.includeZero if the properties are set to incompatible values.<br> **Notes:**   * This value is only used if `options.type` is set to TimeSeriesChart.   * The value must be greater than the value of `options.axes.min` for the same `options.axes` element.
-	Max *float32 `json:"max,omitempty"`
+	Max *float64 `json:"max,omitempty"`
 	// Specifies the smallest data value to display on the chart. Overrides options.includeZero if the properties are set to incompatible values.<br> **Notes:**   * This value is only used if `options.type` is set to TimeSeriesChart.   * The value must be less than the value of `options.axes.max` for the same `options.axes` element.\"
-	Min *float32 `json:"min,omitempty"`
+	Min *float64 `json:"min,omitempty"`
 }

--- a/vendor/github.com/signalfx/signalfx-go/chart/model_color_scale.go
+++ b/vendor/github.com/signalfx/signalfx-go/chart/model_color_scale.go
@@ -14,5 +14,5 @@ type ColorScale struct {
 	// Determines how to use colors specified in `options.colorRange`. If this property is set to `true` and `options.colorBy`  is set to `Range`, darker colors represent smaller data values. For chart types other than Heatmap, setting this property to `true` results in red representing lower values and green representing higher ones (if the default color scheme is in use).<br> Available when the chart type specified in `options.type` is set to Heatmap, SingleValue, or List.
 	Inverted bool `json:"inverted,omitempty"`
 	// Specifies data values that map to color gradient values. Specify the  values from lowest to highest. Data values that outside the specified partitions don't appear in color, so you should set the first array value to corresopnd to the lowest expected data value. Similarly, set the last array value to correspond to the highest expected data value.<br> **Note** SignalFx only uses the first six elements in the array.
-	Thresholds []float32 `json:"thresholds,omitempty"`
+	Thresholds []float64 `json:"thresholds,omitempty"`
 }

--- a/vendor/github.com/signalfx/signalfx-go/chart/model_secondary_visualization.go
+++ b/vendor/github.com/signalfx/signalfx-go/chart/model_secondary_visualization.go
@@ -11,13 +11,13 @@ package chart
 
 type SecondaryVisualization struct {
 	// The lower threshold of a color range, not including the specified value itself.<br> **Notes:**   * Available if the options.type property is set to List, SingleValue, or Heatmap   * The value must be less than the value of `options.colorScale2.lt` or `options.colorScale2.lte` of the same element.   * `options.colorScale2.gt` and `options.colorScale2.gte` are mutually exclusive
-	Gt *float32 `json:"gt,omitempty"`
+	Gt *float64 `json:"gt,omitempty"`
 	// The lower threshold of a color range, including the specified value itself.<br> **Notes:**   * Available if the options.type property is set to List, SingleValue, or Heatmap   * The value must be less than the value of `options.colorScale2.lt` or `options.colorScale2.lte` of the same element.   * `options.colorScale2.gt` and `options.colorScale2.gte` are mutually exclusive
-	Gte *float32 `json:"gte,omitempty"`
+	Gte *float64 `json:"gte,omitempty"`
 	// The upper threshold of a color range, not including the specified value itself.<br> **Notes:**   * Available if the options.type property is set to List, SingleValue, or Heatmap   * The value must be less than the value of `options.colorScale2.gt` or `options.colorScale2.gte` of the same element.   * `options.colorScale2.lt` and `options.colorScale2.lte` are mutually exclusive
-	Lt *float32 `json:"lt,omitempty"`
+	Lt *float64 `json:"lt,omitempty"`
 	// The upper threshold of a color range, including the specified value itself.<br> **Notes:**   * Available if `options.type` property is `List`, `SingleValue`, or `Heatmap`   * The value must be less than the value of `options.colorScale2.gt` or `options.colorScale2.gte` of the same     element.   * `options.colorScale2.lt` and `options.colorScale2.lte` are mutually exclusive
-	Lte *float32 `json:"lte,omitempty"`
+	Lte *float64 `json:"lte,omitempty"`
 	// Color value to use for points in the specified range. The value is the index of the color in the standard SignalFx color palette, as shown in the following table: <table> <thead> <th >Index</th><th>RGB hex value</th> </thead> <tbody> <tr><td>0</td><td>#999999</td></tr> <tr><td>1</td><td>#0077c2</td></tr> <tr><td>2</td><td>#00b9ff</td></tr> <tr><td>3</td><td>#6ca2b7</td></tr> <tr><td>4</td><td>#b04600</td></tr> <tr><td>5</td><td>#f47e00</td></tr> <tr><td>6</td><td>#e5b312</td></tr> <tr><td>7</td><td>#bd468d</td></tr> <tr><td>8</td><td>#e9008a</td></tr> <tr><td>9</td><td>#ff8dd1</td></tr> <tr><td>10</td><td>#876ff3</td></tr> <tr><td>11</td><td>#a747ff</td></tr> <tr><td>12</td><td>#ab99bc</td></tr> <tr><td>13</td><td>#007c1d</td></tr> <tr><td>14</td><td>#05ce00</td></tr> <tr><td>15</td><td>#0dba8f</td></tr> <tr><td>16</td><td>#ea1849</td></tr> <tr><td>17</td><td>#eac24b</td></tr> <tr><td>18</td><td>#e5e517</td></tr> <tr><td>19</td><td>#acef7f</td></tr> <tr><td>20</td><td>#6bd37e</td></tr> </tbody> </table> **Notes:**  * Available if the options.type property is set to List, SingleValue, or Heatmap. * Users may see colors other than those shown in the table, depending on the settings they select for color   blindness. To see sample swatches of the alternate colors and the mappings used for   color-blind users, see the color palette documentation at the end of the   [Charts Overview](https://developers.signalfx.com/reference#charts-overview-1).
 	PaletteIndex *int32 `json:"paletteIndex"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.6.26
+# github.com/signalfx/signalfx-go v1.6.27
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting
 github.com/signalfx/signalfx-go/chart


### PR DESCRIPTION
# Summary
Bumps the dep for signalfx-go to pick up fixes for the data types for some charting fields. Adjustments then made to functions to work with this.

# Motivation
The incorrect `float32` used in the signalfx-go code caused conversions between `float32` and `float64` which resulted in unclean plans.