### PR TITLE
Enable API HTTP requests/responses logging in debug mode

### DIFF
--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bgentry/go-netrc/netrc"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	homedir "github.com/mitchellh/go-homedir"
@@ -146,7 +147,7 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 		config.CustomAppURL = custom_app_url.(string)
 	}
 
-	var netTransport = &http.Transport{
+	var netTransport = logging.NewTransport("SignalFx", &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: 5 * time.Second,
@@ -154,7 +155,7 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 		TLSHandshakeTimeout: 5 * time.Second,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 100,
-	}
+	})
 
 	pv := version.ProviderVersion
 	providerUserAgent := fmt.Sprintf("Terraform/%s terraform-provider-signalfx/%s", sfxProvider.TerraformVersion, pv)


### PR DESCRIPTION
This PR enables API HTTP requests/responses logging in debug mode.

With this change:

```
TF_LOG=debug terraform plan -target signalfx_gcp_integration.gcp_integration
...
2020-05-28T11:20:31.323+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: -----------------------------------------------------
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: 2020/05/28 11:20:31 [DEBUG] SignalFx API Request Details:
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: ---[ REQUEST ]---------------------------------------
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: GET /v2/integration/TheIntegrationId HTTP/1.1
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Host: api.eu0.signalfx.com
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: User-Agent: Terraform/0.12.25 terraform-provider-signalfx/dev
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Content-Type: application/json
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: X-Sf-Token: MySecretToken
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Accept-Encoding: gzip
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:
2020-05-28T11:20:31.324+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: -----------------------------------------------------
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: 2020/05/28 11:20:31 [DEBUG] SignalFx API Response Details:
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: ---[ RESPONSE ]--------------------------------------
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: HTTP/1.1 200 OK
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Cache-Control: no-cache, no-store, must-revalidate, no-transform
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Connection: keep-alive
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Content-Type: application/json
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Date: Thu, 28 May 2020 09:20:31 GMT
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Expires: 0
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Strict-Transport-Security: max-age=7776000
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: Vary: Accept-Encoding, User-Agent
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: X-Content-Type-Options: nosniff
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: {
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "created" : 1588693081548,
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "creator" : "MyId",
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "enabled" : true,
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "id" : "TheIntegrationId",
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "lastUpdated" : 1590656318692,
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "lastUpdatedBy" : "MyId",
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "name" : "GCPIntegration",
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "pollRate" : 300000,
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "projectServiceKeys" : [ {
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:     "projectId" : "myproject"
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   } ],
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "services" : [ ],
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "type" : "GCP",
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev:   "whitelist" : [ "labels", "system_labels", "user_labels", "metadata.system_labels", "metadata.system_labels.name", "dd_monitoring" ]
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: }
2020-05-28T11:20:31.366+0200 [DEBUG] plugin.terraform-provider-signalfx_v4.22.0-dev: -----------------------------------------------------
```

This really useful to understand API requests/responses and troubleshoot issues.
Note that's already is done in several other terraform providers, e.g.:

- https://github.com/terraform-providers/terraform-provider-kubernetes/blame/v1.11.3/kubernetes/provider.go#L256
- https://github.com/terraform-providers/terraform-provider-google/blame/v3.23.0/google/config.go#L287