### PR TITLE
Fix unclean plans when using AWS services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 4.19.0 (Unreleased)
+## 4.18.5 (Unreleased)
+
+BUGFIXES:
+
+* resource/aws_integration: Using `services` no longer generates unclean plans when there are no changes. [#180](https://github.com/terraform-providers/terraform-provider-signalfx/pull/180)
+
 ## 4.18.4 (March 20, 2020)
 
 IMPROVEMENTS:


### PR DESCRIPTION
# Summary
Fix unclean plan when using `services` property of AWS integration

# Motivation
When setting `services` the SignalFx API returns both `services` and `namespace_sync_rule` populated with each entry from `services`. This is a nice shorthand, but makes it impossible for us to differentiate. This fix looks at the state and ignores `namespace_sync_rule` if we're using `services`.