### PR TITLE
Add context everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 4.24.0 (Unreleased)
+
+IMPROVEMENTS:
+* Bumped signalfx-go dependency which requires the use of `context.Context` in many client calls. No material change otherwise.
+
 ## 4.23.0 (June 02, 2020)
 
 IMPROVEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/terraform-plugin-sdk v1.11.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.6.39
+	github.com/signalfx/signalfx-go v1.7.0
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.6.39 h1:JDPVLHSG4dk9UKuMMVlQKqL10uVi1v/AVUab+6nU9Iw=
-github.com/signalfx/signalfx-go v1.6.39/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.7.0 h1:a0Wvl0QtNn7728C7tjiJeptPATBrkN1rcOwcHQ//vuY=
+github.com/signalfx/signalfx-go v1.7.0/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac h1:wbW+Bybf9pXxnCFAOWZTqkRjAc7rAIwo2e1ArUhiHxg=

--- a/signalfx/data_source_dimension_values.go
+++ b/signalfx/data_source_dimension_values.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -37,7 +38,7 @@ func dataSourceReadSignalFxDimensionValue(d *schema.ResourceData, meta interface
 	query := d.Get("query").(string)
 
 	log.Printf("[DEBUG] SignalFx: Requesting dimension search: query=%s, limit=%d", query, PAGE_LIMIT)
-	resp, err := config.Client.SearchDimension(query, "", int(PAGE_LIMIT), 0)
+	resp, err := config.Client.SearchDimension(context.TODO(), query, "", int(PAGE_LIMIT), 0)
 	if err != nil {
 		return err
 	}
@@ -61,7 +62,7 @@ func dataSourceReadSignalFxDimensionValue(d *schema.ResourceData, meta interface
 			// If this isn't the first in the loop, fetch the next batch
 			offset := i + int(PAGE_LIMIT) + 1
 			log.Printf("[DEBUG] SignalFx: Requesting dimension search: query=%s, limit=%d, offset=%d", query, PAGE_LIMIT, offset)
-			resp, err = config.Client.SearchDimension(query, "", int(PAGE_LIMIT), offset)
+			resp, err = config.Client.SearchDimension(context.TODO(), query, "", int(PAGE_LIMIT), offset)
 			if err != nil {
 				return err
 			}

--- a/signalfx/resource_signalfx_alert_muting_rule.go
+++ b/signalfx/resource_signalfx_alert_muting_rule.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -131,7 +132,7 @@ func alertMutingRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Alert Muting Rule Payload: %s", string(debugOutput))
 
-	amr, err := config.Client.CreateAlertMutingRule(payload)
+	amr, err := config.Client.CreateAlertMutingRule(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -142,7 +143,7 @@ func alertMutingRuleCreate(d *schema.ResourceData, meta interface{}) error {
 
 func alertMutingRuleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAlertMutingRule(d.Id())
+	_, err := config.Client.GetAlertMutingRule(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -154,7 +155,7 @@ func alertMutingRuleExists(d *schema.ResourceData, meta interface{}) (bool, erro
 
 func alertMutingRuleRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	amr, err := config.Client.GetAlertMutingRule(d.Id())
+	amr, err := config.Client.GetAlertMutingRule(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -243,7 +244,7 @@ func alertMutingRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Alert Muting Rule Payload: %s", string(debugOutput))
 
-	det, err := config.Client.UpdateAlertMutingRule(d.Id(), payload)
+	det, err := config.Client.UpdateAlertMutingRule(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -256,5 +257,5 @@ func alertMutingRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 func alertMutingRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteAlertMutingRule(d.Id())
+	return config.Client.DeleteAlertMutingRule(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_alert_muting_rule_test.go
+++ b/signalfx/resource_signalfx_alert_muting_rule_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -111,7 +112,7 @@ func testAccCreateUpdateAlertMutingRuleResourceExists(s *terraform.State) error 
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_alert_muting_rule":
-			amr, err := client.GetAlertMutingRule(rs.Primary.ID)
+			amr, err := client.GetAlertMutingRule(context.TODO(), rs.Primary.ID)
 			if amr.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding alert muting rule %s: %s", rs.Primary.ID, err)
 			}
@@ -127,7 +128,7 @@ func testAccAlertMutingRuleDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_alert_muting_rule":
-			amr, _ := client.GetAlertMutingRule(rs.Primary.ID)
+			amr, _ := client.GetAlertMutingRule(context.TODO(), rs.Primary.ID)
 			if amr != nil {
 				return fmt.Errorf("Found deleted alert muting rule %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_aws_external_integration.go
+++ b/signalfx/resource_signalfx_aws_external_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -48,7 +49,7 @@ func integrationAWSExternalResource() *schema.Resource {
 
 func integrationAWSExternalExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAWSCloudWatchIntegration(d.Id())
+	_, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -60,7 +61,7 @@ func integrationAWSExternalExists(d *schema.ResourceData, meta interface{}) (boo
 
 func integrationAWSExternalRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	int, err := config.Client.GetAWSCloudWatchIntegration(d.Id())
+	int, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -112,7 +113,7 @@ func integrationAWSExternalCreate(d *schema.ResourceData, meta interface{}) erro
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create AWS External Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreateAWSCloudWatchIntegration(payload)
+	int, err := config.Client.CreateAWSCloudWatchIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -138,5 +139,5 @@ func integrationAWSExternalCreate(d *schema.ResourceData, meta interface{}) erro
 func integrationAWSExternalDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteAWSCloudWatchIntegration(d.Id())
+	return config.Client.DeleteAWSCloudWatchIntegration(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -188,7 +189,7 @@ func integrationAWSResource() *schema.Resource {
 
 func integrationAWSExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAWSCloudWatchIntegration(d.Get("integration_id").(string))
+	_, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Get("integration_id").(string))
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -201,7 +202,7 @@ func integrationAWSExists(d *schema.ResourceData, meta interface{}) (bool, error
 func integrationAWSRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	int, err := config.Client.GetAWSCloudWatchIntegration(d.Get("integration_id").(string))
+	int, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Get("integration_id").(string))
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -481,7 +482,7 @@ func getNamespaceRules(tfRules []interface{}) []*integration.AwsNameSpaceSyncRul
 func integrationAWSCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	preInt, err := config.Client.GetAWSCloudWatchIntegration(d.Get("integration_id").(string))
+	preInt, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Get("integration_id").(string))
 	if err != nil {
 		return fmt.Errorf("Error fetching existing integration for integration %s, %s", d.Get("integration_id").(string), err.Error())
 	}
@@ -501,7 +502,7 @@ func integrationAWSCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create (Update) AWS Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdateAWSCloudWatchIntegration(d.Get("integration_id").(string), payload)
+	int, err := config.Client.UpdateAWSCloudWatchIntegration(context.TODO(), d.Get("integration_id").(string), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -524,7 +525,7 @@ func integrationAWSUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update AWS Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdateAWSCloudWatchIntegration(d.Id(), payload)
+	int, err := config.Client.UpdateAWSCloudWatchIntegration(context.TODO(), d.Id(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())

--- a/signalfx/resource_signalfx_aws_integration_test.go
+++ b/signalfx/resource_signalfx_aws_integration_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -165,7 +166,7 @@ func testAccCheckIntegrationAWSResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_aws_integration", "signalfx_aws_external_integration", "signalfx_aws_token_integration":
-			integration, err := client.GetAWSCloudWatchIntegration(rs.Primary.ID)
+			integration, err := client.GetAWSCloudWatchIntegration(context.TODO(), rs.Primary.ID)
 			if integration == nil {
 				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
 			}
@@ -182,7 +183,7 @@ func testAccIntegrationAWSDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_aws_integration", "signalfx_aws_external_integration", "signalfx_aws_token_integration":
-			integration, _ := client.GetAWSCloudWatchIntegration(rs.Primary.ID)
+			integration, _ := client.GetAWSCloudWatchIntegration(context.TODO(), rs.Primary.ID)
 			if integration != nil {
 				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_aws_token_integration.go
+++ b/signalfx/resource_signalfx_aws_token_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -48,7 +49,7 @@ func integrationAWSTokenResource() *schema.Resource {
 
 func integrationAWSTokenExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAWSCloudWatchIntegration(d.Id())
+	_, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -60,7 +61,7 @@ func integrationAWSTokenExists(d *schema.ResourceData, meta interface{}) (bool, 
 
 func integrationAWSTokenRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAWSCloudWatchIntegration(d.Id())
+	_, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -99,7 +100,7 @@ func integrationAWSTokenCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create AWS Token Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreateAWSCloudWatchIntegration(payload)
+	int, err := config.Client.CreateAWSCloudWatchIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -125,5 +126,5 @@ func integrationAWSTokenCreate(d *schema.ResourceData, meta interface{}) error {
 func integrationAWSTokenDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteAWSCloudWatchIntegration(d.Id())
+	return config.Client.DeleteAWSCloudWatchIntegration(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_azure_integration.go
+++ b/signalfx/resource_signalfx_azure_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -94,7 +95,7 @@ func integrationAzureResource() *schema.Resource {
 
 func integrationAzureExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAzureIntegration(d.Id())
+	_, err := config.Client.GetAzureIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -106,7 +107,7 @@ func integrationAzureExists(d *schema.ResourceData, meta interface{}) (bool, err
 
 func integrationAzureRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	int, err := config.Client.GetAzureIntegration(d.Id())
+	int, err := config.Client.GetAzureIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -221,7 +222,7 @@ func integrationAzureCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Azure Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreateAzureIntegration(payload)
+	int, err := config.Client.CreateAzureIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -243,7 +244,7 @@ func integrationAzureUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Azure Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdateAzureIntegration(d.Id(), payload)
+	int, err := config.Client.UpdateAzureIntegration(context.TODO(), d.Id(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -258,7 +259,7 @@ func integrationAzureUpdate(d *schema.ResourceData, meta interface{}) error {
 func integrationAzureDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteAzureIntegration(d.Id())
+	return config.Client.DeleteAzureIntegration(context.TODO(), d.Id())
 }
 
 func validateAzureService(v interface{}, k string) (we []string, errors []error) {

--- a/signalfx/resource_signalfx_azure_integration_test.go
+++ b/signalfx/resource_signalfx_azure_integration_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -89,7 +90,7 @@ func testAccCheckIntegrationAzureResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_azure_integration":
-			integration, err := client.GetAzureIntegration(rs.Primary.ID)
+			integration, err := client.GetAzureIntegration(context.TODO(), rs.Primary.ID)
 			if integration == nil {
 				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
 			}
@@ -106,7 +107,7 @@ func testAccIntegrationAzureDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_azure_integration":
-			integration, _ := client.GetAzureIntegration(rs.Primary.ID)
+			integration, _ := client.GetAzureIntegration(context.TODO(), rs.Primary.ID)
 			if integration != nil {
 				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -720,7 +721,7 @@ func dashboardCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Dashboard Create Payload: %s", debugOutput)
 
-	dash, err := config.Client.CreateDashboard(payload)
+	dash, err := config.Client.CreateDashboard(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -739,7 +740,7 @@ func dashboardCreate(d *schema.ResourceData, meta interface{}) error {
 
 func dashboardExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetDashboard(d.Id())
+	_, err := config.Client.GetDashboard(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -751,7 +752,7 @@ func dashboardExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 
 func dashboardRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	dash, err := config.Client.GetDashboard(d.Id())
+	dash, err := config.Client.GetDashboard(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -996,7 +997,7 @@ func dashboardUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Dashboard Payload: %s", string(debugOutput))
 
-	dash, err := config.Client.UpdateDashboard(d.Id(), payload)
+	dash, err := config.Client.UpdateDashboard(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -1016,7 +1017,7 @@ func dashboardUpdate(d *schema.ResourceData, meta interface{}) error {
 func dashboardDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	err := config.Client.DeleteDashboard(d.Id())
+	err := config.Client.DeleteDashboard(context.TODO(), d.Id())
 	return err
 }
 

--- a/signalfx/resource_signalfx_dashboard_and_friends_test.go
+++ b/signalfx/resource_signalfx_dashboard_and_friends_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -460,22 +461,22 @@ func testAccCheckDashboardGroupResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_time_chart", "signalfx_list_chart", "signalfx_single_value_chart", "signalfx_heatmap_chart", "signalfx_text_chart", "signalfx_event_feed_chart":
-			chart, err := client.GetChart(rs.Primary.ID)
+			chart, err := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding chart %s: %s", rs.Primary.ID, err)
 			}
 		case "signalfx_dashboard":
-			dash, err := client.GetDashboard(rs.Primary.ID)
+			dash, err := client.GetDashboard(context.TODO(), rs.Primary.ID)
 			if dash.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding dashboard %s: %s", rs.Primary.ID, err)
 			}
 		case "signalfx_dashboard_group":
-			dashgroup, err := client.GetDashboardGroup(rs.Primary.ID)
+			dashgroup, err := client.GetDashboardGroup(context.TODO(), rs.Primary.ID)
 			if dashgroup.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding dashboard group %s: %s", rs.Primary.ID, err)
 			}
 		case "signalfx_data_link":
-			dl, err := client.GetDataLink(rs.Primary.ID)
+			dl, err := client.GetDataLink(context.TODO(), rs.Primary.ID)
 			if err != nil || dl.Id != rs.Primary.ID {
 				return fmt.Errorf("Error finding data link %s: %s", rs.Primary.ID, err)
 			}
@@ -491,22 +492,22 @@ func testAccDashboardGroupDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_time_chart", "signalfx_list_chart", "signalfx_single_value_chart", "signalfx_heatmap_chart", "signalfx_text_chart", "signalfx_event_feed_chart":
-			chart, _ := client.GetChart(rs.Primary.ID)
+			chart, _ := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart != nil {
 				return fmt.Errorf("Found deleted chart %s", rs.Primary.ID)
 			}
 		case "signalfx_dashboard":
-			dash, _ := client.GetDashboard(rs.Primary.ID)
+			dash, _ := client.GetDashboard(context.TODO(), rs.Primary.ID)
 			if dash != nil {
 				return fmt.Errorf("Found deleted dashboard %s", rs.Primary.ID)
 			}
 		case "signalfx_dashboard_group":
-			dashgroup, _ := client.GetDashboardGroup(rs.Primary.ID)
+			dashgroup, _ := client.GetDashboardGroup(context.TODO(), rs.Primary.ID)
 			if dashgroup != nil {
 				return fmt.Errorf("Found deleted dashboard group %s", rs.Primary.ID)
 			}
 		case "signalfx_data_link":
-			dl, _ := client.GetDataLink(rs.Primary.ID)
+			dl, _ := client.GetDataLink(context.TODO(), rs.Primary.ID)
 			if dl != nil {
 				return fmt.Errorf("Found deleted data link %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"strings"
@@ -169,7 +170,7 @@ func dashboardGroupResource() *schema.Resource {
 
 func dashboardgroupExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetDashboardGroup(d.Id())
+	_, err := config.Client.GetDashboardGroup(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -353,7 +354,7 @@ func dashboardgroupCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Dashboard Group Create Payload: %s", debugOutput)
 
-	dg, err := config.Client.CreateDashboardGroup(payload, true)
+	dg, err := config.Client.CreateDashboardGroup(context.TODO(), payload, true)
 	if err != nil {
 		return err
 	}
@@ -477,7 +478,7 @@ func dashboardGroupAPIToTF(d *schema.ResourceData, dg *dashboard_group.Dashboard
 
 func dashboardgroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	dg, err := config.Client.GetDashboardGroup(d.Id())
+	dg, err := config.Client.GetDashboardGroup(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -491,7 +492,7 @@ func dashboardgroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Dashboard Group Payload: %s", string(debugOutput))
 
-	dg, err := config.Client.UpdateDashboardGroup(d.Id(), payload)
+	dg, err := config.Client.UpdateDashboardGroup(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -505,5 +506,5 @@ func dashboardgroupUpdate(d *schema.ResourceData, meta interface{}) error {
 func dashboardgroupDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteDashboardGroup(d.Id())
+	return config.Client.DeleteDashboardGroup(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_data_link.go
+++ b/signalfx/resource_signalfx_data_link.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -264,7 +265,7 @@ func dataLinkCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Data Link Payload: %s", string(debugOutput))
 
-	dl, err := config.Client.CreateDataLink(payload)
+	dl, err := config.Client.CreateDataLink(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -343,7 +344,7 @@ func dataLinkAPIToTF(d *schema.ResourceData, dl *datalink.DataLink) error {
 func dataLinkRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	fmt.Printf("[DEBUG] SignalFx: Looking for data link %s", d.Id())
-	dl, err := config.Client.GetDataLink(d.Id())
+	dl, err := config.Client.GetDataLink(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -360,7 +361,7 @@ func dataLinkUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Data Link Payload: %s", string(debugOutput))
 
-	dl, err := config.Client.UpdateDataLink(d.Id(), payload)
+	dl, err := config.Client.UpdateDataLink(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -373,12 +374,12 @@ func dataLinkUpdate(d *schema.ResourceData, meta interface{}) error {
 func dataLinkDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteDataLink(d.Id())
+	return config.Client.DeleteDataLink(context.TODO(), d.Id())
 }
 
 func dataLinkExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetDataLink(d.Id())
+	_, err := config.Client.GetDataLink(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil

--- a/signalfx/resource_signalfx_data_link_test.go
+++ b/signalfx/resource_signalfx_data_link_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -144,7 +145,7 @@ func testAccCheckDataLinkResourceExists(s *terraform.State) error {
 		switch rs.Type {
 		case "signalfx_data_link":
 			fmt.Printf("[DEBUG] SignalFx: GETTING DATA LINK %s", rs.Primary.ID)
-			dl, err := client.GetDataLink(rs.Primary.ID)
+			dl, err := client.GetDataLink(context.TODO(), rs.Primary.ID)
 			if err != nil || dl.Id != rs.Primary.ID {
 				return fmt.Errorf("Error finding data link %s: %s", rs.Primary.ID, err)
 			}
@@ -160,7 +161,7 @@ func testAccDataLinkDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_data_link":
-			dl, _ := client.GetDataLink(rs.Primary.ID)
+			dl, _ := client.GetDataLink(context.TODO(), rs.Primary.ID)
 			if dl != nil {
 				return fmt.Errorf("Found deleted data link %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -422,7 +423,7 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Detector Payload: %s", string(debugOutput))
 
-	det, err := config.Client.CreateDetector(payload)
+	det, err := config.Client.CreateDetector(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -441,7 +442,7 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 
 func detectorExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetDetector(d.Id())
+	_, err := config.Client.GetDetector(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -453,7 +454,7 @@ func detectorExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 
 func detectorRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	det, err := config.Client.GetDetector(d.Id())
+	det, err := config.Client.GetDetector(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -602,7 +603,7 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Detector Payload: %s", string(debugOutput))
 
-	det, err := config.Client.UpdateDetector(d.Id(), payload)
+	det, err := config.Client.UpdateDetector(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -622,7 +623,7 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 func detectorDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteDetector(d.Id())
+	return config.Client.DeleteDetector(context.TODO(), d.Id())
 }
 
 func getPerSignalDetectorVizOptions(d *schema.ResourceData) []*detector.PublishLabelOptions {

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -225,7 +226,7 @@ func testAccCheckDetectorResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_detector":
-			detector, err := client.GetDetector(rs.Primary.ID)
+			detector, err := client.GetDetector(context.TODO(), rs.Primary.ID)
 			if detector.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding detector %s: %s", rs.Primary.ID, err)
 			}
@@ -241,7 +242,7 @@ func testAccDetectorDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_detector":
-			detector, _ := client.GetDetector(rs.Primary.ID)
+			detector, _ := client.GetDetector(context.TODO(), rs.Primary.ID)
 			if detector != nil {
 				return fmt.Errorf("Found deleted detector %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_event_feed_chart.go
+++ b/signalfx/resource_signalfx_event_feed_chart.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 
@@ -106,7 +107,7 @@ func eventFeedChartCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Event Feed Chart Payload: %s", string(debugOutput))
 
-	c, err := config.Client.CreateChart(payload)
+	c, err := config.Client.CreateChart(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -164,7 +165,7 @@ func eventfeedchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 
 func eventFeedChartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	c, err := config.Client.GetChart(d.Id())
+	c, err := config.Client.GetChart(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -186,7 +187,7 @@ func eventFeedChartUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Event Feed Chart Payload: %s", string(debugOutput))
 
-	c, err := config.Client.UpdateChart(d.Id(), payload)
+	c, err := config.Client.UpdateChart(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -199,5 +200,5 @@ func eventFeedChartUpdate(d *schema.ResourceData, meta interface{}) error {
 func eventFeedChartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteChart(d.Id())
+	return config.Client.DeleteChart(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_event_feed_chart_test.go
+++ b/signalfx/resource_signalfx_event_feed_chart_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -70,7 +71,7 @@ func testAccCheckEventFeedChartResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_event_feed_chart":
-			chart, err := client.GetChart(rs.Primary.ID)
+			chart, err := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding chart %s: %s", rs.Primary.ID, err)
 			}
@@ -86,7 +87,7 @@ func testAccEventFeedChartDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_event_feed_chart":
-			chart, _ := client.GetChart(rs.Primary.ID)
+			chart, _ := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart != nil {
 				return fmt.Errorf("Found deleted chart %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_gcp_integration.go
+++ b/signalfx/resource_signalfx_gcp_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -87,7 +88,7 @@ func integrationGCPResource() *schema.Resource {
 
 func integrationGCPExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetGCPIntegration(d.Id())
+	_, err := config.Client.GetGCPIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -99,7 +100,7 @@ func integrationGCPExists(d *schema.ResourceData, meta interface{}) (bool, error
 
 func integrationGCPRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	int, err := config.Client.GetGCPIntegration(d.Id())
+	int, err := config.Client.GetGCPIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -206,7 +207,7 @@ func integrationGCPCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create GCP Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreateGCPIntegration(payload)
+	int, err := config.Client.CreateGCPIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -225,7 +226,7 @@ func integrationGCPUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update GCP Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdateGCPIntegration(d.Id(), payload)
+	int, err := config.Client.UpdateGCPIntegration(context.TODO(), d.Id(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -240,7 +241,7 @@ func integrationGCPUpdate(d *schema.ResourceData, meta interface{}) error {
 func integrationGCPDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteGCPIntegration(d.Id())
+	return config.Client.DeleteGCPIntegration(context.TODO(), d.Id())
 }
 
 func validateGcpService(v interface{}, k string) (we []string, errors []error) {

--- a/signalfx/resource_signalfx_gcp_integration_test.go
+++ b/signalfx/resource_signalfx_gcp_integration_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -97,7 +98,7 @@ func testAccCheckIntegrationGCPResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_gcp_integration":
-			integration, err := client.GetIntegration(rs.Primary.ID)
+			integration, err := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			id := integration["id"]
 			if id != nil && id.(string) != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
@@ -115,7 +116,7 @@ func testAccIntegrationGCPDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_gcp_integration":
-			integration, _ := client.GetIntegration(rs.Primary.ID)
+			integration, _ := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if _, ok := integration["id"]; ok {
 				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -300,7 +301,7 @@ func heatmapchartCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Heatmap Chart Payload: %s", string(debugOutput))
 
-	c, err := config.Client.CreateChart(payload)
+	c, err := config.Client.CreateChart(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -397,7 +398,7 @@ func heatmapchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 
 func heatmapchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	c, err := config.Client.GetChart(d.Id())
+	c, err := config.Client.GetChart(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -420,7 +421,7 @@ func heatmapchartUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	c, err := config.Client.UpdateChart(d.Id(), payload)
+	c, err := config.Client.UpdateChart(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -441,7 +442,7 @@ func heatmapchartUpdate(d *schema.ResourceData, meta interface{}) error {
 func heatmapchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteChart(d.Id())
+	return config.Client.DeleteChart(context.TODO(), d.Id())
 }
 
 /*

--- a/signalfx/resource_signalfx_heatmap_chart_test.go
+++ b/signalfx/resource_signalfx_heatmap_chart_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -96,7 +97,7 @@ func testAccCheckHeatmapChartResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_heatmap_chart":
-			chart, err := client.GetChart(rs.Primary.ID)
+			chart, err := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding chart %s: %s", rs.Primary.ID, err)
 			}
@@ -112,7 +113,7 @@ func testAccHeatmapChartDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_heatmap_chart":
-			chart, _ := client.GetChart(rs.Primary.ID)
+			chart, _ := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart != nil {
 				return fmt.Errorf("Found deleted chart %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_jira_integration.go
+++ b/signalfx/resource_signalfx_jira_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -99,7 +100,7 @@ func integrationJiraResource() *schema.Resource {
 
 func integrationJiraExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetJiraIntegration(d.Id())
+	_, err := config.Client.GetJiraIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -111,7 +112,7 @@ func integrationJiraExists(d *schema.ResourceData, meta interface{}) (bool, erro
 
 func integrationJiraRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	int, err := config.Client.GetJiraIntegration(d.Id())
+	int, err := config.Client.GetJiraIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -210,7 +211,7 @@ func integrationJiraCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Jira Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreateJiraIntegration(payload)
+	int, err := config.Client.CreateJiraIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -232,7 +233,7 @@ func integrationJiraUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Jira Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdateJiraIntegration(d.Id(), payload)
+	int, err := config.Client.UpdateJiraIntegration(context.TODO(), d.Id(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -247,5 +248,5 @@ func integrationJiraUpdate(d *schema.ResourceData, meta interface{}) error {
 func integrationJiraDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteJiraIntegration(d.Id())
+	return config.Client.DeleteJiraIntegration(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_jira_integration_test.go
+++ b/signalfx/resource_signalfx_jira_integration_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -81,7 +82,7 @@ func testAccCheckIntegrationJiraResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_jira_integration":
-			integration, err := client.GetJiraIntegration(rs.Primary.ID)
+			integration, err := client.GetJiraIntegration(context.TODO(), rs.Primary.ID)
 			if integration == nil {
 				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
 			}
@@ -98,7 +99,7 @@ func testAccIntegrationJiraDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_jira_integration":
-			integration, _ := client.GetJiraIntegration(rs.Primary.ID)
+			integration, _ := client.GetJiraIntegration(context.TODO(), rs.Primary.ID)
 			if integration != nil {
 				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -350,7 +351,7 @@ func listchartCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create List Chart Payload: %s", string(debugOutput))
 
-	c, err := config.Client.CreateChart(payload)
+	c, err := config.Client.CreateChart(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -476,7 +477,7 @@ func listchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 
 func listchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	c, err := config.Client.GetChart(d.Id())
+	c, err := config.Client.GetChart(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -501,7 +502,7 @@ func listchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update List Chart Payload: %s", string(debugOutput))
 
-	c, err := config.Client.UpdateChart(d.Id(), payload)
+	c, err := config.Client.UpdateChart(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -514,5 +515,5 @@ func listchartUpdate(d *schema.ResourceData, meta interface{}) error {
 func listchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteChart(d.Id())
+	return config.Client.DeleteChart(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_list_chart_test.go
+++ b/signalfx/resource_signalfx_list_chart_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -156,7 +157,7 @@ func testAccCheckListChartResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_list_chart":
-			chart, err := client.GetChart(rs.Primary.ID)
+			chart, err := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding chart %s: %s", rs.Primary.ID, err)
 			}
@@ -172,7 +173,7 @@ func testAccListChartDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_list_chart":
-			chart, _ := client.GetChart(rs.Primary.ID)
+			chart, _ := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart != nil {
 				return fmt.Errorf("Found deleted chart %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_opsgenie_integration.go
+++ b/signalfx/resource_signalfx_opsgenie_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -49,7 +50,7 @@ func integrationOpsgenieResource() *schema.Resource {
 
 func integrationOpsgenieExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetOpsgenieIntegration(d.Id())
+	_, err := config.Client.GetOpsgenieIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -71,7 +72,7 @@ func getOpsgeniePayloadIntegration(d *schema.ResourceData) *integration.Opsgenie
 
 func integrationOpsgenieRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	int, err := config.Client.GetOpsgenieIntegration(d.Id())
+	int, err := config.Client.GetOpsgenieIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -103,7 +104,7 @@ func integrationOpsgenieCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Opsgenie Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreateOpsgenieIntegration(payload)
+	int, err := config.Client.CreateOpsgenieIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -122,7 +123,7 @@ func integrationOpsgenieUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Opsgenie Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdateOpsgenieIntegration(d.Id(), payload)
+	int, err := config.Client.UpdateOpsgenieIntegration(context.TODO(), d.Id(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -137,5 +138,5 @@ func integrationOpsgenieUpdate(d *schema.ResourceData, meta interface{}) error {
 func integrationOpsgenieDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteOpsgenieIntegration(d.Id())
+	return config.Client.DeleteOpsgenieIntegration(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_opsgenie_integration_test.go
+++ b/signalfx/resource_signalfx_opsgenie_integration_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -68,7 +69,7 @@ func testAccCheckIntegrationOpsgenieResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_opsgenie_integration":
-			integration, err := client.GetIntegration(rs.Primary.ID)
+			integration, err := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if integration["id"].(string) != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
 			}
@@ -85,7 +86,7 @@ func testAccIntegrationOpsgenieDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_opsgenie_integration":
-			integration, _ := client.GetIntegration(rs.Primary.ID)
+			integration, _ := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if _, ok := integration["id"]; ok {
 				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_org_token.go
+++ b/signalfx/resource_signalfx_org_token.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -224,7 +225,7 @@ func orgTokenCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Org Token Payload: %s", string(debugOutput))
 
-	t, err := config.Client.CreateOrgToken(payload)
+	t, err := config.Client.CreateOrgToken(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -320,7 +321,7 @@ func orgTokenAPIToTF(d *schema.ResourceData, t *orgtoken.Token) error {
 func orgTokenRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	fmt.Printf("[DEBUG] SignalFx: Looking for org token %s\n", d.Id())
-	t, err := config.Client.GetOrgToken(d.Id())
+	t, err := config.Client.GetOrgToken(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -337,7 +338,7 @@ func orgTokenUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Org Token Payload: %s", string(debugOutput))
 
-	t, err := config.Client.UpdateOrgToken(d.Id(), payload)
+	t, err := config.Client.UpdateOrgToken(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -350,12 +351,12 @@ func orgTokenUpdate(d *schema.ResourceData, meta interface{}) error {
 func orgTokenDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteOrgToken(d.Id())
+	return config.Client.DeleteOrgToken(context.TODO(), d.Id())
 }
 
 func orgTokenExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetOrgToken(d.Id())
+	_, err := config.Client.GetOrgToken(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil

--- a/signalfx/resource_signalfx_org_token_test.go
+++ b/signalfx/resource_signalfx_org_token_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -86,7 +87,7 @@ func testAccCheckOrgTokenResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_org_token":
-			tok, err := client.GetOrgToken(rs.Primary.ID)
+			tok, err := client.GetOrgToken(context.TODO(), rs.Primary.ID)
 			if err != nil || tok.Name != rs.Primary.ID {
 				return fmt.Errorf("Error finding org token %s: %s", rs.Primary.ID, err)
 			}
@@ -102,7 +103,7 @@ func testAccOrgTokenDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_org_token":
-			tok, _ := client.GetOrgToken(rs.Primary.ID)
+			tok, _ := client.GetOrgToken(context.TODO(), rs.Primary.ID)
 			if tok != nil {
 				return fmt.Errorf("Found deleted org token %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_pagerduty_integration.go
+++ b/signalfx/resource_signalfx_pagerduty_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -44,7 +45,7 @@ func integrationPagerDutyResource() *schema.Resource {
 
 func integrationPagerDutyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetPagerDutyIntegration(d.Id())
+	_, err := config.Client.GetPagerDutyIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -56,7 +57,7 @@ func integrationPagerDutyExists(d *schema.ResourceData, meta interface{}) (bool,
 
 func integrationPagerDutyRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	int, err := config.Client.GetPagerDutyIntegration(d.Id())
+	int, err := config.Client.GetPagerDutyIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "404") {
 			d.SetId("")
@@ -98,7 +99,7 @@ func integrationPagerDutyCreate(d *schema.ResourceData, meta interface{}) error 
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create PagerDuty Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreatePagerDutyIntegration(payload)
+	int, err := config.Client.CreatePagerDutyIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -116,7 +117,7 @@ func integrationPagerDutyUpdate(d *schema.ResourceData, meta interface{}) error 
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update PagerDuty Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdatePagerDutyIntegration(d.Id(), payload)
+	int, err := config.Client.UpdatePagerDutyIntegration(context.TODO(), d.Id(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -130,5 +131,5 @@ func integrationPagerDutyUpdate(d *schema.ResourceData, meta interface{}) error 
 func integrationPagerDutyDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeletePagerDutyIntegration(d.Id())
+	return config.Client.DeletePagerDutyIntegration(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_pagerduty_integration_test.go
+++ b/signalfx/resource_signalfx_pagerduty_integration_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -60,7 +61,7 @@ func testAccCheckIntegrationPagerDutyResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_pagerduty_integration":
-			integration, err := client.GetIntegration(rs.Primary.ID)
+			integration, err := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if integration["id"].(string) != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
 			}
@@ -77,7 +78,7 @@ func testAccIntegrationPagerDutyDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_pagerduty_integration":
-			integration, _ := client.GetIntegration(rs.Primary.ID)
+			integration, _ := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if _, ok := integration["id"]; ok {
 				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"math"
@@ -259,7 +260,7 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Single Value Chart Payload: %s", string(debugOutput))
 
-	chart, err := config.Client.CreateChart(payload)
+	chart, err := config.Client.CreateChart(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -386,7 +387,7 @@ func decodeColorScale(options *chart.Options) ([]map[string]interface{}, error) 
 
 func singlevaluechartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	c, err := config.Client.GetChart(d.Id())
+	c, err := config.Client.GetChart(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -408,7 +409,7 @@ func singlevaluechartUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Single Value Chart Payload: %s", string(debugOutput))
 
-	c, err := config.Client.UpdateChart(d.Id(), payload)
+	c, err := config.Client.UpdateChart(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -421,5 +422,5 @@ func singlevaluechartUpdate(d *schema.ResourceData, meta interface{}) error {
 func singlevaluechartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteChart(d.Id())
+	return config.Client.DeleteChart(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_single_value_chart_test.go
+++ b/signalfx/resource_signalfx_single_value_chart_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -152,7 +153,7 @@ func testAccCheckSingleValueChartResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_single_value_chart":
-			chart, err := client.GetChart(rs.Primary.ID)
+			chart, err := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding chart %s: %s", rs.Primary.ID, err)
 			}
@@ -168,7 +169,7 @@ func testAccSingleValueChartDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_single_value_chart":
-			chart, _ := client.GetChart(rs.Primary.ID)
+			chart, _ := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart != nil {
 				return fmt.Errorf("Found deleted chart %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_slack_integration.go
+++ b/signalfx/resource_signalfx_slack_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -44,7 +45,7 @@ func integrationSlackResource() *schema.Resource {
 
 func integrationSlackExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetSlackIntegration(d.Id())
+	_, err := config.Client.GetSlackIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -65,7 +66,7 @@ func getSlackPayloadIntegration(d *schema.ResourceData) *integration.SlackIntegr
 
 func integrationSlackRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	int, err := config.Client.GetSlackIntegration(d.Id())
+	int, err := config.Client.GetSlackIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "404") {
 			d.SetId("")
@@ -97,7 +98,7 @@ func integrationSlackCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Slack Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreateSlackIntegration(payload)
+	int, err := config.Client.CreateSlackIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -116,7 +117,7 @@ func integrationSlackUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Slack Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdateSlackIntegration(d.Id(), payload)
+	int, err := config.Client.UpdateSlackIntegration(context.TODO(), d.Id(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -131,5 +132,5 @@ func integrationSlackUpdate(d *schema.ResourceData, meta interface{}) error {
 func integrationSlackDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteSlackIntegration(d.Id())
+	return config.Client.DeleteSlackIntegration(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_slack_integration_test.go
+++ b/signalfx/resource_signalfx_slack_integration_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -68,7 +69,7 @@ func testAccCheckIntegrationSlackResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_slack_integration":
-			integration, err := client.GetIntegration(rs.Primary.ID)
+			integration, err := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if integration["id"].(string) != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
 			}
@@ -85,7 +86,7 @@ func testAccIntegrationSlackDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_slack_integration":
-			integration, _ := client.GetIntegration(rs.Primary.ID)
+			integration, _ := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if _, ok := integration["id"]; ok {
 				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_team.go
+++ b/signalfx/resource_signalfx_team.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"strings"
@@ -260,7 +261,7 @@ func teamCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Team Payload: %s", string(debugOutput))
 
-	c, err := config.Client.CreateTeam(payload)
+	c, err := config.Client.CreateTeam(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -358,7 +359,7 @@ func getNotificationsFromAPI(nots []*notification.Notification) ([]string, error
 
 func teamRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	c, err := config.Client.GetTeam(d.Id())
+	c, err := config.Client.GetTeam(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -375,7 +376,7 @@ func teamUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Team Payload: %s", string(debugOutput))
 
-	c, err := config.Client.UpdateTeam(d.Id(), payload)
+	c, err := config.Client.UpdateTeam(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -388,12 +389,12 @@ func teamUpdate(d *schema.ResourceData, meta interface{}) error {
 func teamDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteTeam(d.Id())
+	return config.Client.DeleteTeam(context.TODO(), d.Id())
 }
 
 func teamExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetTeam(d.Id())
+	_, err := config.Client.GetTeam(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil

--- a/signalfx/resource_signalfx_team_test.go
+++ b/signalfx/resource_signalfx_team_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -82,7 +83,7 @@ func testAccCheckTeamResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_team":
-			team, err := client.GetTeam(rs.Primary.ID)
+			team, err := client.GetTeam(context.TODO(), rs.Primary.ID)
 			if team.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding team %s: %s", rs.Primary.ID, err)
 			}
@@ -98,7 +99,7 @@ func testAccTeamDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_team":
-			team, _ := client.GetTeam(rs.Primary.ID)
+			team, _ := client.GetTeam(context.TODO(), rs.Primary.ID)
 			if team != nil {
 				return fmt.Errorf("Found deleted team %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_text_chart.go
+++ b/signalfx/resource_signalfx_text_chart.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 
@@ -65,7 +66,7 @@ func textchartCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Text Chart Payload: %s", string(debugOutput))
 
-	c, err := config.Client.CreateChart(payload)
+	c, err := config.Client.CreateChart(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -100,7 +101,7 @@ func textchartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 
 func textchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	c, err := config.Client.GetChart(d.Id())
+	c, err := config.Client.GetChart(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -122,7 +123,7 @@ func textchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Text Chart Payload: %s", string(debugOutput))
 
-	c, err := config.Client.UpdateChart(d.Id(), payload)
+	c, err := config.Client.UpdateChart(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -135,5 +136,5 @@ func textchartUpdate(d *schema.ResourceData, meta interface{}) error {
 func textchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteChart(d.Id())
+	return config.Client.DeleteChart(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_text_chart_test.go
+++ b/signalfx/resource_signalfx_text_chart_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -65,7 +66,7 @@ func testAccCheckTextChartResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_text_chart":
-			chart, err := client.GetChart(rs.Primary.ID)
+			chart, err := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding chart %s: %s", rs.Primary.ID, err)
 			}
@@ -81,7 +82,7 @@ func testAccTextChartDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_text_chart":
-			chart, _ := client.GetChart(rs.Primary.ID)
+			chart, _ := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart != nil {
 				return fmt.Errorf("Found deleted chart %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -785,7 +786,7 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Time Chart Payload: %s", string(debugOutput))
 
-	c, err := config.Client.CreateChart(payload)
+	c, err := config.Client.CreateChart(context.TODO(), payload)
 	if err != nil {
 		return err
 	}
@@ -805,7 +806,7 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 func timechartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	c, err := config.Client.GetChart(d.Id())
+	c, err := config.Client.GetChart(context.TODO(), d.Id())
 	if err != nil {
 		return err
 	}
@@ -1109,7 +1110,7 @@ func timechartUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	payload := getPayloadTimeChart(d)
 
-	c, err := config.Client.UpdateChart(d.Id(), payload)
+	c, err := config.Client.UpdateChart(context.TODO(), d.Id(), payload)
 	if err != nil {
 		return err
 	}
@@ -1130,7 +1131,7 @@ func timechartUpdate(d *schema.ResourceData, meta interface{}) error {
 func timechartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteChart(d.Id())
+	return config.Client.DeleteChart(context.TODO(), d.Id())
 }
 
 var validateUnitTimeChart = validation.StringInSlice([]string{

--- a/signalfx/resource_signalfx_time_chart_test.go
+++ b/signalfx/resource_signalfx_time_chart_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -256,7 +257,7 @@ func testAccCheckTimeChartResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_time_chart":
-			chart, err := client.GetChart(rs.Primary.ID)
+			chart, err := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding chart %s: %s", rs.Primary.ID, err)
 			}
@@ -272,7 +273,7 @@ func testAccTimeChartDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_time_chart":
-			chart, _ := client.GetChart(rs.Primary.ID)
+			chart, _ := client.GetChart(context.TODO(), rs.Primary.ID)
 			if chart != nil {
 				return fmt.Errorf("Found deleted chart %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_victor_ops_integration.go
+++ b/signalfx/resource_signalfx_victor_ops_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -43,7 +44,7 @@ func integrationVictorOpsResource() *schema.Resource {
 
 func integrationVictorOpsExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetVictorOpsIntegration(d.Id())
+	_, err := config.Client.GetVictorOpsIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -64,7 +65,7 @@ func getVictorOpsPayloadIntegration(d *schema.ResourceData) *integration.VictorO
 
 func integrationVictorOpsRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	int, err := config.Client.GetVictorOpsIntegration(d.Id())
+	int, err := config.Client.GetVictorOpsIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -96,7 +97,7 @@ func integrationVictorOpsCreate(d *schema.ResourceData, meta interface{}) error 
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create VictorOps Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreateVictorOpsIntegration(payload)
+	int, err := config.Client.CreateVictorOpsIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -115,7 +116,7 @@ func integrationVictorOpsUpdate(d *schema.ResourceData, meta interface{}) error 
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update VictorOps Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdateVictorOpsIntegration(d.Id(), payload)
+	int, err := config.Client.UpdateVictorOpsIntegration(context.TODO(), d.Id(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -130,5 +131,5 @@ func integrationVictorOpsUpdate(d *schema.ResourceData, meta interface{}) error 
 func integrationVictorOpsDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteVictorOpsIntegration(d.Id())
+	return config.Client.DeleteVictorOpsIntegration(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_victor_ops_integration_test.go
+++ b/signalfx/resource_signalfx_victor_ops_integration_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -66,7 +67,7 @@ func testAccCheckIntegrationVictorOpsResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_victor_ops_integration":
-			integration, err := client.GetIntegration(rs.Primary.ID)
+			integration, err := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if integration["id"].(string) != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
 			}
@@ -83,7 +84,7 @@ func testAccIntegrationVictorOpsDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_victor_ops_integration":
-			integration, _ := client.GetIntegration(rs.Primary.ID)
+			integration, _ := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if _, ok := integration["id"]; ok {
 				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
 			}

--- a/signalfx/resource_signalfx_webhook_integration.go
+++ b/signalfx/resource_signalfx_webhook_integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -68,7 +69,7 @@ func integrationWebhookResource() *schema.Resource {
 
 func integrationWebhookExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetWebhookIntegration(d.Id())
+	_, err := config.Client.GetWebhookIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -105,7 +106,7 @@ func getWebhookPayloadIntegration(d *schema.ResourceData) *integration.WebhookIn
 
 func integrationWebhookRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	int, err := config.Client.GetWebhookIntegration(d.Id())
+	int, err := config.Client.GetWebhookIntegration(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
@@ -156,7 +157,7 @@ func integrationWebhookCreate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Webhook Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.CreateWebhookIntegration(payload)
+	int, err := config.Client.CreateWebhookIntegration(context.TODO(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -175,7 +176,7 @@ func integrationWebhookUpdate(d *schema.ResourceData, meta interface{}) error {
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Webhook Integration Payload: %s", string(debugOutput))
 
-	int, err := config.Client.UpdateWebhookIntegration(d.Id(), payload)
+	int, err := config.Client.UpdateWebhookIntegration(context.TODO(), d.Id(), payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "40") {
 			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
@@ -190,5 +191,5 @@ func integrationWebhookUpdate(d *schema.ResourceData, meta interface{}) error {
 func integrationWebhookDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	return config.Client.DeleteWebhookIntegration(d.Id())
+	return config.Client.DeleteWebhookIntegration(context.TODO(), d.Id())
 }

--- a/signalfx/resource_signalfx_webhook_integration_test.go
+++ b/signalfx/resource_signalfx_webhook_integration_test.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -76,7 +77,7 @@ func testAccCheckIntegrationWebhookResourceExists(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_webhook_integration":
-			integration, err := client.GetIntegration(rs.Primary.ID)
+			integration, err := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if integration["id"].(string) != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
 			}
@@ -93,7 +94,7 @@ func testAccIntegrationWebhookDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "signalfx_webhook_integration":
-			integration, _ := client.GetIntegration(rs.Primary.ID)
+			integration, _ := client.GetIntegration(context.TODO(), rs.Primary.ID)
 			if _, ok := integration["id"]; ok {
 				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
 			}

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -84,7 +85,7 @@ func buildAppURL(appURL string, fragment string) (string, error) {
 
 func chartExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetChart(d.Id())
+	_, err := config.Client.GetChart(context.TODO(), d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -1,4 +1,6 @@
-# 1.6.40, Pending
+# 1.7.0, 2020-06-02
+
+* Added contexts to everything, switch to `NewRequestWithContext` for HTTP.
 
 # 1.6.39, 2020-06-02
 

--- a/vendor/github.com/signalfx/signalfx-go/alertmuting.go
+++ b/vendor/github.com/signalfx/signalfx-go/alertmuting.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,13 +18,13 @@ import (
 const AlertMutingRuleAPIURL = "/v2/alertmuting"
 
 // CreateAlertMutingRule creates an alert muting rule.
-func (c *Client) CreateAlertMutingRule(muteRequest *alertmuting.CreateUpdateAlertMutingRuleRequest) (*alertmuting.AlertMutingRule, error) {
+func (c *Client) CreateAlertMutingRule(ctx context.Context, muteRequest *alertmuting.CreateUpdateAlertMutingRuleRequest) (*alertmuting.AlertMutingRule, error) {
 	payload, err := json.Marshal(muteRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", AlertMutingRuleAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", AlertMutingRuleAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -45,8 +46,8 @@ func (c *Client) CreateAlertMutingRule(muteRequest *alertmuting.CreateUpdateAler
 }
 
 // DeleteAlertMutingRule deletes an alert muting rule.
-func (c *Client) DeleteAlertMutingRule(name string) error {
-	resp, err := c.doRequest("DELETE", AlertMutingRuleAPIURL+"/"+name, nil, nil)
+func (c *Client) DeleteAlertMutingRule(ctx context.Context, name string) error {
+	resp, err := c.doRequest(ctx, "DELETE", AlertMutingRuleAPIURL+"/"+name, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -64,8 +65,8 @@ func (c *Client) DeleteAlertMutingRule(name string) error {
 }
 
 // GetAlertMutingRule gets an alert muting rule.
-func (c *Client) GetAlertMutingRule(id string) (*alertmuting.AlertMutingRule, error) {
-	resp, err := c.doRequest("GET", AlertMutingRuleAPIURL+"/"+id, nil, nil)
+func (c *Client) GetAlertMutingRule(ctx context.Context, id string) (*alertmuting.AlertMutingRule, error) {
+	resp, err := c.doRequest(ctx, "GET", AlertMutingRuleAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -87,13 +88,13 @@ func (c *Client) GetAlertMutingRule(id string) (*alertmuting.AlertMutingRule, er
 }
 
 // UpdateAlertMutingRule updates an alert muting rule.
-func (c *Client) UpdateAlertMutingRule(id string, muteRequest *alertmuting.CreateUpdateAlertMutingRuleRequest) (*alertmuting.AlertMutingRule, error) {
+func (c *Client) UpdateAlertMutingRule(ctx context.Context, id string, muteRequest *alertmuting.CreateUpdateAlertMutingRuleRequest) (*alertmuting.AlertMutingRule, error) {
 	payload, err := json.Marshal(muteRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", AlertMutingRuleAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", AlertMutingRuleAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -115,14 +116,14 @@ func (c *Client) UpdateAlertMutingRule(id string, muteRequest *alertmuting.Creat
 }
 
 // SearchAlertMutingRules searches for alert muting rules given a query string in `name`.
-func (c *Client) SearchAlertMutingRules(include string, limit int, name string, offset int) (*alertmuting.SearchResult, error) {
+func (c *Client) SearchAlertMutingRules(ctx context.Context, include string, limit int, name string, offset int) (*alertmuting.SearchResult, error) {
 	params := url.Values{}
 	params.Add("include", include)
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("name", name)
 	params.Add("offset", strconv.Itoa(offset))
 
-	resp, err := c.doRequest("GET", AlertMutingRuleAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", AlertMutingRuleAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/aws_cloudwatch_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/aws_cloudwatch_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,13 +13,13 @@ import (
 )
 
 // CreateAWSCloudWatchIntegration creates an AWS CloudWatch integration.
-func (c *Client) CreateAWSCloudWatchIntegration(acwi *integration.AwsCloudWatchIntegration) (*integration.AwsCloudWatchIntegration, error) {
+func (c *Client) CreateAWSCloudWatchIntegration(ctx context.Context, acwi *integration.AwsCloudWatchIntegration) (*integration.AwsCloudWatchIntegration, error) {
 	payload, err := json.Marshal(acwi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -40,8 +41,8 @@ func (c *Client) CreateAWSCloudWatchIntegration(acwi *integration.AwsCloudWatchI
 }
 
 // GetAWSCloudWatchIntegration retrieves an AWS CloudWatch integration.
-func (c *Client) GetAWSCloudWatchIntegration(id string) (*integration.AwsCloudWatchIntegration, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetAWSCloudWatchIntegration(ctx context.Context, id string) (*integration.AwsCloudWatchIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,13 +64,13 @@ func (c *Client) GetAWSCloudWatchIntegration(id string) (*integration.AwsCloudWa
 }
 
 // UpdateAWSCloudWatchIntegration updates an AWS CloudWatch integration.
-func (c *Client) UpdateAWSCloudWatchIntegration(id string, acwi *integration.AwsCloudWatchIntegration) (*integration.AwsCloudWatchIntegration, error) {
+func (c *Client) UpdateAWSCloudWatchIntegration(ctx context.Context, id string, acwi *integration.AwsCloudWatchIntegration) (*integration.AwsCloudWatchIntegration, error) {
 	payload, err := json.Marshal(acwi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -91,8 +92,8 @@ func (c *Client) UpdateAWSCloudWatchIntegration(id string, acwi *integration.Aws
 }
 
 // DeleteAWSCloudWatchIntegration deletes an AWS CloudWatch integration.
-func (c *Client) DeleteAWSCloudWatchIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteAWSCloudWatchIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/azure_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/azure_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,13 +13,13 @@ import (
 )
 
 // CreateAzureIntegration creates an Azure integration.
-func (c *Client) CreateAzureIntegration(acwi *integration.AzureIntegration) (*integration.AzureIntegration, error) {
+func (c *Client) CreateAzureIntegration(ctx context.Context, acwi *integration.AzureIntegration) (*integration.AzureIntegration, error) {
 	payload, err := json.Marshal(acwi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -40,8 +41,8 @@ func (c *Client) CreateAzureIntegration(acwi *integration.AzureIntegration) (*in
 }
 
 // GetAzureIntegration retrieves an Azure integration.
-func (c *Client) GetAzureIntegration(id string) (*integration.AzureIntegration, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetAzureIntegration(ctx context.Context, id string) (*integration.AzureIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,13 +64,13 @@ func (c *Client) GetAzureIntegration(id string) (*integration.AzureIntegration, 
 }
 
 // UpdateAzureIntegration updates an Azure integration.
-func (c *Client) UpdateAzureIntegration(id string, acwi *integration.AzureIntegration) (*integration.AzureIntegration, error) {
+func (c *Client) UpdateAzureIntegration(ctx context.Context, id string, acwi *integration.AzureIntegration) (*integration.AzureIntegration, error) {
 	payload, err := json.Marshal(acwi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -91,8 +92,8 @@ func (c *Client) UpdateAzureIntegration(id string, acwi *integration.AzureIntegr
 }
 
 // DeleteAzureIntegration deletes an Azure integration.
-func (c *Client) DeleteAzureIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteAzureIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/chart.go
+++ b/vendor/github.com/signalfx/signalfx-go/chart.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,13 +19,13 @@ import (
 const ChartAPIURL = "/v2/chart"
 
 // CreateChart creates a chart.
-func (c *Client) CreateChart(chartRequest *chart.CreateUpdateChartRequest) (*chart.Chart, error) {
+func (c *Client) CreateChart(ctx context.Context, chartRequest *chart.CreateUpdateChartRequest) (*chart.Chart, error) {
 	payload, err := json.Marshal(chartRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", ChartAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", ChartAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -46,8 +47,8 @@ func (c *Client) CreateChart(chartRequest *chart.CreateUpdateChartRequest) (*cha
 }
 
 // DeleteChart deletes a chart.
-func (c *Client) DeleteChart(id string) error {
-	resp, err := c.doRequest("DELETE", ChartAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteChart(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", ChartAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -64,8 +65,8 @@ func (c *Client) DeleteChart(id string) error {
 }
 
 // GetChart gets a chart.
-func (c *Client) GetChart(id string) (*chart.Chart, error) {
-	resp, err := c.doRequest("GET", ChartAPIURL+"/"+id, nil, nil)
+func (c *Client) GetChart(ctx context.Context, id string) (*chart.Chart, error) {
+	resp, err := c.doRequest(ctx, "GET", ChartAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -87,13 +88,13 @@ func (c *Client) GetChart(id string) (*chart.Chart, error) {
 }
 
 // UpdateChart updates a chart.
-func (c *Client) UpdateChart(id string, chartRequest *chart.CreateUpdateChartRequest) (*chart.Chart, error) {
+func (c *Client) UpdateChart(ctx context.Context, id string, chartRequest *chart.CreateUpdateChartRequest) (*chart.Chart, error) {
 	payload, err := json.Marshal(chartRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", ChartAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", ChartAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -115,7 +116,7 @@ func (c *Client) UpdateChart(id string, chartRequest *chart.CreateUpdateChartReq
 }
 
 // SearchCharts searches for charts, given a query string in `name`.
-func (c *Client) SearchCharts(limit int, name string, offset int, tags string) (*chart.SearchResult, error) {
+func (c *Client) SearchCharts(ctx context.Context, limit int, name string, offset int, tags string) (*chart.SearchResult, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
 	if name != "" {
@@ -126,7 +127,7 @@ func (c *Client) SearchCharts(limit int, name string, offset int, tags string) (
 		params.Add("tags", tags)
 	}
 
-	resp, err := c.doRequest("GET", ChartAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", ChartAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/client.go
+++ b/vendor/github.com/signalfx/signalfx-go/client.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -76,11 +77,11 @@ func HTTPClient(httpClient *http.Client) ClientParam {
 	}
 }
 
-func (c *Client) doRequest(method string, path string, params url.Values, body io.Reader) (*http.Response, error) {
-	return c.doRequestWithToken(method, path, params, body, c.authToken)
+func (c *Client) doRequest(ctx context.Context, method string, path string, params url.Values, body io.Reader) (*http.Response, error) {
+	return c.doRequestWithToken(ctx, method, path, params, body, c.authToken)
 }
 
-func (c *Client) doRequestWithToken(method string, path string, params url.Values, body io.Reader, token string) (*http.Response, error) {
+func (c *Client) doRequestWithToken(ctx context.Context, method string, path string, params url.Values, body io.Reader, token string) (*http.Response, error) {
 	destURL, err := url.Parse(c.baseURL)
 	if err != nil {
 		return nil, err
@@ -90,7 +91,7 @@ func (c *Client) doRequestWithToken(method string, path string, params url.Value
 	if params != nil {
 		destURL.RawQuery = params.Encode()
 	}
-	req, err := http.NewRequest(method, destURL.String(), body)
+	req, err := http.NewRequestWithContext(ctx, method, destURL.String(), body)
 	if token != "" {
 		req.Header.Set(AuthHeaderKey, token)
 	}

--- a/vendor/github.com/signalfx/signalfx-go/dashboard.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboard.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,13 +20,13 @@ import (
 const DashboardAPIURL = "/v2/dashboard"
 
 // CreateDashboard creates a dashboard.
-func (c *Client) CreateDashboard(dashboardRequest *dashboard.CreateUpdateDashboardRequest) (*dashboard.Dashboard, error) {
+func (c *Client) CreateDashboard(ctx context.Context, dashboardRequest *dashboard.CreateUpdateDashboardRequest) (*dashboard.Dashboard, error) {
 	payload, err := json.Marshal(dashboardRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", DashboardAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", DashboardAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -47,8 +48,8 @@ func (c *Client) CreateDashboard(dashboardRequest *dashboard.CreateUpdateDashboa
 }
 
 // DeleteDashboard deletes a dashboard.
-func (c *Client) DeleteDashboard(id string) error {
-	resp, err := c.doRequest("DELETE", DashboardAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteDashboard(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", DashboardAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -66,8 +67,8 @@ func (c *Client) DeleteDashboard(id string) error {
 }
 
 // GetDashboard gets a dashboard.
-func (c *Client) GetDashboard(id string) (*dashboard.Dashboard, error) {
-	resp, err := c.doRequest("GET", DashboardAPIURL+"/"+id, nil, nil)
+func (c *Client) GetDashboard(ctx context.Context, id string) (*dashboard.Dashboard, error) {
+	resp, err := c.doRequest(ctx, "GET", DashboardAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -89,13 +90,13 @@ func (c *Client) GetDashboard(id string) (*dashboard.Dashboard, error) {
 }
 
 // UpdateDashboard updates a dashboard.
-func (c *Client) UpdateDashboard(id string, dashboardRequest *dashboard.CreateUpdateDashboardRequest) (*dashboard.Dashboard, error) {
+func (c *Client) UpdateDashboard(ctx context.Context, id string, dashboardRequest *dashboard.CreateUpdateDashboardRequest) (*dashboard.Dashboard, error) {
 	payload, err := json.Marshal(dashboardRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", DashboardAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", DashboardAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -117,14 +118,14 @@ func (c *Client) UpdateDashboard(id string, dashboardRequest *dashboard.CreateUp
 }
 
 // SearchDashboard searches for dashboards, given a query string in `name`.
-func (c *Client) SearchDashboard(limit int, name string, offset int, tags string) (*dashboard.SearchResult, error) {
+func (c *Client) SearchDashboard(ctx context.Context, limit int, name string, offset int, tags string) (*dashboard.SearchResult, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("name", name)
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("tags", tags)
 
-	resp, err := c.doRequest("GET", DashboardAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", DashboardAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/dashboardgroup.go
+++ b/vendor/github.com/signalfx/signalfx-go/dashboardgroup.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,7 +20,7 @@ const DashboardGroupAPIURL = "/v2/dashboardgroup"
 // TODO Clone dashboard to group
 
 // CreateDashboardGroup creates a dashboard.
-func (c *Client) CreateDashboardGroup(dashboardGroupRequest *dashboard_group.CreateUpdateDashboardGroupRequest, skipImplicitDashboard bool) (*dashboard_group.DashboardGroup, error) {
+func (c *Client) CreateDashboardGroup(ctx context.Context, dashboardGroupRequest *dashboard_group.CreateUpdateDashboardGroupRequest, skipImplicitDashboard bool) (*dashboard_group.DashboardGroup, error) {
 	payload, err := json.Marshal(dashboardGroupRequest)
 	if err != nil {
 		return nil, err
@@ -30,7 +31,7 @@ func (c *Client) CreateDashboardGroup(dashboardGroupRequest *dashboard_group.Cre
 		params.Add("empty", "true")
 	}
 
-	resp, err := c.doRequest("POST", DashboardGroupAPIURL, params, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", DashboardGroupAPIURL, params, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -52,8 +53,8 @@ func (c *Client) CreateDashboardGroup(dashboardGroupRequest *dashboard_group.Cre
 }
 
 // DeleteDashboardGroup deletes a dashboard.
-func (c *Client) DeleteDashboardGroup(id string) error {
-	resp, err := c.doRequest("DELETE", DashboardGroupAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteDashboardGroup(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", DashboardGroupAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -71,8 +72,8 @@ func (c *Client) DeleteDashboardGroup(id string) error {
 }
 
 // GetDashboardGroup gets a dashboard group.
-func (c *Client) GetDashboardGroup(id string) (*dashboard_group.DashboardGroup, error) {
-	resp, err := c.doRequest("GET", DashboardGroupAPIURL+"/"+id, nil, nil)
+func (c *Client) GetDashboardGroup(ctx context.Context, id string) (*dashboard_group.DashboardGroup, error) {
+	resp, err := c.doRequest(ctx, "GET", DashboardGroupAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -94,13 +95,13 @@ func (c *Client) GetDashboardGroup(id string) (*dashboard_group.DashboardGroup, 
 }
 
 // UpdateDashboardGroup updates a dashboard group.
-func (c *Client) UpdateDashboardGroup(id string, dashboardGroupRequest *dashboard_group.CreateUpdateDashboardGroupRequest) (*dashboard_group.DashboardGroup, error) {
+func (c *Client) UpdateDashboardGroup(ctx context.Context, id string, dashboardGroupRequest *dashboard_group.CreateUpdateDashboardGroupRequest) (*dashboard_group.DashboardGroup, error) {
 	payload, err := json.Marshal(dashboardGroupRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", DashboardGroupAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", DashboardGroupAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -122,13 +123,13 @@ func (c *Client) UpdateDashboardGroup(id string, dashboardGroupRequest *dashboar
 }
 
 // SearchDashboardGroup searches for dashboard groups, given a query string in `name`.
-func (c *Client) SearchDashboardGroups(limit int, name string, offset int) (*dashboard_group.SearchResult, error) {
+func (c *Client) SearchDashboardGroups(ctx context.Context, limit int, name string, offset int) (*dashboard_group.SearchResult, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("name", name)
 	params.Add("offset", strconv.Itoa(offset))
 
-	resp, err := c.doRequest("GET", DashboardGroupAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", DashboardGroupAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/datalink.go
+++ b/vendor/github.com/signalfx/signalfx-go/datalink.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,13 +18,13 @@ import (
 const DataLinkAPIURL = "/v2/crosslink"
 
 // CreateDataLink creates a data link.
-func (c *Client) CreateDataLink(dataLinkRequest *datalink.CreateUpdateDataLinkRequest) (*datalink.DataLink, error) {
+func (c *Client) CreateDataLink(ctx context.Context, dataLinkRequest *datalink.CreateUpdateDataLinkRequest) (*datalink.DataLink, error) {
 	payload, err := json.Marshal(dataLinkRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", DataLinkAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", DataLinkAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -45,8 +46,8 @@ func (c *Client) CreateDataLink(dataLinkRequest *datalink.CreateUpdateDataLinkRe
 }
 
 // DeleteDataLink deletes a data link.
-func (c *Client) DeleteDataLink(id string) error {
-	resp, err := c.doRequest("DELETE", DataLinkAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteDataLink(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", DataLinkAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -66,8 +67,8 @@ func (c *Client) DeleteDataLink(id string) error {
 }
 
 // GetDataLink gets a data link.
-func (c *Client) GetDataLink(id string) (*datalink.DataLink, error) {
-	resp, err := c.doRequest("GET", DataLinkAPIURL+"/"+id, nil, nil)
+func (c *Client) GetDataLink(ctx context.Context, id string) (*datalink.DataLink, error) {
+	resp, err := c.doRequest(ctx, "GET", DataLinkAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -89,14 +90,14 @@ func (c *Client) GetDataLink(id string) (*datalink.DataLink, error) {
 }
 
 // UpdateDataLink updates a data link.
-func (c *Client) UpdateDataLink(id string, dataLinkRequest *datalink.CreateUpdateDataLinkRequest) (*datalink.DataLink, error) {
+func (c *Client) UpdateDataLink(ctx context.Context, id string, dataLinkRequest *datalink.CreateUpdateDataLinkRequest) (*datalink.DataLink, error) {
 	payload, err := json.Marshal(dataLinkRequest)
 	if err != nil {
 		return nil, err
 	}
 
 	encodedName := url.PathEscape(id)
-	resp, err := c.doRequest("PUT", DataLinkAPIURL+"/"+encodedName, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", DataLinkAPIURL+"/"+encodedName, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -118,13 +119,13 @@ func (c *Client) UpdateDataLink(id string, dataLinkRequest *datalink.CreateUpdat
 }
 
 // SearchDataLinks searches for data links given a query string in `name`.
-func (c *Client) SearchDataLinks(limit int, context string, offset int) (*datalink.SearchResults, error) {
+func (c *Client) SearchDataLinks(ctx context.Context, limit int, context string, offset int) (*datalink.SearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("context", context)
 	params.Add("offset", strconv.Itoa(offset))
 
-	resp, err := c.doRequest("GET", DataLinkAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", DataLinkAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/detector.go
+++ b/vendor/github.com/signalfx/signalfx-go/detector.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,13 +18,13 @@ import (
 const DetectorAPIURL = "/v2/detector"
 
 // CreateDetector creates a detector.
-func (c *Client) CreateDetector(detectorRequest *detector.CreateUpdateDetectorRequest) (*detector.Detector, error) {
+func (c *Client) CreateDetector(ctx context.Context, detectorRequest *detector.CreateUpdateDetectorRequest) (*detector.Detector, error) {
 	payload, err := json.Marshal(detectorRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", DetectorAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", DetectorAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -45,8 +46,8 @@ func (c *Client) CreateDetector(detectorRequest *detector.CreateUpdateDetectorRe
 }
 
 // DeleteDetector deletes a detector.
-func (c *Client) DeleteDetector(id string) error {
-	resp, err := c.doRequest("DELETE", DetectorAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteDetector(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", DetectorAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -64,13 +65,13 @@ func (c *Client) DeleteDetector(id string) error {
 }
 
 // DisableDetector disables a detector.
-func (c *Client) DisableDetector(id string, labels []string) error {
+func (c *Client) DisableDetector(ctx context.Context, id string, labels []string) error {
 	payload, err := json.Marshal(labels)
 	if err != nil {
 		return err
 	}
 
-	resp, err := c.doRequest("PUT", DetectorAPIURL+"/"+id+"/disable", nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", DetectorAPIURL+"/"+id+"/disable", nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -88,13 +89,13 @@ func (c *Client) DisableDetector(id string, labels []string) error {
 }
 
 // EnableDetector enables a detector.
-func (c *Client) EnableDetector(id string, labels []string) error {
+func (c *Client) EnableDetector(ctx context.Context, id string, labels []string) error {
 	payload, err := json.Marshal(labels)
 	if err != nil {
 		return err
 	}
 
-	resp, err := c.doRequest("PUT", DetectorAPIURL+"/"+id+"/enable", nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", DetectorAPIURL+"/"+id+"/enable", nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -112,8 +113,8 @@ func (c *Client) EnableDetector(id string, labels []string) error {
 }
 
 // GetDetector gets a detector.
-func (c *Client) GetDetector(id string) (*detector.Detector, error) {
-	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id, nil, nil)
+func (c *Client) GetDetector(ctx context.Context, id string) (*detector.Detector, error) {
+	resp, err := c.doRequest(ctx, "GET", DetectorAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -135,13 +136,13 @@ func (c *Client) GetDetector(id string) (*detector.Detector, error) {
 }
 
 // UpdateDetector updates a detector.
-func (c *Client) UpdateDetector(id string, detectorRequest *detector.CreateUpdateDetectorRequest) (*detector.Detector, error) {
+func (c *Client) UpdateDetector(ctx context.Context, id string, detectorRequest *detector.CreateUpdateDetectorRequest) (*detector.Detector, error) {
 	payload, err := json.Marshal(detectorRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", DetectorAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", DetectorAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -163,7 +164,7 @@ func (c *Client) UpdateDetector(id string, detectorRequest *detector.CreateUpdat
 }
 
 // SearchDetectors searches for detectors, given a query string in `name`.
-func (c *Client) SearchDetectors(limit int, name string, offset int, tags string) (*detector.SearchResults, error) {
+func (c *Client) SearchDetectors(ctx context.Context, limit int, name string, offset int, tags string) (*detector.SearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("name", name)
@@ -172,7 +173,7 @@ func (c *Client) SearchDetectors(limit int, name string, offset int, tags string
 		params.Add("tags", tags)
 	}
 
-	resp, err := c.doRequest("GET", DetectorAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", DetectorAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -194,13 +195,13 @@ func (c *Client) SearchDetectors(limit int, name string, offset int, tags string
 }
 
 // GetDetectorEvents gets a detector's events.
-func (c *Client) GetDetectorEvents(id string, from int, to int, offset int, limit int) ([]*detector.Event, error) {
+func (c *Client) GetDetectorEvents(ctx context.Context, id string, from int, to int, offset int, limit int) ([]*detector.Event, error) {
 	params := url.Values{}
 	params.Add("from", strconv.Itoa(from))
 	params.Add("to", strconv.Itoa(to))
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("limit", strconv.Itoa(limit))
-	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id+"/events", params, nil)
+	resp, err := c.doRequest(ctx, "GET", DetectorAPIURL+"/"+id+"/events", params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -222,11 +223,11 @@ func (c *Client) GetDetectorEvents(id string, from int, to int, offset int, limi
 }
 
 // GetDetectorIncidents gets a detector's incidents.
-func (c *Client) GetDetectorIncidents(id string, offset int, limit int) ([]*detector.Incident, error) {
+func (c *Client) GetDetectorIncidents(ctx context.Context, id string, offset int, limit int) ([]*detector.Incident, error) {
 	params := url.Values{}
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("limit", strconv.Itoa(limit))
-	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id+"/incidents", params, nil)
+	resp, err := c.doRequest(ctx, "GET", DetectorAPIURL+"/"+id+"/incidents", params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/gcp_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/gcp_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,13 +13,13 @@ import (
 )
 
 // CreateGCPIntegration creates a GCP integration.
-func (c *Client) CreateGCPIntegration(gcpi *integration.GCPIntegration) (*integration.GCPIntegration, error) {
+func (c *Client) CreateGCPIntegration(ctx context.Context, gcpi *integration.GCPIntegration) (*integration.GCPIntegration, error) {
 	payload, err := json.Marshal(gcpi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -40,8 +41,8 @@ func (c *Client) CreateGCPIntegration(gcpi *integration.GCPIntegration) (*integr
 }
 
 // GetGCPIntegration retrieves a GCP integration.
-func (c *Client) GetGCPIntegration(id string) (*integration.GCPIntegration, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetGCPIntegration(ctx context.Context, id string) (*integration.GCPIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,13 +64,13 @@ func (c *Client) GetGCPIntegration(id string) (*integration.GCPIntegration, erro
 }
 
 // UpdateGCPIntegration updates a GCP integration.
-func (c *Client) UpdateGCPIntegration(id string, gcpi *integration.GCPIntegration) (*integration.GCPIntegration, error) {
+func (c *Client) UpdateGCPIntegration(ctx context.Context, id string, gcpi *integration.GCPIntegration) (*integration.GCPIntegration, error) {
 	payload, err := json.Marshal(gcpi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -91,8 +92,8 @@ func (c *Client) UpdateGCPIntegration(id string, gcpi *integration.GCPIntegratio
 }
 
 // DeleteGCPIntegration deletes a GCP integration.
-func (c *Client) DeleteGCPIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteGCPIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/integration.go
@@ -1,6 +1,7 @@
 package signalfx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,8 +13,8 @@ import (
 const IntegrationAPIURL = "/v2/integration"
 
 // DeleteIntegration deletes an integration.
-func (c *Client) DeleteIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -31,8 +32,8 @@ func (c *Client) DeleteIntegration(id string) error {
 }
 
 // GetIntegration gets a integration.
-func (c *Client) GetIntegration(id string) (map[string]interface{}, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetIntegration(ctx context.Context, id string) (map[string]interface{}, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/jira_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/jira_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,13 +13,13 @@ import (
 )
 
 // CreateJiraIntegration creates an Jira integration.
-func (c *Client) CreateJiraIntegration(ji *integration.JiraIntegration) (*integration.JiraIntegration, error) {
+func (c *Client) CreateJiraIntegration(ctx context.Context, ji *integration.JiraIntegration) (*integration.JiraIntegration, error) {
 	payload, err := json.Marshal(ji)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -40,8 +41,8 @@ func (c *Client) CreateJiraIntegration(ji *integration.JiraIntegration) (*integr
 }
 
 // GetJiraIntegration retrieves an Jira integration.
-func (c *Client) GetJiraIntegration(id string) (*integration.JiraIntegration, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetJiraIntegration(ctx context.Context, id string) (*integration.JiraIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,13 +64,13 @@ func (c *Client) GetJiraIntegration(id string) (*integration.JiraIntegration, er
 }
 
 // UpdateJiraIntegration updates an Jira integration.
-func (c *Client) UpdateJiraIntegration(id string, ji *integration.JiraIntegration) (*integration.JiraIntegration, error) {
+func (c *Client) UpdateJiraIntegration(ctx context.Context, id string, ji *integration.JiraIntegration) (*integration.JiraIntegration, error) {
 	payload, err := json.Marshal(ji)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -91,8 +92,8 @@ func (c *Client) UpdateJiraIntegration(id string, ji *integration.JiraIntegratio
 }
 
 // DeleteJiraIntegration deletes an Jira integration.
-func (c *Client) DeleteJiraIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteJiraIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/metrics_metadata.go
+++ b/vendor/github.com/signalfx/signalfx-go/metrics_metadata.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,8 +27,8 @@ const MetricTimeSeriesAPIURL = "/v2/metrictimeseries"
 const TagAPIURL = "/v2/tag"
 
 // GetDimension gets a dimension.
-func (c *Client) GetDimension(key string, value string) (*metrics_metadata.Dimension, error) {
-	resp, err := c.doRequest("GET", DimensionAPIURL+"/"+key+"/"+value, nil, nil)
+func (c *Client) GetDimension(ctx context.Context, key string, value string) (*metrics_metadata.Dimension, error) {
+	resp, err := c.doRequest(ctx, "GET", DimensionAPIURL+"/"+key+"/"+value, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -48,13 +49,13 @@ func (c *Client) GetDimension(key string, value string) (*metrics_metadata.Dimen
 }
 
 // UpdateDimension updates a dimension.
-func (c *Client) UpdateDimension(key string, value string, dim *metrics_metadata.Dimension) (*metrics_metadata.Dimension, error) {
+func (c *Client) UpdateDimension(ctx context.Context, key string, value string, dim *metrics_metadata.Dimension) (*metrics_metadata.Dimension, error) {
 	payload, err := json.Marshal(dim)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", DimensionAPIURL+"/"+key+"/"+value, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", DimensionAPIURL+"/"+key+"/"+value, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -76,7 +77,7 @@ func (c *Client) UpdateDimension(key string, value string, dim *metrics_metadata
 }
 
 // SearchDimension searches for dimensions, given a query string in `query`.
-func (c *Client) SearchDimension(query string, orderBy string, limit int, offset int) (*metrics_metadata.DimensionQueryResponseModel, error) {
+func (c *Client) SearchDimension(ctx context.Context, query string, orderBy string, limit int, offset int) (*metrics_metadata.DimensionQueryResponseModel, error) {
 	params := url.Values{}
 	params.Add("query", query)
 	if orderBy != "" {
@@ -85,7 +86,7 @@ func (c *Client) SearchDimension(query string, orderBy string, limit int, offset
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
-	resp, err := c.doRequest("GET", DimensionAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", DimensionAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -107,14 +108,14 @@ func (c *Client) SearchDimension(query string, orderBy string, limit int, offset
 }
 
 // SearchMetric searches for metrics, given a query string in `query`.
-func (c *Client) SearchMetric(query string, orderBy string, limit int, offset int) (*metrics_metadata.RetrieveMetricMetadataResponseModel, error) {
+func (c *Client) SearchMetric(ctx context.Context, query string, orderBy string, limit int, offset int) (*metrics_metadata.RetrieveMetricMetadataResponseModel, error) {
 	params := url.Values{}
 	params.Add("query", query)
 	params.Add("orderBy", orderBy)
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
-	resp, err := c.doRequest("GET", MetricAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", MetricAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -136,8 +137,8 @@ func (c *Client) SearchMetric(query string, orderBy string, limit int, offset in
 }
 
 // GetMetric retrieves a single metric by name.
-func (c *Client) GetMetric(name string) (*metrics_metadata.Metric, error) {
-	resp, err := c.doRequest("GET", MetricAPIURL+"/"+name, nil, nil)
+func (c *Client) GetMetric(ctx context.Context, name string) (*metrics_metadata.Metric, error) {
+	resp, err := c.doRequest(ctx, "GET", MetricAPIURL+"/"+name, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -159,8 +160,8 @@ func (c *Client) GetMetric(name string) (*metrics_metadata.Metric, error) {
 }
 
 // GetMetricTimeSeries retrieves a metric time series by id.
-func (c *Client) GetMetricTimeSeries(id string) (*metrics_metadata.MetricTimeSeries, error) {
-	resp, err := c.doRequest("GET", MetricTimeSeriesAPIURL+"/"+id, nil, nil)
+func (c *Client) GetMetricTimeSeries(ctx context.Context, id string) (*metrics_metadata.MetricTimeSeries, error) {
+	resp, err := c.doRequest(ctx, "GET", MetricTimeSeriesAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -182,14 +183,14 @@ func (c *Client) GetMetricTimeSeries(id string) (*metrics_metadata.MetricTimeSer
 }
 
 // SearchMetricTimeSeries searches for metric time series, given a query string in `query`.
-func (c *Client) SearchMetricTimeSeries(query string, orderBy string, limit int, offset int) (*metrics_metadata.MetricTimeSeriesRetrieveResponseModel, error) {
+func (c *Client) SearchMetricTimeSeries(ctx context.Context, query string, orderBy string, limit int, offset int) (*metrics_metadata.MetricTimeSeriesRetrieveResponseModel, error) {
 	params := url.Values{}
 	params.Add("query", query)
 	params.Add("orderBy", orderBy)
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
-	resp, err := c.doRequest("GET", MetricTimeSeriesAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", MetricTimeSeriesAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -211,14 +212,14 @@ func (c *Client) SearchMetricTimeSeries(query string, orderBy string, limit int,
 }
 
 // SearchTag searches for tags, given a query string in `query`.
-func (c *Client) SearchTag(query string, orderBy string, limit int, offset int) (*metrics_metadata.TagRetrieveResponseModel, error) {
+func (c *Client) SearchTag(ctx context.Context, query string, orderBy string, limit int, offset int) (*metrics_metadata.TagRetrieveResponseModel, error) {
 	params := url.Values{}
 	params.Add("query", query)
 	params.Add("orderBy", orderBy)
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
-	resp, err := c.doRequest("GET", TagAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", TagAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -240,8 +241,8 @@ func (c *Client) SearchTag(query string, orderBy string, limit int, offset int) 
 }
 
 // GetTag gets a tag by name
-func (c *Client) GetTag(name string) (*metrics_metadata.Tag, error) {
-	resp, err := c.doRequest("GET", TagAPIURL+"/"+name, nil, nil)
+func (c *Client) GetTag(ctx context.Context, name string) (*metrics_metadata.Tag, error) {
+	resp, err := c.doRequest(ctx, "GET", TagAPIURL+"/"+name, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -263,8 +264,8 @@ func (c *Client) GetTag(name string) (*metrics_metadata.Tag, error) {
 }
 
 // DeleteTag deletes a tag.
-func (c *Client) DeleteTag(id string) error {
-	resp, err := c.doRequest("DELETE", TagAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteTag(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", TagAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -282,13 +283,13 @@ func (c *Client) DeleteTag(id string) error {
 }
 
 // CreateUpdateTag creates or updates a dimension.
-func (c *Client) CreateUpdateTag(name string, cutr *metrics_metadata.CreateUpdateTagRequest) (*metrics_metadata.Tag, error) {
+func (c *Client) CreateUpdateTag(ctx context.Context, name string, cutr *metrics_metadata.CreateUpdateTagRequest) (*metrics_metadata.Tag, error) {
 	payload, err := json.Marshal(cutr)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", TagAPIURL+"/"+name, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", TagAPIURL+"/"+name, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/opsgenie_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/opsgenie_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,13 +13,13 @@ import (
 )
 
 // CreateOpsgenieIntegration creates an Opsgenie integration.
-func (c *Client) CreateOpsgenieIntegration(oi *integration.OpsgenieIntegration) (*integration.OpsgenieIntegration, error) {
+func (c *Client) CreateOpsgenieIntegration(ctx context.Context, oi *integration.OpsgenieIntegration) (*integration.OpsgenieIntegration, error) {
 	payload, err := json.Marshal(oi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -40,8 +41,8 @@ func (c *Client) CreateOpsgenieIntegration(oi *integration.OpsgenieIntegration) 
 }
 
 // GetOpsgenieIntegration retrieves an Opsgenie integration.
-func (c *Client) GetOpsgenieIntegration(id string) (*integration.OpsgenieIntegration, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetOpsgenieIntegration(ctx context.Context, id string) (*integration.OpsgenieIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,13 +64,13 @@ func (c *Client) GetOpsgenieIntegration(id string) (*integration.OpsgenieIntegra
 }
 
 // UpdateOpsgenieIntegration updates an Opsgenie integration.
-func (c *Client) UpdateOpsgenieIntegration(id string, oi *integration.OpsgenieIntegration) (*integration.OpsgenieIntegration, error) {
+func (c *Client) UpdateOpsgenieIntegration(ctx context.Context, id string, oi *integration.OpsgenieIntegration) (*integration.OpsgenieIntegration, error) {
 	payload, err := json.Marshal(oi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -91,8 +92,8 @@ func (c *Client) UpdateOpsgenieIntegration(id string, oi *integration.OpsgenieIn
 }
 
 // DeleteOpsgenieIntegration deletes an Opsgenie integration.
-func (c *Client) DeleteOpsgenieIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteOpsgenieIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/organization.go
+++ b/vendor/github.com/signalfx/signalfx-go/organization.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,8 +20,8 @@ const OrganizationMemberAPIURL = "/v2/organization/member"
 const OrganizationMembersAPIURL = "/v2/organization/members"
 
 // GetOrganization gets an organization.
-func (c *Client) GetOrganization(id string) (*organization.Organization, error) {
-	resp, err := c.doRequest("GET", OrganizationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetOrganization(ctx context.Context, id string) (*organization.Organization, error) {
+	resp, err := c.doRequest(ctx, "GET", OrganizationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -42,8 +43,8 @@ func (c *Client) GetOrganization(id string) (*organization.Organization, error) 
 }
 
 // GetMember gets a member.
-func (c *Client) GetMember(id string) (*organization.Member, error) {
-	resp, err := c.doRequest("GET", OrganizationMemberAPIURL+"/"+id, nil, nil)
+func (c *Client) GetMember(ctx context.Context, id string) (*organization.Member, error) {
+	resp, err := c.doRequest(ctx, "GET", OrganizationMemberAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -65,8 +66,8 @@ func (c *Client) GetMember(id string) (*organization.Member, error) {
 }
 
 // DeleteMember deletes a detector.
-func (c *Client) DeleteMember(id string) error {
-	resp, err := c.doRequest("DELETE", OrganizationMemberAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteMember(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", OrganizationMemberAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -84,13 +85,13 @@ func (c *Client) DeleteMember(id string) error {
 }
 
 // InviteMember invites a member to the organization.
-func (c *Client) InviteMember(inviteRequest *organization.CreateUpdateMemberRequest) (*organization.Member, error) {
+func (c *Client) InviteMember(ctx context.Context, inviteRequest *organization.CreateUpdateMemberRequest) (*organization.Member, error) {
 	payload, err := json.Marshal(inviteRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", OrganizationMemberAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", OrganizationMemberAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -112,13 +113,13 @@ func (c *Client) InviteMember(inviteRequest *organization.CreateUpdateMemberRequ
 }
 
 // InviteMembers invites many members to the organization.
-func (c *Client) InviteMembers(inviteRequest *organization.InviteMembersRequest) (*organization.InviteMembersRequest, error) {
+func (c *Client) InviteMembers(ctx context.Context, inviteRequest *organization.InviteMembersRequest) (*organization.InviteMembersRequest, error) {
 	payload, err := json.Marshal(inviteRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", OrganizationMembersAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", OrganizationMembersAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -140,14 +141,14 @@ func (c *Client) InviteMembers(inviteRequest *organization.InviteMembersRequest)
 }
 
 // GetOrganizationMembers gets members for an org, with an optional search.
-func (c *Client) GetOrganizationMembers(limit int, query string, offset int, orderBy string) (*organization.MemberSearchResults, error) {
+func (c *Client) GetOrganizationMembers(ctx context.Context, limit int, query string, offset int, orderBy string) (*organization.MemberSearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("query", query)
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("orderBy", orderBy)
 
-	resp, err := c.doRequest("GET", OrganizationMemberAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", OrganizationMemberAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/orgtoken.go
+++ b/vendor/github.com/signalfx/signalfx-go/orgtoken.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,13 +18,13 @@ import (
 const TokenAPIURL = "/v2/token"
 
 // CreateOrgToken creates a org token.
-func (c *Client) CreateOrgToken(tokenRequest *orgtoken.CreateUpdateTokenRequest) (*orgtoken.Token, error) {
+func (c *Client) CreateOrgToken(ctx context.Context, tokenRequest *orgtoken.CreateUpdateTokenRequest) (*orgtoken.Token, error) {
 	payload, err := json.Marshal(tokenRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", TokenAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", TokenAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -45,9 +46,9 @@ func (c *Client) CreateOrgToken(tokenRequest *orgtoken.CreateUpdateTokenRequest)
 }
 
 // DeleteOrgToken deletes a token.
-func (c *Client) DeleteOrgToken(name string) error {
+func (c *Client) DeleteOrgToken(ctx context.Context, name string) error {
 	encodedName := url.PathEscape(name)
-	resp, err := c.doRequest("DELETE", TokenAPIURL+"/"+encodedName, nil, nil)
+	resp, err := c.doRequest(ctx, "DELETE", TokenAPIURL+"/"+encodedName, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -65,9 +66,9 @@ func (c *Client) DeleteOrgToken(name string) error {
 }
 
 // GetOrgToken gets a token.
-func (c *Client) GetOrgToken(id string) (*orgtoken.Token, error) {
+func (c *Client) GetOrgToken(ctx context.Context, id string) (*orgtoken.Token, error) {
 	encodedName := url.PathEscape(id)
-	resp, err := c.doRequest("GET", TokenAPIURL+"/"+encodedName, nil, nil)
+	resp, err := c.doRequest(ctx, "GET", TokenAPIURL+"/"+encodedName, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -89,14 +90,14 @@ func (c *Client) GetOrgToken(id string) (*orgtoken.Token, error) {
 }
 
 // UpdateOrgToken updates a token.
-func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTokenRequest) (*orgtoken.Token, error) {
+func (c *Client) UpdateOrgToken(ctx context.Context, id string, tokenRequest *orgtoken.CreateUpdateTokenRequest) (*orgtoken.Token, error) {
 	payload, err := json.Marshal(tokenRequest)
 	if err != nil {
 		return nil, err
 	}
 
 	encodedName := url.PathEscape(id)
-	resp, err := c.doRequest("PUT", TokenAPIURL+"/"+encodedName, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", TokenAPIURL+"/"+encodedName, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -117,14 +118,14 @@ func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTo
 	return finalToken, err
 }
 
-// SearchOrgToken searches for tokens given a query string in `name`.
-func (c *Client) SearchOrgTokens(limit int, name string, offset int) (*orgtoken.SearchResults, error) {
+// SearchOrgTokens searches for tokens given a query string in `name`.
+func (c *Client) SearchOrgTokens(ctx context.Context, limit int, name string, offset int) (*orgtoken.SearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("name", url.PathEscape(name))
 	params.Add("offset", strconv.Itoa(offset))
 
-	resp, err := c.doRequest("GET", TokenAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", TokenAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/pagerduty_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/pagerduty_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,13 +13,13 @@ import (
 )
 
 // CreatePagerDutyIntegration creates a PagerDuty integration.
-func (c *Client) CreatePagerDutyIntegration(pdi *integration.PagerDutyIntegration) (*integration.PagerDutyIntegration, error) {
+func (c *Client) CreatePagerDutyIntegration(ctx context.Context, pdi *integration.PagerDutyIntegration) (*integration.PagerDutyIntegration, error) {
 	payload, err := json.Marshal(pdi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -40,8 +41,8 @@ func (c *Client) CreatePagerDutyIntegration(pdi *integration.PagerDutyIntegratio
 }
 
 // GetPagerDutyIntegration retrieves a PagerDuty integration.
-func (c *Client) GetPagerDutyIntegration(id string) (*integration.PagerDutyIntegration, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetPagerDutyIntegration(ctx context.Context, id string) (*integration.PagerDutyIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,13 +64,13 @@ func (c *Client) GetPagerDutyIntegration(id string) (*integration.PagerDutyInteg
 }
 
 // UpdatePagerDutyIntegration updates a PagerDuty integration.
-func (c *Client) UpdatePagerDutyIntegration(id string, pdi *integration.PagerDutyIntegration) (*integration.PagerDutyIntegration, error) {
+func (c *Client) UpdatePagerDutyIntegration(ctx context.Context, id string, pdi *integration.PagerDutyIntegration) (*integration.PagerDutyIntegration, error) {
 	payload, err := json.Marshal(pdi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -91,8 +92,8 @@ func (c *Client) UpdatePagerDutyIntegration(id string, pdi *integration.PagerDut
 }
 
 // DeletePagerDutyIntegration deletes a PagerDuty integration.
-func (c *Client) DeletePagerDutyIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeletePagerDutyIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/sessiontoken.go
+++ b/vendor/github.com/signalfx/signalfx-go/sessiontoken.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,7 +16,7 @@ import (
 const SessionTokenAPIURL = "/v2/session"
 
 // CreateOrgToken creates a org token.
-func (c *Client) CreateSessionToken(tokenRequest *sessiontoken.CreateTokenRequest) (*sessiontoken.Token, error) {
+func (c *Client) CreateSessionToken(ctx context.Context, tokenRequest *sessiontoken.CreateTokenRequest) (*sessiontoken.Token, error) {
 	payload, err := json.Marshal(tokenRequest)
 	if err != nil {
 		return nil, err
@@ -23,7 +24,7 @@ func (c *Client) CreateSessionToken(tokenRequest *sessiontoken.CreateTokenReques
 
 	// we need to explicitly pass an empty token (which means it wont get set in the header)
 	// the API accepts either no token or a valid token, but not an empty token.
-	resp, err := c.doRequestWithToken("POST", SessionTokenAPIURL, nil, bytes.NewReader(payload), "")
+	resp, err := c.doRequestWithToken(ctx, "POST", SessionTokenAPIURL, nil, bytes.NewReader(payload), "")
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -45,8 +46,8 @@ func (c *Client) CreateSessionToken(tokenRequest *sessiontoken.CreateTokenReques
 }
 
 // DeleteOrgToken deletes a token.
-func (c *Client) DeleteSessionToken(token string) error {
-	resp, err := c.doRequestWithToken("DELETE", SessionTokenAPIURL, nil, nil, token)
+func (c *Client) DeleteSessionToken(ctx context.Context, token string) error {
+	resp, err := c.doRequestWithToken(ctx, "DELETE", SessionTokenAPIURL, nil, nil, token)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/slack_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/slack_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,13 +13,13 @@ import (
 )
 
 // CreateSlackIntegration creates a Slack integration.
-func (c *Client) CreateSlackIntegration(si *integration.SlackIntegration) (*integration.SlackIntegration, error) {
+func (c *Client) CreateSlackIntegration(ctx context.Context, si *integration.SlackIntegration) (*integration.SlackIntegration, error) {
 	payload, err := json.Marshal(si)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -40,8 +41,8 @@ func (c *Client) CreateSlackIntegration(si *integration.SlackIntegration) (*inte
 }
 
 // GetSlackIntegration retrieves a Slack integration.
-func (c *Client) GetSlackIntegration(id string) (*integration.SlackIntegration, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetSlackIntegration(ctx context.Context, id string) (*integration.SlackIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,13 +64,13 @@ func (c *Client) GetSlackIntegration(id string) (*integration.SlackIntegration, 
 }
 
 // UpdateSlackIntegration updates a Slack integration.
-func (c *Client) UpdateSlackIntegration(id string, si *integration.SlackIntegration) (*integration.SlackIntegration, error) {
+func (c *Client) UpdateSlackIntegration(ctx context.Context, id string, si *integration.SlackIntegration) (*integration.SlackIntegration, error) {
 	payload, err := json.Marshal(si)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -91,8 +92,8 @@ func (c *Client) UpdateSlackIntegration(id string, si *integration.SlackIntegrat
 }
 
 // DeleteSlackIntegration deletes a Slack integration.
-func (c *Client) DeleteSlackIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteSlackIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/team.go
+++ b/vendor/github.com/signalfx/signalfx-go/team.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,13 +19,13 @@ import (
 const TeamAPIURL = "/v2/team"
 
 // CreateTeam creates a team.
-func (c *Client) CreateTeam(t *team.CreateUpdateTeamRequest) (*team.Team, error) {
+func (c *Client) CreateTeam(ctx context.Context, t *team.CreateUpdateTeamRequest) (*team.Team, error) {
 	payload, err := json.Marshal(t)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", TeamAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", TeamAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -46,8 +47,8 @@ func (c *Client) CreateTeam(t *team.CreateUpdateTeamRequest) (*team.Team, error)
 }
 
 // DeleteTeam deletes a team.
-func (c *Client) DeleteTeam(id string) error {
-	resp, err := c.doRequest("DELETE", TeamAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteTeam(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", TeamAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -64,8 +65,8 @@ func (c *Client) DeleteTeam(id string) error {
 }
 
 // GetTeam gets a team.
-func (c *Client) GetTeam(id string) (*team.Team, error) {
-	resp, err := c.doRequest("GET", TeamAPIURL+"/"+id, nil, nil)
+func (c *Client) GetTeam(ctx context.Context, id string) (*team.Team, error) {
+	resp, err := c.doRequest(ctx, "GET", TeamAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -86,13 +87,13 @@ func (c *Client) GetTeam(id string) (*team.Team, error) {
 }
 
 // UpdateTeam updates a team.
-func (c *Client) UpdateTeam(id string, t *team.CreateUpdateTeamRequest) (*team.Team, error) {
+func (c *Client) UpdateTeam(ctx context.Context, id string, t *team.CreateUpdateTeamRequest) (*team.Team, error) {
 	payload, err := json.Marshal(t)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", TeamAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", TeamAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -113,14 +114,14 @@ func (c *Client) UpdateTeam(id string, t *team.CreateUpdateTeamRequest) (*team.T
 }
 
 // SearchTeam searches for teams, given a query string in `name`.
-func (c *Client) SearchTeam(limit int, name string, offset int, tags string) (*team.SearchResults, error) {
+func (c *Client) SearchTeam(ctx context.Context, limit int, name string, offset int, tags string) (*team.SearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("name", name)
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("tags", tags)
 
-	resp, err := c.doRequest("GET", TeamAPIURL, params, nil)
+	resp, err := c.doRequest(ctx, "GET", TeamAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/victor_ops_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/victor_ops_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,13 +13,13 @@ import (
 )
 
 // CreateVictorOpsIntegration creates an VictorOps integration.
-func (c *Client) CreateVictorOpsIntegration(oi *integration.VictorOpsIntegration) (*integration.VictorOpsIntegration, error) {
+func (c *Client) CreateVictorOpsIntegration(ctx context.Context, oi *integration.VictorOpsIntegration) (*integration.VictorOpsIntegration, error) {
 	payload, err := json.Marshal(oi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -40,8 +41,8 @@ func (c *Client) CreateVictorOpsIntegration(oi *integration.VictorOpsIntegration
 }
 
 // GetVictorOpsIntegration retrieves an VictorOps integration.
-func (c *Client) GetVictorOpsIntegration(id string) (*integration.VictorOpsIntegration, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetVictorOpsIntegration(ctx context.Context, id string) (*integration.VictorOpsIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,13 +64,13 @@ func (c *Client) GetVictorOpsIntegration(id string) (*integration.VictorOpsInteg
 }
 
 // UpdateVictorOpsIntegration updates an VictorOps integration.
-func (c *Client) UpdateVictorOpsIntegration(id string, oi *integration.VictorOpsIntegration) (*integration.VictorOpsIntegration, error) {
+func (c *Client) UpdateVictorOpsIntegration(ctx context.Context, id string, oi *integration.VictorOpsIntegration) (*integration.VictorOpsIntegration, error) {
 	payload, err := json.Marshal(oi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -91,8 +92,8 @@ func (c *Client) UpdateVictorOpsIntegration(id string, oi *integration.VictorOps
 }
 
 // DeleteVictorOpsIntegration deletes an VictorOps integration.
-func (c *Client) DeleteVictorOpsIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteVictorOpsIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/github.com/signalfx/signalfx-go/webhook_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/webhook_integration.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,13 +13,13 @@ import (
 )
 
 // CreateWebhookIntegration creates an Webhook integration.
-func (c *Client) CreateWebhookIntegration(oi *integration.WebhookIntegration) (*integration.WebhookIntegration, error) {
+func (c *Client) CreateWebhookIntegration(ctx context.Context, oi *integration.WebhookIntegration) (*integration.WebhookIntegration, error) {
 	payload, err := json.Marshal(oi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -40,8 +41,8 @@ func (c *Client) CreateWebhookIntegration(oi *integration.WebhookIntegration) (*
 }
 
 // GetWebhookIntegration retrieves an Webhook integration.
-func (c *Client) GetWebhookIntegration(id string) (*integration.WebhookIntegration, error) {
-	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) GetWebhookIntegration(ctx context.Context, id string) (*integration.WebhookIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,13 +64,13 @@ func (c *Client) GetWebhookIntegration(id string) (*integration.WebhookIntegrati
 }
 
 // UpdateWebhookIntegration updates an Webhook integration.
-func (c *Client) UpdateWebhookIntegration(id string, oi *integration.WebhookIntegration) (*integration.WebhookIntegration, error) {
+func (c *Client) UpdateWebhookIntegration(ctx context.Context, id string, oi *integration.WebhookIntegration) (*integration.WebhookIntegration, error) {
 	payload, err := json.Marshal(oi)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, "PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -91,8 +92,8 @@ func (c *Client) UpdateWebhookIntegration(id string, oi *integration.WebhookInte
 }
 
 // DeleteWebhookIntegration deletes an Webhook integration.
-func (c *Client) DeleteWebhookIntegration(id string) error {
-	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+func (c *Client) DeleteWebhookIntegration(ctx context.Context, id string) error {
+	resp, err := c.doRequest(ctx, "DELETE", IntegrationAPIURL+"/"+id, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -217,7 +217,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.6.39
+# github.com/signalfx/signalfx-go v1.7.0
 ## explicit
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting


### PR DESCRIPTION
# Summary
Add `context.Context` everywhere.

# Motivation
This was added in signalfx-go for customer use, so need to get this folded in now before I need to upgrade for a different reason.