### PR TITLE
Bump SFx-go for package specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * provider: Bumped signalfx-go dependency which requires the use of `context.Context` in many client calls. No material change otherwise.
 * provider: Various doc improvements around formatting, syntax, and more. Thanks [@pdecat](https://github.com/pdecat)! [#217](https://github.com/terraform-providers/terraform-provider-signalfx/pull/217)
+* provider/detector: Now sets the `packageSpecifications` field to an empty string, which is an API requirement for some advanced program text use cases. [#220](https://github.com/terraform-providers/terraform-provider-signalfx/pull/220)
 
 ## 4.23.0 (June 02, 2020)
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/terraform-plugin-sdk v1.11.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.7.0
+	github.com/signalfx/signalfx-go v1.7.2
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.7.0 h1:a0Wvl0QtNn7728C7tjiJeptPATBrkN1rcOwcHQ//vuY=
-github.com/signalfx/signalfx-go v1.7.0/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.7.2 h1:nnYqXyuo95K4BjWM8TkVS32gwkCa8Lf7BoTUpaGcHBg=
+github.com/signalfx/signalfx-go v1.7.2/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac h1:wbW+Bybf9pXxnCFAOWZTqkRjAc7rAIwo2e1ArUhiHxg=

--- a/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
+++ b/vendor/github.com/signalfx/signalfx-go/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.1, 2020-06-10
+* Added `packageSpecifications` field to Detector`
+
 # 1.7.0, 2020-06-02
 
 * Added contexts to everything, switch to `NewRequestWithContext` for HTTP.

--- a/vendor/github.com/signalfx/signalfx-go/detector/model_create_detector_request.go
+++ b/vendor/github.com/signalfx/signalfx-go/detector/model_create_detector_request.go
@@ -19,6 +19,8 @@ type CreateUpdateDetectorRequest struct {
 	MaxDelay *int32 `json:"maxDelay,omitempty"`
 	// The displayed name of the detector in the dashboard
 	Name string `json:"name,omitempty"`
+	// The package spec. Should default to "" so is not `omitempty`
+	PackageSpecification string `json:"packageSpecifications"`
 	// The SignalFlow program that populates the detector. The program must include one or more detect functions and each detect function must be modified by a publish stream method with a label that's unique across the program. If you wish to support custom notification messages that include input data you must use variables to assign the detect conditions . If more than one line of SignalFlow is included, each line should be separated by either semicolons (\";\") or new line characters (\"\\n\"). See the [Detectors Overview](https://developers.signalfx.com/v2/reference.html#detectors-overview) for more information.
 	ProgramText string `json:"programText,omitempty"`
 	// An array of *rules* that define aspects of an alert. These include the alert\\'s severity and the specification of how notifications are sent when the alert is triggered. Each rule is connected to a specific detect function in the programText property by the value of the label in its publish method. The connection is to a set of one or more notification directives and an severity indicator. A single condition can be used in multiple rules if different severity indicators are desired for different notification methods. <p> To see the properties for a rule, expand the definition of the rules array. What you see is the \"rules\" object that specifies a single rule.

--- a/vendor/github.com/signalfx/signalfx-go/detector/model_detector.go
+++ b/vendor/github.com/signalfx/signalfx-go/detector/model_detector.go
@@ -34,6 +34,8 @@ type Detector struct {
 	Name string `json:"name,omitempty"`
 	// If true one, or more statements in the detector matched too many time series and the matched set was forcefully limited. In this case, the detector is most likely looking at incomplete data or an incomplete aggregation. If this flag is set to true, you can use a series of partition_filter functions to split the data set into manageable pieces then use the union function to rejoin the results in a subsequent computation. Note that the union function still observes the time series limit; some type of aggregation on the partial streams must limit the data set prior to recombining the streams for this approach to work.
 	OverMTSLimit bool `json:"overMTSLimit,omitempty"`
+	// The package spec. Should default to "" so is not `omitempty`
+	PackageSpecification string `json:"packageSpecifications"`
 	// The SignalFlow program that populates the detector. The program must include one or more detect functions and each detect function must be modified by a publish stream method with a label that's unique across the program. If you wish to support custom notification messages that include input data you must use variables to assign the detect conditions . If more than one line of SignalFlow is included, each line should be separated by either semicolons (\";\") or new line characters (\"\\n\"). See the [Detectors Overview](https://developers.signalfx.com/v2/reference.html#detectors-overview) for more information.
 	ProgramText string  `json:"programText,omitempty"`
 	Rules       []*Rule `json:"rules,omitempty"`

--- a/vendor/github.com/signalfx/signalfx-go/detector/model_validate_detector_request_model.go
+++ b/vendor/github.com/signalfx/signalfx-go/detector/model_validate_detector_request_model.go
@@ -18,6 +18,8 @@ type ValidateDetectorRequestModel struct {
 	MaxDelay int32 `json:"maxDelay,omitempty"`
 	// The displayed name of the detector in the dashboard
 	Name string `json:"name,omitempty"`
+	// The package spec. Should default to "" so is not `omitempty`
+	PackageSpecification string `json:"packageSpecifications"`
 	// The SignalFlow program that populates the detector. The program must include one or more detect functions and each detect function must be modified by a publish stream method with a label that's unique across the program. If you wish to support custom notification messages that include input data you must use variables to assign the detect conditions . If more than one line of SignalFlow is included, each line should be separated by either semicolons (\";\") or new line characters (\"\\n\"). See the [Detectors Overview](https://developers.signalfx.com/v2/reference.html#detectors-overview) for more information.
 	ProgramText string `json:"programText,omitempty"`
 	// An array of *rules* that define aspects of an alert. These include the alert\\'s severity and the specification of how notifications are sent when the alert is triggered. Each rule is connected to a specific detect function in the programText property by the value of the label in its publish method. The connection is to a set of one or more notification directives and an severity indicator. A single condition can be used in multiple rules if different severity indicators are desired for different notification methods. <p> To see the properties for a rule, expand the definition of the rules array. What you see is the \"rules\" object that specifies a single rule.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -217,7 +217,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.7.0
+# github.com/signalfx/signalfx-go v1.7.2
 ## explicit
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting


### PR DESCRIPTION
# Summary
Bump SFx-go dep.

# Motivation
Allows us to send an empty `packageSpecifications` field, which is what the API expects versus the current missing field.