### PR TITLE
Fix spelling error in docs for signalfx_team resource

### DIFF
--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -25,7 +25,7 @@ resource "signalfx_team" "myteam0" {
       "PagerDuty,credentialId"
     ]
 
-    notificiations_info = [
+    notifications_info = [
       "Email,notify@example.com"
     ]
 }


### PR DESCRIPTION
Literally a one-character doc fix... it was just bugging me ;)