### PR TITLE
Don't try and set null limits on org tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 4.20.0 (Unreleased)
+## 4.19.2 (Unreleased)
+
+BUGFIXES
+
+* resource/org_token: No longer crashes when trying to create without any limits. [#192](https://github.com/terraform-providers/terraform-provider-signalfx/pull/192)
+
 ## 4.19.1 (April 13, 2020)
 
 IMPROVEMENTS:

--- a/signalfx/resource_signalfx_org_token.go
+++ b/signalfx/resource_signalfx_org_token.go
@@ -285,8 +285,10 @@ func orgTokenAPIToTF(d *schema.ResourceData, t *orgtoken.Token) error {
 					usageStuff["high_res_metrics_notification_threshold"] = *cnt.HighResMetricThreshold
 				}
 			}
-			if err := d.Set("host_or_usage_limits", []interface{}{usageStuff}); err != nil {
-				return err
+			if len(usageStuff) > 0 {
+				if err := d.Set("host_or_usage_limits", []map[string]interface{}{usageStuff}); err != nil {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #191 wherein a crash resulted from a token being created without any limits.