### PR TITLE
Improve HTTP safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 4.20.0 (Unreleased)
+## 4.19.5 (Unreleased)
+
+IMPROVEMENTS:
+* provider: Some additional checks to ensure HTTP cleanliness, hopefully preventing possible hangs or leaks. [#198](https://github.com/terraform-providers/terraform-provider-signalfx/pull/198)
+
 ## 4.19.4 (April 24, 2020)
 
 BUGFIXES:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.6.32
+	github.com/signalfx/signalfx-go v1.6.33
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.6.32 h1:coRDeOqrN96umMD6tO1OAJCuGp4+Ozvhdo4HcCryhAE=
-github.com/signalfx/signalfx-go v1.6.32/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.6.33 h1:XtwD4pSHe9EG5bYoW7xXEw8uKs8Qy48goRYRz6Fb77s=
+github.com/signalfx/signalfx-go v1.6.33/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -143,6 +143,8 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 			Timeout: 5 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 5 * time.Second,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
 	}
 
 	pv := version.ProviderVersion

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -1,4 +1,14 @@
-# 1.6.32, Pending
+# 1.6.34, Pending
+
+# 1.6.33, 2020-04-29
+
+* Adjust behavior to more reliably close/fully-read HTTP bodies with sketchy replies. [#81](https://github.com/signalfx/signalfx-go/pull/81)
+
+# 1.6.32, 2020-04-13
+
+## Improvements
+
+* Added User-Agent client param and header to client.
 
 # 1.6.31, 2020-04-10
 

--- a/vendor/github.com/signalfx/signalfx-go/alertmuting.go
+++ b/vendor/github.com/signalfx/signalfx-go/alertmuting.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -23,10 +24,12 @@ func (c *Client) CreateAlertMutingRule(muteRequest *alertmuting.CreateUpdateAler
 	}
 
 	resp, err := c.doRequest("POST", AlertMutingRuleAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -36,6 +39,7 @@ func (c *Client) CreateAlertMutingRule(muteRequest *alertmuting.CreateUpdateAler
 	finalRule := &alertmuting.AlertMutingRule{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalRule)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalRule, err
 }
@@ -43,16 +47,18 @@ func (c *Client) CreateAlertMutingRule(muteRequest *alertmuting.CreateUpdateAler
 // DeleteAlertMutingRule deletes an alert muting rule.
 func (c *Client) DeleteAlertMutingRule(name string) error {
 	resp, err := c.doRequest("DELETE", AlertMutingRuleAPIURL+"/"+name, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -60,10 +66,12 @@ func (c *Client) DeleteAlertMutingRule(name string) error {
 // GetAlertMutingRule gets an alert muting rule.
 func (c *Client) GetAlertMutingRule(id string) (*alertmuting.AlertMutingRule, error) {
 	resp, err := c.doRequest("GET", AlertMutingRuleAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -73,6 +81,7 @@ func (c *Client) GetAlertMutingRule(id string) (*alertmuting.AlertMutingRule, er
 	finalRule := &alertmuting.AlertMutingRule{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalRule)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalRule, err
 }
@@ -85,10 +94,12 @@ func (c *Client) UpdateAlertMutingRule(id string, muteRequest *alertmuting.Creat
 	}
 
 	resp, err := c.doRequest("PUT", AlertMutingRuleAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -98,6 +109,7 @@ func (c *Client) UpdateAlertMutingRule(id string, muteRequest *alertmuting.Creat
 	finalRule := &alertmuting.AlertMutingRule{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalRule)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalRule, err
 }
@@ -111,15 +123,17 @@ func (c *Client) SearchAlertMutingRules(include string, limit int, name string, 
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", AlertMutingRuleAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalRules := &alertmuting.SearchResult{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalRules)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalRules, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/aws_cloudwatch_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/aws_cloudwatch_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -18,11 +19,12 @@ func (c *Client) CreateAWSCloudWatchIntegration(acwi *integration.AwsCloudWatchI
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -32,6 +34,7 @@ func (c *Client) CreateAWSCloudWatchIntegration(acwi *integration.AwsCloudWatchI
 	finalIntegration := integration.AwsCloudWatchIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -39,11 +42,12 @@ func (c *Client) CreateAWSCloudWatchIntegration(acwi *integration.AwsCloudWatchI
 // GetAWSCloudWatchIntegration retrieves an AWS CloudWatch integration.
 func (c *Client) GetAWSCloudWatchIntegration(id string) (*integration.AwsCloudWatchIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +57,7 @@ func (c *Client) GetAWSCloudWatchIntegration(id string) (*integration.AwsCloudWa
 	finalIntegration := integration.AwsCloudWatchIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -65,11 +70,12 @@ func (c *Client) UpdateAWSCloudWatchIntegration(id string, acwi *integration.Aws
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -79,6 +85,7 @@ func (c *Client) UpdateAWSCloudWatchIntegration(id string, acwi *integration.Aws
 	finalIntegration := integration.AwsCloudWatchIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -86,16 +93,18 @@ func (c *Client) UpdateAWSCloudWatchIntegration(id string, acwi *integration.Aws
 // DeleteAWSCloudWatchIntegration deletes an AWS CloudWatch integration.
 func (c *Client) DeleteAWSCloudWatchIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/vendor/github.com/signalfx/signalfx-go/azure_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/azure_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -18,11 +19,12 @@ func (c *Client) CreateAzureIntegration(acwi *integration.AzureIntegration) (*in
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -32,6 +34,7 @@ func (c *Client) CreateAzureIntegration(acwi *integration.AzureIntegration) (*in
 	finalIntegration := integration.AzureIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -39,11 +42,12 @@ func (c *Client) CreateAzureIntegration(acwi *integration.AzureIntegration) (*in
 // GetAzureIntegration retrieves an Azure integration.
 func (c *Client) GetAzureIntegration(id string) (*integration.AzureIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +57,7 @@ func (c *Client) GetAzureIntegration(id string) (*integration.AzureIntegration, 
 	finalIntegration := integration.AzureIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -65,11 +70,12 @@ func (c *Client) UpdateAzureIntegration(id string, acwi *integration.AzureIntegr
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -79,6 +85,7 @@ func (c *Client) UpdateAzureIntegration(id string, acwi *integration.AzureIntegr
 	finalIntegration := integration.AzureIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -86,16 +93,18 @@ func (c *Client) UpdateAzureIntegration(id string, acwi *integration.AzureIntegr
 // DeleteAzureIntegration deletes an Azure integration.
 func (c *Client) DeleteAzureIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/vendor/github.com/signalfx/signalfx-go/chart.go
+++ b/vendor/github.com/signalfx/signalfx-go/chart.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -24,10 +25,12 @@ func (c *Client) CreateChart(chartRequest *chart.CreateUpdateChartRequest) (*cha
 	}
 
 	resp, err := c.doRequest("POST", ChartAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -37,6 +40,7 @@ func (c *Client) CreateChart(chartRequest *chart.CreateUpdateChartRequest) (*cha
 	finalChart := &chart.Chart{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalChart)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalChart, err
 }
@@ -44,15 +48,17 @@ func (c *Client) CreateChart(chartRequest *chart.CreateUpdateChartRequest) (*cha
 // DeleteChart deletes a chart.
 func (c *Client) DeleteChart(id string) error {
 	resp, err := c.doRequest("DELETE", ChartAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return errors.New("Unexpected status code: " + resp.Status)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -60,11 +66,12 @@ func (c *Client) DeleteChart(id string) error {
 // GetChart gets a chart.
 func (c *Client) GetChart(id string) (*chart.Chart, error) {
 	resp, err := c.doRequest("GET", ChartAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -74,6 +81,7 @@ func (c *Client) GetChart(id string) (*chart.Chart, error) {
 	finalChart := &chart.Chart{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalChart)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalChart, err
 }
@@ -86,10 +94,12 @@ func (c *Client) UpdateChart(id string, chartRequest *chart.CreateUpdateChartReq
 	}
 
 	resp, err := c.doRequest("PUT", ChartAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -99,6 +109,7 @@ func (c *Client) UpdateChart(id string, chartRequest *chart.CreateUpdateChartReq
 	finalChart := &chart.Chart{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalChart)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalChart, err
 }
@@ -116,15 +127,17 @@ func (c *Client) SearchCharts(limit int, name string, offset int, tags string) (
 	}
 
 	resp, err := c.doRequest("GET", ChartAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalCharts := &chart.SearchResult{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalCharts)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalCharts, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/dashboard.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -25,10 +26,12 @@ func (c *Client) CreateDashboard(dashboardRequest *dashboard.CreateUpdateDashboa
 	}
 
 	resp, err := c.doRequest("POST", DashboardAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -38,6 +41,7 @@ func (c *Client) CreateDashboard(dashboardRequest *dashboard.CreateUpdateDashboa
 	finalDashboard := &dashboard.Dashboard{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboard)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboard, err
 }
@@ -45,16 +49,18 @@ func (c *Client) CreateDashboard(dashboardRequest *dashboard.CreateUpdateDashboa
 // DeleteDashboard deletes a dashboard.
 func (c *Client) DeleteDashboard(id string) error {
 	resp, err := c.doRequest("DELETE", DashboardAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -62,11 +68,12 @@ func (c *Client) DeleteDashboard(id string) error {
 // GetDashboard gets a dashboard.
 func (c *Client) GetDashboard(id string) (*dashboard.Dashboard, error) {
 	resp, err := c.doRequest("GET", DashboardAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -76,6 +83,7 @@ func (c *Client) GetDashboard(id string) (*dashboard.Dashboard, error) {
 	finalDashboard := &dashboard.Dashboard{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboard)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboard, err
 }
@@ -88,10 +96,12 @@ func (c *Client) UpdateDashboard(id string, dashboardRequest *dashboard.CreateUp
 	}
 
 	resp, err := c.doRequest("PUT", DashboardAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -101,6 +111,7 @@ func (c *Client) UpdateDashboard(id string, dashboardRequest *dashboard.CreateUp
 	finalDashboard := &dashboard.Dashboard{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboard)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboard, err
 }
@@ -114,15 +125,17 @@ func (c *Client) SearchDashboard(limit int, name string, offset int, tags string
 	params.Add("tags", tags)
 
 	resp, err := c.doRequest("GET", DashboardAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDashboards := &dashboard.SearchResult{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboards)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboards, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/dashboardgroup.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboardgroup.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -30,10 +31,12 @@ func (c *Client) CreateDashboardGroup(dashboardGroupRequest *dashboard_group.Cre
 	}
 
 	resp, err := c.doRequest("POST", DashboardGroupAPIURL, params, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -43,6 +46,7 @@ func (c *Client) CreateDashboardGroup(dashboardGroupRequest *dashboard_group.Cre
 	finalDashboardGroup := &dashboard_group.DashboardGroup{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboardGroup)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboardGroup, err
 }
@@ -50,16 +54,18 @@ func (c *Client) CreateDashboardGroup(dashboardGroupRequest *dashboard_group.Cre
 // DeleteDashboardGroup deletes a dashboard.
 func (c *Client) DeleteDashboardGroup(id string) error {
 	resp, err := c.doRequest("DELETE", DashboardGroupAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -67,11 +73,12 @@ func (c *Client) DeleteDashboardGroup(id string) error {
 // GetDashboardGroup gets a dashboard group.
 func (c *Client) GetDashboardGroup(id string) (*dashboard_group.DashboardGroup, error) {
 	resp, err := c.doRequest("GET", DashboardGroupAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -81,6 +88,7 @@ func (c *Client) GetDashboardGroup(id string) (*dashboard_group.DashboardGroup, 
 	finalDashboardGroup := &dashboard_group.DashboardGroup{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboardGroup)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboardGroup, err
 }
@@ -93,10 +101,12 @@ func (c *Client) UpdateDashboardGroup(id string, dashboardGroupRequest *dashboar
 	}
 
 	resp, err := c.doRequest("PUT", DashboardGroupAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -106,6 +116,7 @@ func (c *Client) UpdateDashboardGroup(id string, dashboardGroupRequest *dashboar
 	finalDashboardGroup := &dashboard_group.DashboardGroup{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboardGroup)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboardGroup, err
 }
@@ -118,15 +129,17 @@ func (c *Client) SearchDashboardGroups(limit int, name string, offset int) (*das
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", DashboardGroupAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDashboardGroups := &dashboard_group.SearchResult{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboardGroups)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboardGroups, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/datalink.go
+++ b/vendor/github.com/signalfx/signalfx-go/datalink.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -23,10 +24,12 @@ func (c *Client) CreateDataLink(dataLinkRequest *datalink.CreateUpdateDataLinkRe
 	}
 
 	resp, err := c.doRequest("POST", DataLinkAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -36,6 +39,7 @@ func (c *Client) CreateDataLink(dataLinkRequest *datalink.CreateUpdateDataLinkRe
 	finalDataLink := &datalink.DataLink{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDataLink)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDataLink, err
 }
@@ -43,11 +47,12 @@ func (c *Client) CreateDataLink(dataLinkRequest *datalink.CreateUpdateDataLinkRe
 // DeleteDataLink deletes a data link.
 func (c *Client) DeleteDataLink(id string) error {
 	resp, err := c.doRequest("DELETE", DataLinkAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	// The API returns a 200 here, which I think is a mistake so covering for
 	// future changes.
@@ -55,6 +60,7 @@ func (c *Client) DeleteDataLink(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -62,10 +68,12 @@ func (c *Client) DeleteDataLink(id string) error {
 // GetDataLink gets a data link.
 func (c *Client) GetDataLink(id string) (*datalink.DataLink, error) {
 	resp, err := c.doRequest("GET", DataLinkAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -75,6 +83,7 @@ func (c *Client) GetDataLink(id string) (*datalink.DataLink, error) {
 	finalDataLink := &datalink.DataLink{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDataLink)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDataLink, err
 }
@@ -88,10 +97,12 @@ func (c *Client) UpdateDataLink(id string, dataLinkRequest *datalink.CreateUpdat
 
 	encodedName := url.PathEscape(id)
 	resp, err := c.doRequest("PUT", DataLinkAPIURL+"/"+encodedName, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -101,6 +112,7 @@ func (c *Client) UpdateDataLink(id string, dataLinkRequest *datalink.CreateUpdat
 	finalDataLink := &datalink.DataLink{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDataLink)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDataLink, err
 }
@@ -113,15 +125,17 @@ func (c *Client) SearchDataLinks(limit int, context string, offset int) (*datali
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", DataLinkAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDataLinks := &datalink.SearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDataLinks)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDataLinks, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/detector.go
+++ b/vendor/github.com/signalfx/signalfx-go/detector.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -23,10 +24,12 @@ func (c *Client) CreateDetector(detectorRequest *detector.CreateUpdateDetectorRe
 	}
 
 	resp, err := c.doRequest("POST", DetectorAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -36,6 +39,7 @@ func (c *Client) CreateDetector(detectorRequest *detector.CreateUpdateDetectorRe
 	finalDetector := &detector.Detector{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDetector)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDetector, err
 }
@@ -43,16 +47,18 @@ func (c *Client) CreateDetector(detectorRequest *detector.CreateUpdateDetectorRe
 // DeleteDetector deletes a detector.
 func (c *Client) DeleteDetector(id string) error {
 	resp, err := c.doRequest("DELETE", DetectorAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -65,15 +71,18 @@ func (c *Client) DisableDetector(id string, labels []string) error {
 	}
 
 	resp, err := c.doRequest("PUT", DetectorAPIURL+"/"+id+"/disable", nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -86,15 +95,18 @@ func (c *Client) EnableDetector(id string, labels []string) error {
 	}
 
 	resp, err := c.doRequest("PUT", DetectorAPIURL+"/"+id+"/enable", nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -102,10 +114,12 @@ func (c *Client) EnableDetector(id string, labels []string) error {
 // GetDetector gets a detector.
 func (c *Client) GetDetector(id string) (*detector.Detector, error) {
 	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -115,9 +129,8 @@ func (c *Client) GetDetector(id string) (*detector.Detector, error) {
 	finalDetector := &detector.Detector{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDetector)
-	if err != nil {
-		fmt.Printf("+%v", err)
-	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return finalDetector, err
 }
 
@@ -129,10 +142,12 @@ func (c *Client) UpdateDetector(id string, detectorRequest *detector.CreateUpdat
 	}
 
 	resp, err := c.doRequest("PUT", DetectorAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -142,11 +157,12 @@ func (c *Client) UpdateDetector(id string, detectorRequest *detector.CreateUpdat
 	finalDetector := &detector.Detector{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDetector)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDetector, err
 }
 
-// SearchDetector searches for detectors, given a query string in `name`.
+// SearchDetectors searches for detectors, given a query string in `name`.
 func (c *Client) SearchDetectors(limit int, name string, offset int, tags string) (*detector.SearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
@@ -157,15 +173,17 @@ func (c *Client) SearchDetectors(limit int, name string, offset int, tags string
 	}
 
 	resp, err := c.doRequest("GET", DetectorAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDetectors := &detector.SearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDetectors)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDetectors, err
 }
@@ -178,10 +196,12 @@ func (c *Client) GetDetectorEvents(id string, from int, to int, offset int, limi
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("limit", strconv.Itoa(limit))
 	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id+"/events", params, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -191,9 +211,8 @@ func (c *Client) GetDetectorEvents(id string, from int, to int, offset int, limi
 	var events []*detector.Event
 
 	err = json.NewDecoder(resp.Body).Decode(&events)
-	if err != nil {
-		fmt.Printf("+%v", err)
-	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return events, err
 }
 
@@ -203,10 +222,12 @@ func (c *Client) GetDetectorIncidents(id string, offset int, limit int) ([]*dete
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("limit", strconv.Itoa(limit))
 	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id+"/incidents", params, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -216,8 +237,7 @@ func (c *Client) GetDetectorIncidents(id string, offset int, limit int) ([]*dete
 	var incidents []*detector.Incident
 
 	err = json.NewDecoder(resp.Body).Decode(&incidents)
-	if err != nil {
-		fmt.Printf("+%v", err)
-	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return incidents, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/gcp_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/gcp_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -18,11 +19,12 @@ func (c *Client) CreateGCPIntegration(gcpi *integration.GCPIntegration) (*integr
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -32,6 +34,7 @@ func (c *Client) CreateGCPIntegration(gcpi *integration.GCPIntegration) (*integr
 	finalIntegration := integration.GCPIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -39,11 +42,12 @@ func (c *Client) CreateGCPIntegration(gcpi *integration.GCPIntegration) (*integr
 // GetGCPIntegration retrieves a GCP integration.
 func (c *Client) GetGCPIntegration(id string) (*integration.GCPIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +57,7 @@ func (c *Client) GetGCPIntegration(id string) (*integration.GCPIntegration, erro
 	finalIntegration := integration.GCPIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -65,11 +70,12 @@ func (c *Client) UpdateGCPIntegration(id string, gcpi *integration.GCPIntegratio
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -79,6 +85,7 @@ func (c *Client) UpdateGCPIntegration(id string, gcpi *integration.GCPIntegratio
 	finalIntegration := integration.GCPIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -86,16 +93,18 @@ func (c *Client) UpdateGCPIntegration(id string, gcpi *integration.GCPIntegratio
 // DeleteGCPIntegration deletes a GCP integration.
 func (c *Client) DeleteGCPIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/vendor/github.com/signalfx/signalfx-go/jira_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/jira_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -18,11 +19,12 @@ func (c *Client) CreateJiraIntegration(ji *integration.JiraIntegration) (*integr
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -32,6 +34,7 @@ func (c *Client) CreateJiraIntegration(ji *integration.JiraIntegration) (*integr
 	finalIntegration := integration.JiraIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -39,11 +42,12 @@ func (c *Client) CreateJiraIntegration(ji *integration.JiraIntegration) (*integr
 // GetJiraIntegration retrieves an Jira integration.
 func (c *Client) GetJiraIntegration(id string) (*integration.JiraIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +57,7 @@ func (c *Client) GetJiraIntegration(id string) (*integration.JiraIntegration, er
 	finalIntegration := integration.JiraIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -65,11 +70,12 @@ func (c *Client) UpdateJiraIntegration(id string, ji *integration.JiraIntegratio
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -79,6 +85,7 @@ func (c *Client) UpdateJiraIntegration(id string, ji *integration.JiraIntegratio
 	finalIntegration := integration.JiraIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -86,16 +93,18 @@ func (c *Client) UpdateJiraIntegration(id string, ji *integration.JiraIntegratio
 // DeleteJiraIntegration deletes an Jira integration.
 func (c *Client) DeleteJiraIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/vendor/github.com/signalfx/signalfx-go/metrics_metadata.go
+++ b/vendor/github.com/signalfx/signalfx-go/metrics_metadata.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -27,10 +28,12 @@ const TagAPIURL = "/v2/tag"
 // GetDimension gets a dimension.
 func (c *Client) GetDimension(key string, value string) (*metrics_metadata.Dimension, error) {
 	resp, err := c.doRequest("GET", DimensionAPIURL+"/"+key+"/"+value, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -52,10 +55,12 @@ func (c *Client) UpdateDimension(key string, value string, dim *metrics_metadata
 	}
 
 	resp, err := c.doRequest("PUT", DimensionAPIURL+"/"+key+"/"+value, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,6 +70,7 @@ func (c *Client) UpdateDimension(key string, value string, dim *metrics_metadata
 	finalDimension := &metrics_metadata.Dimension{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDimension)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDimension, err
 }
@@ -80,15 +86,17 @@ func (c *Client) SearchDimension(query string, orderBy string, limit int, offset
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", DimensionAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDimensions := &metrics_metadata.DimensionQueryResponseModel{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDimensions)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDimensions, err
 }
@@ -102,15 +110,17 @@ func (c *Client) SearchMetric(query string, orderBy string, limit int, offset in
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", MetricAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalMetrics := &metrics_metadata.RetrieveMetricMetadataResponseModel{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMetrics)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMetrics, err
 }
@@ -118,10 +128,12 @@ func (c *Client) SearchMetric(query string, orderBy string, limit int, offset in
 // GetMetric retrieves a single metric by name.
 func (c *Client) GetMetric(name string) (*metrics_metadata.Metric, error) {
 	resp, err := c.doRequest("GET", MetricAPIURL+"/"+name, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -131,6 +143,7 @@ func (c *Client) GetMetric(name string) (*metrics_metadata.Metric, error) {
 	finalMetric := &metrics_metadata.Metric{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMetric)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMetric, err
 }
@@ -138,10 +151,12 @@ func (c *Client) GetMetric(name string) (*metrics_metadata.Metric, error) {
 // GetMetricTimeSeries retrieves a metric time series by id.
 func (c *Client) GetMetricTimeSeries(id string) (*metrics_metadata.MetricTimeSeries, error) {
 	resp, err := c.doRequest("GET", MetricTimeSeriesAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -151,6 +166,8 @@ func (c *Client) GetMetricTimeSeries(id string) (*metrics_metadata.MetricTimeSer
 	finalMetricTimeSeries := &metrics_metadata.MetricTimeSeries{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMetricTimeSeries)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return finalMetricTimeSeries, err
 }
 
@@ -163,15 +180,17 @@ func (c *Client) SearchMetricTimeSeries(query string, orderBy string, limit int,
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", MetricTimeSeriesAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalMTS := &metrics_metadata.MetricTimeSeriesRetrieveResponseModel{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMTS)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMTS, err
 }
@@ -185,15 +204,17 @@ func (c *Client) SearchTag(query string, orderBy string, limit int, offset int) 
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", TagAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalTags := &metrics_metadata.TagRetrieveResponseModel{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTags)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTags, err
 }
@@ -201,10 +222,12 @@ func (c *Client) SearchTag(query string, orderBy string, limit int, offset int) 
 // GetTag gets a tag by name
 func (c *Client) GetTag(name string) (*metrics_metadata.Tag, error) {
 	resp, err := c.doRequest("GET", TagAPIURL+"/"+name, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -214,22 +237,26 @@ func (c *Client) GetTag(name string) (*metrics_metadata.Tag, error) {
 	finalTag := &metrics_metadata.Tag{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTag)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return finalTag, err
 }
 
 // DeleteTag deletes a tag.
 func (c *Client) DeleteTag(id string) error {
 	resp, err := c.doRequest("DELETE", TagAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -242,10 +269,12 @@ func (c *Client) CreateUpdateTag(name string, cutr *metrics_metadata.CreateUpdat
 	}
 
 	resp, err := c.doRequest("PUT", TagAPIURL+"/"+name, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -255,6 +284,7 @@ func (c *Client) CreateUpdateTag(name string, cutr *metrics_metadata.CreateUpdat
 	finalTag := &metrics_metadata.Tag{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTag)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTag, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/opsgenie_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/opsgenie_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -18,11 +19,12 @@ func (c *Client) CreateOpsgenieIntegration(oi *integration.OpsgenieIntegration) 
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -32,6 +34,7 @@ func (c *Client) CreateOpsgenieIntegration(oi *integration.OpsgenieIntegration) 
 	finalIntegration := integration.OpsgenieIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -39,11 +42,12 @@ func (c *Client) CreateOpsgenieIntegration(oi *integration.OpsgenieIntegration) 
 // GetOpsgenieIntegration retrieves an Opsgenie integration.
 func (c *Client) GetOpsgenieIntegration(id string) (*integration.OpsgenieIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +57,7 @@ func (c *Client) GetOpsgenieIntegration(id string) (*integration.OpsgenieIntegra
 	finalIntegration := integration.OpsgenieIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -65,11 +70,12 @@ func (c *Client) UpdateOpsgenieIntegration(id string, oi *integration.OpsgenieIn
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -79,6 +85,7 @@ func (c *Client) UpdateOpsgenieIntegration(id string, oi *integration.OpsgenieIn
 	finalIntegration := integration.OpsgenieIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -86,16 +93,18 @@ func (c *Client) UpdateOpsgenieIntegration(id string, oi *integration.OpsgenieIn
 // DeleteOpsgenieIntegration deletes an Opsgenie integration.
 func (c *Client) DeleteOpsgenieIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/vendor/github.com/signalfx/signalfx-go/organization.go
+++ b/vendor/github.com/signalfx/signalfx-go/organization.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -20,10 +21,12 @@ const OrganizationMembersAPIURL = "/v2/organization/members"
 // GetOrganization gets an organization.
 func (c *Client) GetOrganization(id string) (*organization.Organization, error) {
 	resp, err := c.doRequest("GET", OrganizationAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -33,6 +36,7 @@ func (c *Client) GetOrganization(id string) (*organization.Organization, error) 
 	finalOrganization := &organization.Organization{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalOrganization)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalOrganization, err
 }
@@ -40,10 +44,12 @@ func (c *Client) GetOrganization(id string) (*organization.Organization, error) 
 // GetMember gets a member.
 func (c *Client) GetMember(id string) (*organization.Member, error) {
 	resp, err := c.doRequest("GET", OrganizationMemberAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +59,7 @@ func (c *Client) GetMember(id string) (*organization.Member, error) {
 	finalMember := &organization.Member{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMember)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMember, err
 }
@@ -60,16 +67,18 @@ func (c *Client) GetMember(id string) (*organization.Member, error) {
 // DeleteMember deletes a detector.
 func (c *Client) DeleteMember(id string) error {
 	resp, err := c.doRequest("DELETE", OrganizationMemberAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -82,10 +91,12 @@ func (c *Client) InviteMember(inviteRequest *organization.CreateUpdateMemberRequ
 	}
 
 	resp, err := c.doRequest("POST", OrganizationMemberAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -95,6 +106,7 @@ func (c *Client) InviteMember(inviteRequest *organization.CreateUpdateMemberRequ
 	finalMember := &organization.Member{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMember)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMember, err
 }
@@ -107,10 +119,12 @@ func (c *Client) InviteMembers(inviteRequest *organization.InviteMembersRequest)
 	}
 
 	resp, err := c.doRequest("POST", OrganizationMembersAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -120,6 +134,7 @@ func (c *Client) InviteMembers(inviteRequest *organization.InviteMembersRequest)
 	finalMembers := &organization.InviteMembersRequest{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMembers)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMembers, err
 }
@@ -133,15 +148,17 @@ func (c *Client) GetOrganizationMembers(limit int, query string, offset int, ord
 	params.Add("orderBy", orderBy)
 
 	resp, err := c.doRequest("GET", OrganizationMemberAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalMembers := &organization.MemberSearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMembers)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMembers, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/orgtoken.go
+++ b/vendor/github.com/signalfx/signalfx-go/orgtoken.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -23,10 +24,12 @@ func (c *Client) CreateOrgToken(tokenRequest *orgtoken.CreateUpdateTokenRequest)
 	}
 
 	resp, err := c.doRequest("POST", TokenAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -36,6 +39,7 @@ func (c *Client) CreateOrgToken(tokenRequest *orgtoken.CreateUpdateTokenRequest)
 	finalToken := &orgtoken.Token{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalToken)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalToken, err
 }
@@ -44,28 +48,32 @@ func (c *Client) CreateOrgToken(tokenRequest *orgtoken.CreateUpdateTokenRequest)
 func (c *Client) DeleteOrgToken(name string) error {
 	encodedName := url.PathEscape(name)
 	resp, err := c.doRequest("DELETE", TokenAPIURL+"/"+encodedName, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
 
-// GetToken gets a token.
+// GetOrgToken gets a token.
 func (c *Client) GetOrgToken(id string) (*orgtoken.Token, error) {
 	encodedName := url.PathEscape(id)
 	resp, err := c.doRequest("GET", TokenAPIURL+"/"+encodedName, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -75,11 +83,12 @@ func (c *Client) GetOrgToken(id string) (*orgtoken.Token, error) {
 	finalToken := &orgtoken.Token{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalToken)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalToken, err
 }
 
-// UpdateToken updates a token.
+// UpdateOrgToken updates a token.
 func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTokenRequest) (*orgtoken.Token, error) {
 	payload, err := json.Marshal(tokenRequest)
 	if err != nil {
@@ -88,10 +97,12 @@ func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTo
 
 	encodedName := url.PathEscape(id)
 	resp, err := c.doRequest("PUT", TokenAPIURL+"/"+encodedName, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -101,11 +112,12 @@ func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTo
 	finalToken := &orgtoken.Token{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalToken)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalToken, err
 }
 
-// SearchToken searches for tokens given a query string in `name`.
+// SearchOrgToken searches for tokens given a query string in `name`.
 func (c *Client) SearchOrgTokens(limit int, name string, offset int) (*orgtoken.SearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
@@ -113,15 +125,17 @@ func (c *Client) SearchOrgTokens(limit int, name string, offset int) (*orgtoken.
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", TokenAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalTokens := &orgtoken.SearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTokens)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTokens, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/pagerduty_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/pagerduty_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -18,11 +19,12 @@ func (c *Client) CreatePagerDutyIntegration(pdi *integration.PagerDutyIntegratio
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -32,6 +34,7 @@ func (c *Client) CreatePagerDutyIntegration(pdi *integration.PagerDutyIntegratio
 	finalIntegration := integration.PagerDutyIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -39,11 +42,12 @@ func (c *Client) CreatePagerDutyIntegration(pdi *integration.PagerDutyIntegratio
 // GetPagerDutyIntegration retrieves a PagerDuty integration.
 func (c *Client) GetPagerDutyIntegration(id string) (*integration.PagerDutyIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +57,7 @@ func (c *Client) GetPagerDutyIntegration(id string) (*integration.PagerDutyInteg
 	finalIntegration := integration.PagerDutyIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -65,11 +70,12 @@ func (c *Client) UpdatePagerDutyIntegration(id string, pdi *integration.PagerDut
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -79,6 +85,7 @@ func (c *Client) UpdatePagerDutyIntegration(id string, pdi *integration.PagerDut
 	finalIntegration := integration.PagerDutyIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -86,16 +93,18 @@ func (c *Client) UpdatePagerDutyIntegration(id string, pdi *integration.PagerDut
 // DeletePagerDutyIntegration deletes a PagerDuty integration.
 func (c *Client) DeletePagerDutyIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/vendor/github.com/signalfx/signalfx-go/slack_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/slack_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -18,11 +19,12 @@ func (c *Client) CreateSlackIntegration(si *integration.SlackIntegration) (*inte
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -32,6 +34,7 @@ func (c *Client) CreateSlackIntegration(si *integration.SlackIntegration) (*inte
 	finalIntegration := integration.SlackIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -39,11 +42,12 @@ func (c *Client) CreateSlackIntegration(si *integration.SlackIntegration) (*inte
 // GetSlackIntegration retrieves a Slack integration.
 func (c *Client) GetSlackIntegration(id string) (*integration.SlackIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +57,7 @@ func (c *Client) GetSlackIntegration(id string) (*integration.SlackIntegration, 
 	finalIntegration := integration.SlackIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -65,11 +70,12 @@ func (c *Client) UpdateSlackIntegration(id string, si *integration.SlackIntegrat
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -79,6 +85,7 @@ func (c *Client) UpdateSlackIntegration(id string, si *integration.SlackIntegrat
 	finalIntegration := integration.SlackIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -86,16 +93,18 @@ func (c *Client) UpdateSlackIntegration(id string, si *integration.SlackIntegrat
 // DeleteSlackIntegration deletes a Slack integration.
 func (c *Client) DeleteSlackIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/vendor/github.com/signalfx/signalfx-go/team.go
+++ b/vendor/github.com/signalfx/signalfx-go/team.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -24,10 +25,12 @@ func (c *Client) CreateTeam(t *team.CreateUpdateTeamRequest) (*team.Team, error)
 	}
 
 	resp, err := c.doRequest("POST", TeamAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -37,6 +40,7 @@ func (c *Client) CreateTeam(t *team.CreateUpdateTeamRequest) (*team.Team, error)
 	finalTeam := &team.Team{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTeam)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTeam, err
 }
@@ -44,15 +48,17 @@ func (c *Client) CreateTeam(t *team.CreateUpdateTeamRequest) (*team.Team, error)
 // DeleteTeam deletes a team.
 func (c *Client) DeleteTeam(id string) error {
 	resp, err := c.doRequest("DELETE", TeamAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		return errors.New("Unexpected status code: " + resp.Status)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -60,11 +66,12 @@ func (c *Client) DeleteTeam(id string) error {
 // GetTeam gets a team.
 func (c *Client) GetTeam(id string) (*team.Team, error) {
 	resp, err := c.doRequest("GET", TeamAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
@@ -73,6 +80,7 @@ func (c *Client) GetTeam(id string) (*team.Team, error) {
 	finalTeam := &team.Team{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTeam)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTeam, err
 }
@@ -85,10 +93,12 @@ func (c *Client) UpdateTeam(id string, t *team.CreateUpdateTeamRequest) (*team.T
 	}
 
 	resp, err := c.doRequest("PUT", TeamAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
@@ -97,6 +107,7 @@ func (c *Client) UpdateTeam(id string, t *team.CreateUpdateTeamRequest) (*team.T
 	finalTeam := &team.Team{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTeam)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTeam, err
 }
@@ -110,15 +121,17 @@ func (c *Client) SearchTeam(limit int, name string, offset int, tags string) (*t
 	params.Add("tags", tags)
 
 	resp, err := c.doRequest("GET", TeamAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalTeams := &team.SearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTeams)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTeams, err
 }

--- a/vendor/github.com/signalfx/signalfx-go/victor_ops_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/victor_ops_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -18,11 +19,12 @@ func (c *Client) CreateVictorOpsIntegration(oi *integration.VictorOpsIntegration
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -32,6 +34,7 @@ func (c *Client) CreateVictorOpsIntegration(oi *integration.VictorOpsIntegration
 	finalIntegration := integration.VictorOpsIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -39,11 +42,12 @@ func (c *Client) CreateVictorOpsIntegration(oi *integration.VictorOpsIntegration
 // GetVictorOpsIntegration retrieves an VictorOps integration.
 func (c *Client) GetVictorOpsIntegration(id string) (*integration.VictorOpsIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +57,7 @@ func (c *Client) GetVictorOpsIntegration(id string) (*integration.VictorOpsInteg
 	finalIntegration := integration.VictorOpsIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -65,11 +70,12 @@ func (c *Client) UpdateVictorOpsIntegration(id string, oi *integration.VictorOps
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -79,6 +85,7 @@ func (c *Client) UpdateVictorOpsIntegration(id string, oi *integration.VictorOps
 	finalIntegration := integration.VictorOpsIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -86,16 +93,18 @@ func (c *Client) UpdateVictorOpsIntegration(id string, oi *integration.VictorOps
 // DeleteVictorOpsIntegration deletes an VictorOps integration.
 func (c *Client) DeleteVictorOpsIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/vendor/github.com/signalfx/signalfx-go/webhook_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/webhook_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -18,11 +19,12 @@ func (c *Client) CreateWebhookIntegration(oi *integration.WebhookIntegration) (*
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -32,6 +34,7 @@ func (c *Client) CreateWebhookIntegration(oi *integration.WebhookIntegration) (*
 	finalIntegration := integration.WebhookIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -39,11 +42,12 @@ func (c *Client) CreateWebhookIntegration(oi *integration.WebhookIntegration) (*
 // GetWebhookIntegration retrieves an Webhook integration.
 func (c *Client) GetWebhookIntegration(id string) (*integration.WebhookIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -53,6 +57,7 @@ func (c *Client) GetWebhookIntegration(id string) (*integration.WebhookIntegrati
 	finalIntegration := integration.WebhookIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -65,11 +70,12 @@ func (c *Client) UpdateWebhookIntegration(id string, oi *integration.WebhookInte
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -79,6 +85,7 @@ func (c *Client) UpdateWebhookIntegration(id string, oi *integration.WebhookInte
 	finalIntegration := integration.WebhookIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -86,16 +93,18 @@ func (c *Client) UpdateWebhookIntegration(id string, oi *integration.WebhookInte
 // DeleteWebhookIntegration deletes an Webhook integration.
 func (c *Client) DeleteWebhookIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,7 +215,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.6.32
+# github.com/signalfx/signalfx-go v1.6.33
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting
 github.com/signalfx/signalfx-go/chart


### PR DESCRIPTION
# Summary
Bumps version of signalfx-go and adjusts some HTTP connection parameters.

# Motivation
Some possible leaks in HTTP bodies [were cleaned up](https://github.com/signalfx/signalfx-go/pull/81) so we're pulling that in.

In case there are any reuse problems, we bumped the max idle connections per host to match the total idle. I don't think this causes hangs, but it might cause leaks that turn into hangs or something?

# Note
This aims to address #197 and #175 