### PR TITLE
Respect standard environment variables for HTTP proxies

### DIFF
--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -130,6 +130,7 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 	}
 
 	var netTransport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: 5 * time.Second,
 		}).Dial,


### PR DESCRIPTION
This should fix #182; ProxyFromEnvironment will use a proxy
if any of the standard HTTP/HTTPS_PROXY env vars are set, and
will use no proxy if these env vars are not set, or if NO_PROXY
is set.