### PR TITLE
Format terraform documentation samples with terrafmt

### DIFF
--- a/website/docs/d/aws_services.markdown
+++ b/website/docs/d/aws_services.markdown
@@ -19,10 +19,10 @@ data "signalfx_aws_services" "aws_services" {
 # Leaves out most of the integration bits, see the docs
 # for signalfx_aws_integration for more
 resource "signalfx_aws_integration" "aws_myteam" {
-   # …
+  # …
 
-   # All supported services!
-   services = data.signalfx_aws_services.aws_services.services.*.name
+  # All supported services!
+  services = data.signalfx_aws_services.aws_services.services.*.name
 }
 ```
 

--- a/website/docs/d/azure_services.markdown
+++ b/website/docs/d/azure_services.markdown
@@ -19,10 +19,10 @@ data "signalfx_azure_services" "azure_services" {
 # Leaves out most of the integration bits, see the docs
 # for signalfx_azure_integration for more
 resource "signalfx_azure_integration" "azure_myteam" {
-   # …
+  # …
 
-   # All supported services!
-   services = data.signalfx_azure_services.azure_services.services.*.name
+  # All supported services!
+  services = data.signalfx_azure_services.azure_services.services.*.name
 }
 ```
 

--- a/website/docs/d/dimension_values.markdown
+++ b/website/docs/d/dimension_values.markdown
@@ -16,39 +16,39 @@ Use this data source to get a list of dimension values matching the provided que
 
 ```hcl
 resource "signalfx_dashboard_group" "mydashboardgroup0" {
-    name = "My team dashboard group"
-    description = "Cool dashboard group"
+  name        = "My team dashboard group"
+  description = "Cool dashboard group"
 }
 
 data "signalfx_dimension_values" "hosts" {
-	query = "key:host"
+  query = "key:host"
 }
 
 resource "signalfx_time_chart" "host_charts" {
-		for_each = toset(data.signalfx_dimension_values.hosts.values)
+  for_each = toset(data.signalfx_dimension_values.hosts.values)
 
-    name = "CPU Total Idle ${each.value}"
+  name = "CPU Total Idle ${each.value}"
 
-		plot_type = "ColumnChart"
-		axes_include_zero = true
-		color_by = "Metric"
+  plot_type         = "ColumnChart"
+  axes_include_zero = true
+  color_by          = "Metric"
 
-    program_text = <<-EOF
+  program_text = <<-EOF
 A = data("cpu.idle", filter('host', '${each.key}').publish(label="CPU")
         EOF
 }
 
 resource "signalfx_dashboard" "mydashboard1" {
-    name = "My Dashboard"
-    dashboard_group = signalfx_dashboard_group.mydashboardgroup0.id
+  name            = "My Dashboard"
+  dashboard_group = signalfx_dashboard_group.mydashboardgroup0.id
 
-    time_range = "-30m"
+  time_range = "-30m"
 
-		grid {
-			chart_ids = toset([for v in signalfx_time_chart.host_charts: v.id ])
-			width = 3
-			height = 1
-		}
+  grid {
+    chart_ids = toset([for v in signalfx_time_chart.host_charts : v.id])
+    width     = 3
+    height    = 1
+  }
 }
 ```
 

--- a/website/docs/d/gcp_services.markdown
+++ b/website/docs/d/gcp_services.markdown
@@ -19,10 +19,10 @@ data "signalfx_gcp_services" "gcp_services" {
 # Leaves out most of the integration bits, see the docs
 # for signalfx_gcp_integration for more
 resource "signalfx_gcp_integration" "gcp_myteam" {
-   # …
+  # …
 
-   # All supported services!
-   services = data.signalfx_gcp_services.gcp_services.services.*.name
+  # All supported services!
+  services = data.signalfx_gcp_services.gcp_services.services.*.name
 }
 ```
 

--- a/website/docs/r/alert_muting_rule.html.markdown
+++ b/website/docs/r/alert_muting_rule.html.markdown
@@ -14,19 +14,19 @@ Provides a SignalFx resource for managing alert muting rules. See [Mute Notifica
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_alert_muting_rule" "rool_mooter_one" {
-    description = "mooted it NEW"
+  description = "mooted it NEW"
 
-    start_time = 1573063243
-    stop_time = 0 # Defaults to 0
+  start_time = 1573063243
+  stop_time  = 0 # Defaults to 0
 
-    detectors = [ signalfx_detector.some_detector_id ]
+  detectors = [signalfx_detector.some_detector_id]
 
-    filter {
-      property = "foo"
-      property_value = "bar"
-    }
+  filter {
+    property       = "foo"
+    property_value = "bar"
+  }
 }
 ```
 

--- a/website/docs/r/aws_external_integration.html.markdown
+++ b/website/docs/r/aws_external_integration.html.markdown
@@ -16,9 +16,9 @@ SignalFx AWS CloudWatch integrations using Role ARNs. For help with this integra
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_aws_external_integration" "aws_myteam_extern" {
-   name = "AWSFooNEW"
+  name = "AWSFooNEW"
 }
 
 data "aws_iam_policy_document" "signalfx_assume_policy" {
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "signalfx_assume_policy" {
 
     principals {
       type        = "AWS"
-			identifiers = [signalfx_aws_external_integration.aws_myteam_extern.signalfx_aws_account]
+      identifiers = [signalfx_aws_external_integration.aws_myteam_extern.signalfx_aws_account]
     }
 
     condition {
@@ -39,15 +39,15 @@ data "aws_iam_policy_document" "signalfx_assume_policy" {
 }
 
 resource "aws_iam_role" "aws_sfx_role" {
-	name               = "signalfx-reads-from-cloudwatch2"
+  name               = "signalfx-reads-from-cloudwatch2"
   description        = "signalfx integration to read out data and send it to signalfxs aws account"
-	assume_role_policy = data.aws_iam_policy_document.signalfx_assume_policy.json
+  assume_role_policy = data.aws_iam_policy_document.signalfx_assume_policy.json
 }
 
 resource "aws_iam_policy" "aws_read_permissions" {
-	name = "SignalFxReadPermissionsPolicy"
-	description = "farts"
-	policy = <<EOF
+  name        = "SignalFxReadPermissionsPolicy"
+  description = "farts"
+  policy      = <<EOF
 {
 	"Version": "2012-10-17",
 	"Statement": [
@@ -114,23 +114,23 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "sfx-read-attach" {
-	role = aws_iam_role.aws_sfx_role.name
-	policy_arn = aws_iam_policy.aws_read_permissions.arn
+  role       = aws_iam_role.aws_sfx_role.name
+  policy_arn = aws_iam_policy.aws_read_permissions.arn
 }
 
 
 resource "signalfx_aws_integration" "aws_myteam" {
-   enabled = true
+  enabled = true
 
-		integration_id = signalfx_aws_external_integration.aws_myteam_extern.id
-		external_id = signalfx_aws_external_integration.aws_myteam_extern.external_id
-		role_arn = aws_iam_role.aws_sfx_role.arn
-		# token = "abc123"
-		# key = "abc123"
-		regions = ["us-east-1"]
-		poll_rate = 300
-		import_cloud_watch = true
-		enable_aws_usage = true
+  integration_id = signalfx_aws_external_integration.aws_myteam_extern.id
+  external_id    = signalfx_aws_external_integration.aws_myteam_extern.external_id
+  role_arn       = aws_iam_role.aws_sfx_role.arn
+  # token = "abc123"
+  # key = "abc123"
+  regions            = ["us-east-1"]
+  poll_rate          = 300
+  import_cloud_watch = true
+  enable_aws_usage   = true
 }
 
 ```

--- a/website/docs/r/aws_integration.html.markdown
+++ b/website/docs/r/aws_integration.html.markdown
@@ -16,10 +16,10 @@ SignalFx AWS CloudWatch integrations. For help with this integration see [Monito
 
 ## Example Usage
 
-```terraform
+```tf
 // This resource returns an account id in `external_id`…
 resource "signalfx_aws_external_integration" "aws_myteam_external" {
-    name = "AWSFoo"
+  name = "AWSFoo"
 }
 
 // Make yourself an AWS IAM role here, use `signalfx_aws_external_integration.aws_myteam_external.external_id`
@@ -28,29 +28,29 @@ resource "aws_iam_role" "aws_sfx_role" {
 }
 
 resource "signalfx_aws_integration" "aws_myteam" {
-    enabled = true
+  enabled = true
 
-    integration_id = signalfx_aws_external_integration.aws_myteam_external.id
-    external_id = signalfx_aws_external_integration.aws_myteam_external.external_id
-		role_arn = aws_iam_role.aws_sfx_role.arn
-		regions = ["us-east-1"]
-		poll_rate = 300
-		import_cloud_watch = true
-		enable_aws_usage = true
+  integration_id     = signalfx_aws_external_integration.aws_myteam_external.id
+  external_id        = signalfx_aws_external_integration.aws_myteam_external.external_id
+  role_arn           = aws_iam_role.aws_sfx_role.arn
+  regions            = ["us-east-1"]
+  poll_rate          = 300
+  import_cloud_watch = true
+  enable_aws_usage   = true
 
-		custom_namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "fart"
-		}
+  custom_namespace_sync_rule {
+    default_action = "Exclude"
+    filter_action  = "Include"
+    filter_source  = "filter('code', '200')"
+    namespace      = "fart"
+  }
 
-		namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "AWS/EC2"
-		}
+  namespace_sync_rule {
+    default_action = "Exclude"
+    filter_action  = "Include"
+    filter_source  = "filter('code', '200')"
+    namespace      = "AWS/EC2"
+  }
 }
 ```
 

--- a/website/docs/r/aws_token_integration.html.markdown
+++ b/website/docs/r/aws_token_integration.html.markdown
@@ -16,9 +16,9 @@ SignalFx AWS CloudWatch integrations using security tokens. For help with this i
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_aws_token_integration" "aws_myteam_token" {
-    name = "AWSFoo"
+  name = "AWSFoo"
 }
 
 // Make yourself an AWS IAM role here
@@ -27,29 +27,29 @@ resource "aws_iam_role" "aws_sfx_role" {
 }
 
 resource "signalfx_aws_integration" "aws_myteam" {
-    enabled = true
+  enabled = true
 
-    integration_id = signalfx_aws_token_integration.aws_myteam_token.id
-    token = "put_your_token_here"
-    key = "put_your_key_here"
-		regions = ["us-east-1"]
-		poll_rate = 300
-		import_cloud_watch = true
-		enable_aws_usage = true
+  integration_id     = signalfx_aws_token_integration.aws_myteam_token.id
+  token              = "put_your_token_here"
+  key                = "put_your_key_here"
+  regions            = ["us-east-1"]
+  poll_rate          = 300
+  import_cloud_watch = true
+  enable_aws_usage   = true
 
-		custom_namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "fart"
-		}
+  custom_namespace_sync_rule {
+    default_action = "Exclude"
+    filter_action  = "Include"
+    filter_source  = "filter('code', '200')"
+    namespace      = "fart"
+  }
 
-		namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "AWS/EC2"
-		}
+  namespace_sync_rule {
+    default_action = "Exclude"
+    filter_action  = "Include"
+    filter_source  = "filter('code', '200')"
+    namespace      = "AWS/EC2"
+  }
 }
 ```
 

--- a/website/docs/r/azure_integration.html.markdown
+++ b/website/docs/r/azure_integration.html.markdown
@@ -14,29 +14,29 @@ SignalFx Azure integrations. For help with this integration see [Monitoring Micr
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_azure_integration" "azure_myteam" {
-    name = "Azure Foo"
-    enabled = true
+  name    = "Azure Foo"
+  enabled = true
 
-    resource "signalfx_azure_integration" "azure_myteamXX" {
-        name = "AzureFoo"
-        enabled = false
+  resource "signalfx_azure_integration" "azure_myteamXX" {
+    name    = "AzureFoo"
+    enabled = false
 
-        environment = "azure"
+    environment = "azure"
 
-    		poll_rate = 300
+    poll_rate = 300
 
-        secret_key = "XXX"
+    secret_key = "XXX"
 
-        app_id = "YYY"
+    app_id = "YYY"
 
-        tenant_id = "ZZZ"
+    tenant_id = "ZZZ"
 
-        services = [ "microsoft.sql/servers/elasticpools" ]
+    services = ["microsoft.sql/servers/elasticpools"]
 
-        subscriptions = [ "sub-guid-here" ]
-    }
+    subscriptions = ["sub-guid-here"]
+  }
 }
 ```
 

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -14,32 +14,32 @@ A dashboard is a curated collection of specific charts and supports dimensional 
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_dashboard" "mydashboard0" {
-    name = "My Dashboard"
-    dashboard_group = signalfx_dashboard_group.mydashboardgroup0.id
+  name            = "My Dashboard"
+  dashboard_group = signalfx_dashboard_group.mydashboardgroup0.id
 
-    time_range = "-30m"
+  time_range = "-30m"
 
-    filter {
-        property = "collector"
-        values = ["cpu", "Diamond"]
-    }
-    variable {
-        property = "region"
-        alias = "region"
-        values = ["uswest-1-"]
-    }
-    chart {
-        chart_id = signalfx_time_chart.mychart0.id
-        width = 12
-        height = 1
-    }
-    chart {
-        chart_id = signalfx_time_chart.mychart1.id
-        width = 5
-        height = 2
-    }
+  filter {
+    property = "collector"
+    values   = ["cpu", "Diamond"]
+  }
+  variable {
+    property = "region"
+    alias    = "region"
+    values   = ["uswest-1-"]
+  }
+  chart {
+    chart_id = signalfx_time_chart.mychart0.id
+    width    = 12
+    height   = 1
+  }
+  chart {
+    chart_id = signalfx_time_chart.mychart1.id
+    width    = 5
+    height   = 2
+  }
 }
 ```
 
@@ -117,21 +117,25 @@ The are a bunch of use cases where this layout makes things too verbose and hard
 
 The dashboard is divided into equal-sized charts (defined by `width` and `height`). If a chart does not fit in the same row (because the total width > max allowed by the dashboard), this and the next ones will be place in the next row(s).
 
-```terraform
+```tf
 resource "signalfx_dashboard" "grid_example" {
-    name = "Grid"
-    dashboard_group = "${signalfx_dashboard_group.example.id}"
-    time_range = "-15m"
+  name            = "Grid"
+  dashboard_group = signalfx_dashboard_group.example.id
+  time_range      = "-15m"
 
-    grid {
-        chart_ids = ["${concat(signalfx_time_chart.rps.*.id,
-                signalfx_time_chart.50ths.*.id,
-                signalfx_time_chart.99ths.*.id,
-                signalfx_time_chart.idle_workers.*.id,
-                signalfx_time_chart.cpu_idle.*.id)}"]
-        width = 3
-        height = 1
-    }
+  grid {
+    chart_ids = [
+      concat(
+        signalfx_time_chart.rps.*.id,
+        signalfx_time_chart.p50ths.*.id,
+        signalfx_time_chart.p99ths.*.id,
+        signalfx_time_chart.idle_workers.*.id,
+        signalfx_time_chart.cpu_idle.*.id,
+      )
+    ]
+    width  = 3
+    height = 1
+  }
 }
 ```
 
@@ -139,19 +143,19 @@ resource "signalfx_dashboard" "grid_example" {
 
 The dashboard is divided into equal-sized charts (defined by `width` and `height`). The charts are placed in the grid by column (column number is called `column`).
 
-```terraform
+```tf
 resource "signalfx_dashboard" "load" {
-    name = "Load"
-    dashboard_group = "${signalfx_dashboard_group.example.id}"
+  name            = "Load"
+  dashboard_group = signalfx_dashboard_group.example.id
 
-    column {
-        chart_ids = ["${signalfx_single_value_chart.rps.*.id}"]
-        width = 2
-    }
-    column {
-        chart_ids = ["${signalfx_time_chart.cpu_capacity.*.id}"]
-        column = 2
-        width = 4
-    }
+  column {
+    chart_ids = [signalfx_single_value_chart.rps.*.id]
+    width     = 2
+  }
+  column {
+    chart_ids = [signalfx_time_chart.cpu_capacity.*.id]
+    column    = 2
+    width     = 4
+  }
 }
 ```

--- a/website/docs/r/dashboard_group.html.markdown
+++ b/website/docs/r/dashboard_group.html.markdown
@@ -14,45 +14,45 @@ In the SignalFx web UI, a [dashboard group](https://developers.signalfx.com/dash
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_dashboard_group" "mydashboardgroup0" {
-    name = "My team dashboard group"
-    description = "Cool dashboard group"
+  name        = "My team dashboard group"
+  description = "Cool dashboard group"
 
-    # Note that if you use these features, you must use a user's
-    # admin key to authenticate the provider, lest Terraform not be able
-    # to modify the dashboard group in the future!
-    authorized_writer_teams = [ signalfx_team.mycoolteam.id ]
-    authorized_writer_users = [ "abc123" ]
+  # Note that if you use these features, you must use a user's
+  # admin key to authenticate the provider, lest Terraform not be able
+  # to modify the dashboard group in the future!
+  authorized_writer_teams = [signalfx_team.mycoolteam.id]
+  authorized_writer_users = ["abc123"]
 }
 ```
 
 ## Example Usage With Mirrored Dashboards
 
-```terraform
+```tf
 resource "signalfx_dashboard_group" "mydashboardgroup_withmirrors" {
-    name = "My team dashboard group"
-    description = "Cool dashboard group"
+  name        = "My team dashboard group"
+  description = "Cool dashboard group"
 
-    // You can add as many of these as you like. Make sure your account
-    // supports this feature!
-    dashboard {
-      dashboard_id = signalfx_dashboard.gc_dashboard.id
-      name_override = "GC For My Service"
-      description_override = "Garbage Collection dashboard maintained by JVM team"
+  // You can add as many of these as you like. Make sure your account
+  // supports this feature!
+  dashboard {
+    dashboard_id         = signalfx_dashboard.gc_dashboard.id
+    name_override        = "GC For My Service"
+    description_override = "Garbage Collection dashboard maintained by JVM team"
 
-      filter_override {
-        property = "service"
-        values = [ "myservice" ]
-        negated = false
-      }
-
-      variable_override {
-        property = "region"
-        values = ["us-west1"]
-        values_suggested = ["us-west-1", "us-east-1"]
-      }
+    filter_override {
+      property = "service"
+      values   = ["myservice"]
+      negated  = false
     }
+
+    variable_override {
+      property         = "region"
+      values           = ["us-west1"]
+      values_suggested = ["us-west-1", "us-east-1"]
+    }
+  }
 }
 ```
 

--- a/website/docs/r/data_link.html.markdown
+++ b/website/docs/r/data_link.html.markdown
@@ -12,35 +12,35 @@ Manage SignalFx [Data Links](https://docs.signalfx.com/en/latest/managing/data-l
 
 ## Example Usage
 
-```terraform
+```tf
 # A global link to SignalFx dashboard.
 resource "signalfx_data_link" "my_data_link" {
-    property_name = "pname"
-    property_value = "pvalue"
+  property_name  = "pname"
+  property_value = "pvalue"
 
-    target_signalfx_dashboard {
-      is_default = true
-      name = "sfx_dash"
-			dashboard_group_id = signalfx_dashboard_group.mydashboardgroup0.id
-			dashboard_id = signalfx_dashboard.mydashboard0.id
-    }
+  target_signalfx_dashboard {
+    is_default         = true
+    name               = "sfx_dash"
+    dashboard_group_id = signalfx_dashboard_group.mydashboardgroup0.id
+    dashboard_id       = signalfx_dashboard.mydashboard0.id
+  }
 }
 
 # A dashboard-specific link to an external URL
 resource "signalfx_data_link" "my_data_link_dash" {
-		context_dashboard_id = signalfx_dashboard.mydashboard0.id
-    property_name = "pname2"
-    property_value = "pvalue"
+  context_dashboard_id = signalfx_dashboard.mydashboard0.id
+  property_name        = "pname2"
+  property_value       = "pvalue"
 
-    target_external_url {
-			is_default = false
-      name = "ex_url"
-      time_format = "ISO8601"
-      url = "https://www.example.com"
-      property_key_mapping = {
-        foo = "bar"
-      }
+  target_external_url {
+    is_default  = false
+    name        = "ex_url"
+    time_format = "ISO8601"
+    url         = "https://www.example.com"
+    property_key_mapping = {
+      foo = "bar"
     }
+  }
 }
 ```
 

--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -14,43 +14,43 @@ Provides a SignalFx detector resource. This can be used to create and manage det
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_detector" "application_delay" {
-    count = length(var.clusters)
+  count = length(var.clusters)
 
-    name = " max average delay - ${var.clusters[count.index]}"
-    description = "your application is slow - ${var.clusters[count.index]}"
-    max_delay = 30
+  name        = " max average delay - ${var.clusters[count.index]}"
+  description = "your application is slow - ${var.clusters[count.index]}"
+  max_delay   = 30
 
-    # Note that if you use these features, you must use a user's
-    # admin key to authenticate the provider, lest Terraform not be able
-    # to modify the detector in the future!
-    authorized_writer_teams = [ signalfx_team.mycoolteam.id ]
-    authorized_writer_users = [ "abc123" ]
+  # Note that if you use these features, you must use a user's
+  # admin key to authenticate the provider, lest Terraform not be able
+  # to modify the detector in the future!
+  authorized_writer_teams = [signalfx_team.mycoolteam.id]
+  authorized_writer_users = ["abc123"]
 
-    program_text = <<-EOF
+  program_text = <<-EOF
         signal = data('app.delay', filter('cluster','${var.clusters[count.index]}'), extrapolation='last_value', maxExtrapolations=5).max()
         detect(when(signal > 60, '5m')).publish('Processing old messages 5m')
         detect(when(signal > 60, '30m')).publish('Processing old messages 30m')
     EOF
-    rule {
-        description = "maximum > 60 for 5m"
-        severity = "Warning"
-        detect_label = "Processing old messages 5m"
-        notifications = ["Email,foo-alerts@bar.com"]
-    }
-    rule {
-        description = "maximum > 60 for 30m"
-        severity = "Critical"
-        detect_label = "Processing old messages 30m"
-        notifications = ["Email,foo-alerts@bar.com"]
-    }
+  rule {
+    description   = "maximum > 60 for 5m"
+    severity      = "Warning"
+    detect_label  = "Processing old messages 5m"
+    notifications = ["Email,foo-alerts@bar.com"]
+  }
+  rule {
+    description   = "maximum > 60 for 30m"
+    severity      = "Critical"
+    detect_label  = "Processing old messages 30m"
+    notifications = ["Email,foo-alerts@bar.com"]
+  }
 }
 
 provider "signalfx" {}
 
 variable "clusters" {
-    default = ["clusterA", "clusterB"]
+  default = ["clusterA", "clusterB"]
 }
 ```
 

--- a/website/docs/r/event_feed_chart.html.markdown
+++ b/website/docs/r/event_feed_chart.html.markdown
@@ -12,16 +12,16 @@ Displays a listing of events as a widget in a dashboard.
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_event_feed_chart" "mynote0" {
-    name = "Important Dashboard Note"
-    description = "Lorem ipsum dolor sit amet"
-    program_text = "A = events(eventType='Fart Testing').publish(label='A')"
+  name         = "Important Dashboard Note"
+  description  = "Lorem ipsum dolor sit amet"
+  program_text = "A = events(eventType='Fart Testing').publish(label='A')"
 
-    viz_options {
-        label = "A"
-        color = "orange"
-    }
+  viz_options {
+    label = "A"
+    color = "orange"
+  }
 }
 ```
 

--- a/website/docs/r/gcp_integration.html.markdown
+++ b/website/docs/r/gcp_integration.html.markdown
@@ -14,20 +14,20 @@ SignalFx GCP Integration
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_gcp_integration" "gcp_myteam" {
-    name = "GCP - My Team"
-    enabled = true
-    poll_rate = 300000
-    services = ["compute"]
-    project_service_keys {
-        project_id = "gcp_project_id_1"
-        project_key = "${file("/path/to/gcp_credentials_1.json")}"
-    }
-    project_service_keys {
-        project_id = "gcp_project_id_2"
-        project_key = "${file("/path/to/gcp_credentials_2.json")}"
-    }
+  name      = "GCP - My Team"
+  enabled   = true
+  poll_rate = 300000
+  services  = ["compute"]
+  project_service_keys {
+    project_id  = "gcp_project_id_1"
+    project_key = "${file("/path/to/gcp_credentials_1.json")}"
+  }
+  project_service_keys {
+    project_id  = "gcp_project_id_2"
+    project_key = "${file("/path/to/gcp_credentials_2.json")}"
+  }
 }
 ```
 

--- a/website/docs/r/heatmap_chart.html.markdown
+++ b/website/docs/r/heatmap_chart.html.markdown
@@ -12,42 +12,42 @@ This chart type displays the specified plot in a heatmap fashion. This format is
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_heatmap_chart" "myheatmapchart0" {
-    name = "CPU Total Idle - Heatmap"
+  name = "CPU Total Idle - Heatmap"
 
-    program_text = <<-EOF
+  program_text = <<-EOF
         myfilters = filter("cluster_name", "prod") and filter("role", "search")
         data("cpu.total.idle", filter=myfilters).publish()
         EOF
 
-    description = "Very cool Heatmap"
+  description = "Very cool Heatmap"
 
-    disable_sampling = true
-    sort_by = "+host"
-    group_by = ["hostname", "host"]
-    hide_timestamp = true
+  disable_sampling = true
+  sort_by          = "+host"
+  group_by         = ["hostname", "host"]
+  hide_timestamp   = true
 
-    color_range {
-        min_value = 0
-        max_value = 100
-        color = "#ff0000"
-    }
+  color_range {
+    min_value = 0
+    max_value = 100
+    color     = "#ff0000"
+  }
 
-    # You can only use one of color_range or color_scale!
-    color_scale {
-        gte = 99
-	color = "green"
-    }
-    color_scale {
-        lt = 99 # This ensures terraform recognizes that we cover the range 95-99
-        gte = 95
-	color = "yellow"
-    }
-    color_scale {
-        lt = 95
-	color = "red"
-    }
+  # You can only use one of color_range or color_scale!
+  color_scale {
+    gte   = 99
+    color = "green"
+  }
+  color_scale {
+    lt    = 99 # This ensures terraform recognizes that we cover the range 95-99
+    gte   = 95
+    color = "yellow"
+  }
+  color_scale {
+    lt    = 95
+    color = "red"
+  }
 }
 ```
 

--- a/website/docs/r/jira_integration.html.markdown
+++ b/website/docs/r/jira_integration.html.markdown
@@ -14,26 +14,26 @@ SignalFx Jira integrations. For help with this integration see [Integration with
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_jira_integration" "jira_myteamXX" {
-    name = "JiraFoo"
-    enabled = false
+  name    = "JiraFoo"
+  enabled = false
 
-    auth_method = "UsernameAndPassword"
-    username = "yoosername"
-    password = "paasword"
+  auth_method = "UsernameAndPassword"
+  username    = "yoosername"
+  password    = "paasword"
 
-    # Or…
-    auth_method = "EmailAndToken"
-    user_email = "yoosername@example.com"
-    api_token = "abc123"
+  # Or…
+  #auth_method = "EmailAndToken"
+  #user_email = "yoosername@example.com"
+  #api_token = "abc123"
 
-    assignee_name = "testytesterson"
-    assignee_display_name = "Testy Testerson"
+  assignee_name         = "testytesterson"
+  assignee_display_name = "Testy Testerson"
 
-    base_url = "https://www.example.com"
-    issue_type = "Story"
-    project_key = "TEST"
+  base_url    = "https://www.example.com"
+  issue_type  = "Story"
+  project_key = "TEST"
 }
 ```
 

--- a/website/docs/r/list_chart.html.markdown
+++ b/website/docs/r/list_chart.html.markdown
@@ -15,46 +15,46 @@ The name of each value in the chart reflects the name of the plot and any associ
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_list_chart" "mylistchart0" {
-    name = "CPU Total Idle - List"
+  name = "CPU Total Idle - List"
 
-    program_text = <<-EOF
+  program_text = <<-EOF
     myfilters = filter("cluster_name", "prod") and filter("role", "search")
     data("cpu.total.idle", filter=myfilters).publish()
     EOF
 
-    description = "Very cool List Chart"
+  description = "Very cool List Chart"
 
-    color_by = "Metric"
-    max_delay = 2
-    disable_sampling = true
-    refresh_interval = 1
+  color_by         = "Metric"
+  max_delay        = 2
+  disable_sampling = true
+  refresh_interval = 1
 
-    legend_options_fields {
-      property = "collector"
-      enabled  = false
-    }
+  legend_options_fields {
+    property = "collector"
+    enabled  = false
+  }
 
-    legend_options_fields {
-      property = "cluster_name"
-      enabled = true
-    }
-    legend_options_fields {
-      property = "role"
-      enabled = true
-    }
-    legend_options_fields {
-      property = "collector"
-      enabled = false
-    }
-    legend_options_fields {
-      property = "host"
-      enabled = false
-    }
-    max_precision = 2
-    sort_by = "-value"
- }
+  legend_options_fields {
+    property = "cluster_name"
+    enabled  = true
+  }
+  legend_options_fields {
+    property = "role"
+    enabled  = true
+  }
+  legend_options_fields {
+    property = "collector"
+    enabled  = false
+  }
+  legend_options_fields {
+    property = "host"
+    enabled  = false
+  }
+  max_precision = 2
+  sort_by       = "-value"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/opsgenie_integration.html.markdown
+++ b/website/docs/r/opsgenie_integration.html.markdown
@@ -14,12 +14,12 @@ SignalFx Opsgenie integration.
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_opsgenie_integration" "opgenie_myteam" {
-    name = "Opsgenie - My Team"
-    enabled = true
-    api_key = "farts"
-    api_url = "https://api.opsgenie.com"
+  name    = "Opsgenie - My Team"
+  enabled = true
+  api_key = "farts"
+  api_url = "https://api.opsgenie.com"
 }
 ```
 

--- a/website/docs/r/org_token.html.markdown
+++ b/website/docs/r/org_token.html.markdown
@@ -12,22 +12,22 @@ Manage SignalFx org tokens.
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_org_token" "myteamkey0" {
-    name = "TeamIDKey"
-    description = "My team's rad key"
-    notifications = ["Email,foo-alerts@bar.com"]
+  name          = "TeamIDKey"
+  description   = "My team's rad key"
+  notifications = ["Email,foo-alerts@bar.com"]
 
-    host_or_usage_limits {
-      host_limit = 100
-      host_notification_threshold = 90
-      container_limit = 200
-      container_notification_threshold = 180
-      custom_metrics_limit = 1000
-      custom_metrics_notification_threshold = 900
-      high_res_metrics_limit = 1000
-      high_res_metrics_notification_threshold = 900
-    }
+  host_or_usage_limits {
+    host_limit                              = 100
+    host_notification_threshold             = 90
+    container_limit                         = 200
+    container_notification_threshold        = 180
+    custom_metrics_limit                    = 1000
+    custom_metrics_notification_threshold   = 900
+    high_res_metrics_limit                  = 1000
+    high_res_metrics_notification_threshold = 900
+  }
 }
 ```
 

--- a/website/docs/r/pagerduty_integration.html.markdown
+++ b/website/docs/r/pagerduty_integration.html.markdown
@@ -14,11 +14,11 @@ SignalFx PagerDuty integrations
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_pagerduty_integration" "pagerduty_myteam" {
-    name = "PD - My Team"
-    enabled = true
-    api_key = "1234567890"
+  name    = "PD - My Team"
+  enabled = true
+  api_key = "1234567890"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/single_value_chart.html.markdown
+++ b/website/docs/r/single_value_chart.html.markdown
@@ -14,23 +14,23 @@ If the time period is in the past, the number represents the value of the metric
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_single_value_chart" "mysvchart0" {
-    name = "CPU Total Idle - Single Value"
+  name = "CPU Total Idle - Single Value"
 
-    program_text = <<-EOF
+  program_text = <<-EOF
         myfilters = filter("cluster_name", "prod") and filter("role", "search")
         data("cpu.total.idle", filter=myfilters).publish()
         EOF
 
-    description = "Very cool Single Value Chart"
+  description = "Very cool Single Value Chart"
 
-    color_by = "Dimension"
+  color_by = "Dimension"
 
-    max_delay = 2
-    refresh_interval = 1
-    max_precision = 2
-    is_timestamp_hidden = true
+  max_delay           = 2
+  refresh_interval    = 1
+  max_precision       = 2
+  is_timestamp_hidden = true
 }
 ```
 

--- a/website/docs/r/slack_integration.html.markdown
+++ b/website/docs/r/slack_integration.html.markdown
@@ -14,11 +14,11 @@ SignalFx Slack integration.
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_slack_integration" "slack_myteam" {
-    name = "Slack - My Team"
-    enabled = true
-    webhook_url = "http://example.com"
+  name        = "Slack - My Team"
+  enabled     = true
+  webhook_url = "http://example.com"
 }
 ```
 

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -14,20 +14,24 @@ You can configure [team notification policies](https://docs.signalfx.com/en/late
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_team" "myteam0" {
-    name = "Best Team Ever"
-    description = "Super great team no jerks definitely"
+  name        = "Best Team Ever"
+  description = "Super great team no jerks definitely"
 
-    members = [ "userid1", "userid2", …]
+  members = [
+    "userid1",
+    "userid2",
+    # …
+  ]
 
-    notifications_critical = [
-      "PagerDuty,credentialId"
-    ]
+  notifications_critical = [
+    "PagerDuty,credentialId"
+  ]
 
-    notifications_info = [
-      "Email,notify@example.com"
-    ]
+  notifications_info = [
+    "Email,notify@example.com"
+  ]
 }
 ```
 

--- a/website/docs/r/text_chart.html.markdown
+++ b/website/docs/r/text_chart.html.markdown
@@ -12,12 +12,12 @@ This special type of chart doesn’t display any metric data. Rather, it lets yo
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_text_chart" "mynote0" {
-    name = "Important Dashboard Note"
-    description = "Lorem ipsum dolor sit amet, laudem tibique iracundia at mea. Nam posse dolores ex, nec cu adhuc putent honestatis"
+  name        = "Important Dashboard Note"
+  description = "Lorem ipsum dolor sit amet, laudem tibique iracundia at mea. Nam posse dolores ex, nec cu adhuc putent honestatis"
 
-    markdown = <<-EOF
+  markdown = <<-EOF
     1. First ordered list item
     2. Another item
       * Unordered sub-list.

--- a/website/docs/r/time_chart.html.markdown
+++ b/website/docs/r/time_chart.html.markdown
@@ -14,38 +14,38 @@ Time charts display data points over a period of time.
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_time_chart" "mychart0" {
-    name = "CPU Total Idle"
+  name = "CPU Total Idle"
 
-    program_text = <<-EOF
+  program_text = <<-EOF
         data("cpu.total.idle").publish(label="CPU Idle")
         EOF
 
-    time_range = 3600
+  time_range = 3600
 
-    plot_type = "LineChart"
-    show_data_markers = true
+  plot_type         = "LineChart"
+  show_data_markers = true
 
-    legend_options_fields {
-      property = "collector"
-      enabled = false
-    }
-    legend_options_fields {
-      property = "hostname"
-      enabled = false
-    }
+  legend_options_fields {
+    property = "collector"
+    enabled  = false
+  }
+  legend_options_fields {
+    property = "hostname"
+    enabled  = false
+  }
 
-    viz_options {
-        label = "CPU Idle"
-        axis = "left"
-        color = "orange"
-    }
+  viz_options {
+    label = "CPU Idle"
+    axis  = "left"
+    color = "orange"
+  }
 
-    axis_left {
-        label = "CPU Total Idle"
-        low_watermark = 1000
-    }
+  axis_left {
+    label         = "CPU Total Idle"
+    low_watermark = 1000
+  }
 }
 ```
 

--- a/website/docs/r/victor_ops_integration.html.markdown
+++ b/website/docs/r/victor_ops_integration.html.markdown
@@ -14,11 +14,11 @@ SignalFx VictorOps integration.
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_victor_ops_resource" "vioctor_ops_myteam" {
-    name = "VictorOps - My Team"
-    enabled = true
-    post_url = "https://alert.victorops.com/integrations/generic/1234/alert/$key/$routing_key"
+  name     = "VictorOps - My Team"
+  enabled  = true
+  post_url = "https://alert.victorops.com/integrations/generic/1234/alert/$key/$routing_key"
 }
 ```
 

--- a/website/docs/r/webhook_integration.html.markdown
+++ b/website/docs/r/webhook_integration.html.markdown
@@ -14,17 +14,17 @@ SignalFx Webhook integration.
 
 ## Example Usage
 
-```terraform
+```tf
 resource "signalfx_webhook_resource" "webhook_myteam" {
-    name = "Webhook - My Team"
-    enabled = true
-    url = "https://www.example.com"
-    shared_secret = "abc1234"
+  name          = "Webhook - My Team"
+  enabled       = true
+  url           = "https://www.example.com"
+  shared_secret = "abc1234"
 
-    headers {
-      header_key = "some_header"
-      header_value = "value_for_that_header"
-    }
+  headers {
+    header_key   = "some_header"
+    header_value = "value_for_that_header"
+  }
 }
 ```
 


### PR DESCRIPTION
[terrafmt](https://github.com/katbyte/terrafmt) allows to format terraform configuration blocks embedded in code and documentation.

Usage:
```sh
terrafmt fmt website/
```