### PR TITLE
Update list_chart.html.markdown

### DIFF
--- a/website/docs/r/list_chart.html.markdown
+++ b/website/docs/r/list_chart.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported in the resource block:
     * `value_prefix`, `value_suffix` - (Optional) Arbitrary prefix/suffix to display with the value of this plot.
 * `legend_fields_to_hide` - (Optional) List of properties that should not be displayed in the chart legend (i.e. dimension names). All the properties are visible by default. Deprecated, please use `legend_options_fields`.
 * `legend_options_fields` - (Optional) List of property names and enabled flags that should be displayed in the data table for the chart, in the order provided. This option cannot be used with `legend_fields_to_hide`.
-    * `property` The name of the property to display. Note the special values of `plot_label` (corresponding with the API's `sf_metric`) which shows the label of the time series `publish()` and `metric` (corresponding with the API's `sf_originatingMetric`) that shows the name of the metric for the time series being displayed.
+    * `property` The name of the property to display. Note the special values of `sf_metric` (corresponding with the API's `Plot Name`) which shows the label of the time series `publish()` and `sf_originatingMetric` (corresponding with the API's `metric (sf metric)`) that shows the [name of the metric](https://developers.signalfx.com/signalflow_analytics/functions/data_function.html#table-1-parameter-definitions) for the time series being displayed.
     * `enabled` True or False depending on if you want the property to be shown or hidden.
 * `max_precision` - (Optional) Maximum number of digits to display when rounding values up or down.
 * `secondary_visualization` - (Optional) The type of secondary visualization. Can be `None`, `Radial`, `Linear`, or `Sparkline`. If unset, the SignalFx default is used (`Sparkline`).


### PR DESCRIPTION
`plot_label` appears unused by default list charts, however `sf_metric` in terraform corresponds to "Plot Name" in signalfx and `sf_originatingMetric` corresponds to "metric (sf_metric)" in the signalfx UI which matches the first argument to `data` in signalflow, an argument called "metric". confusing!
Does this correlation change based on some configuration? This is what I saw while working with my own list chart.

sf_originatingMetric -> metric (sf_metric) -> signal label, first argument to data in signalflow "metric"
sf_metric -> Plot Name -> plot label or display name