### PR TITLE
Handle automatic heatmap color range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 4.20.0 (Unreleased)
+## 4.19.4 (Unreleased)
+
+BUGFIXES:
+* resource/heatmap_chart: Importing some heatmaps would fail. Fixed by defaulting to an empty `color_range` if none is specified. [#196](https://github.com/terraform-providers/terraform-provider-signalfx/pull/196)
+
 ## 4.19.3 (April 22, 2020)
 
 IMPROVEMENTS:

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -345,7 +345,7 @@ func heatmapchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 	if err := d.Set("hide_timestamp", options.TimestampHidden); err != nil {
 		return err
 	}
-	if options.ColorRange != nil {
+	if options.ColorRange != nil && options.ColorRange.Color != "" {
 		colorRange := make([]map[string]interface{}, 1)
 		colorRange[0] = map[string]interface{}{
 			"min_value": options.ColorRange.Min,

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -276,14 +276,14 @@ func getHeatmapOptionsChart(d *schema.ResourceData) (*chart.Options, error) {
 		}
 	}
 
+	// Default to an empty range
+	options.ColorBy = "Range"
 	if colorRangeOptions := getHeatmapColorRangeOptions(d); colorRangeOptions != nil {
 		options.ColorBy = "Range"
 		options.ColorRange = colorRangeOptions
 	} else if colorScaleOptions := getColorScaleOptions(d); colorScaleOptions != nil && len(colorScaleOptions) > 0 {
 		options.ColorBy = "Scale"
 		options.ColorScale2 = colorScaleOptions
-	} else {
-		return nil, fmt.Errorf("One of `color_scale` or `color_range` must be set")
 	}
 
 	return options, nil

--- a/website/docs/r/heatmap_chart.html.markdown
+++ b/website/docs/r/heatmap_chart.html.markdown
@@ -28,14 +28,13 @@ resource "signalfx_heatmap_chart" "myheatmapchart0" {
     group_by = ["hostname", "host"]
     hide_timestamp = true
 
-    # You must specify one of `color_range` or `color_scale`
     color_range {
         min_value = 0
         max_value = 100
         color = "#ff0000"
     }
-    
-    # !Do not use both color_range and color_scale!
+
+    # You can only use one of color_range or color_scale!
     color_scale {
         gte = 99
 	color = "green"
@@ -68,11 +67,11 @@ The following arguments are supported in the resource block:
 * `group_by` - (Optional) Properties to group by in the heatmap (in nesting order).
 * `sort_by` - (Optional) The property to use when sorting the elements. Must be prepended with `+` for ascending or `-` for descending (e.g. `-foo`).
 * `hide_timestamp` - (Optional) Whether to show the timestamp in the chart. `false` by default.
-* `color_range` - (Required unless using `color_scale`. Conflicts with `color_scale`) Values and color for the color range. Example: `color_range : { min : 0, max : 100, color : "#0000ff" }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+* `color_range` - (Optional, Default) Values and color for the color range. Example: `color_range : { min : 0, max : 100, color : "#0000ff" }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
     * `min_value` - (Optional) The minimum value within the coloring range.
     * `max_value` - (Optional) The maximum value within the coloring range.
     * `color` - (Required) The color range to use. The starting hex color value for data values in a heatmap chart. Specify the value as a 6-character hexadecimal value preceded by the '#' character, for example "#ea1849" (grass green).
-* `color_scale` - (Required unless using `color_range`.  Conflicts with `color_range`) One to N blocks, each defining a single color range including both the color to display for that range and the borders of the range. Example: `color_scale { gt = 60, color = "blue" } color_scale { lte = 60, color = "yellow" }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+* `color_scale` - (Optional.  Conflicts with `color_range`) One to N blocks, each defining a single color range including both the color to display for that range and the borders of the range. Example: `color_scale { gt = 60, color = "blue" } color_scale { lte = 60, color = "yellow" }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
     * `gt` - (Optional) Indicates the lower threshold non-inclusive value for this range.
     * `gte` - (Optional) Indicates the lower threshold inclusive value for this range.
     * `lt` - (Optional) Indicates the upper threshold non-inclusive value for this range.


### PR DESCRIPTION
Previously we required one of `color_range` or `color_scale` but that isn't how things actually work. We now default to a range, but allow it to be used with no options.