### PR TITLE
Adjust user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 4.24.0 (Unreleased)
+## 4.23.2 (Unreleased)
+
+IMPROVEMENTS:
+* provider: Adjusted the HTTP User-Agent supplied by the provider when making API calls. [#221](https://github.com/terraform-providers/terraform-provider-signalfx/pull/221)
+
 ## 4.23.1 (June 10, 2020)
 
 IMPROVEMENTS:

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -158,6 +158,9 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 	})
 
 	pv := version.ProviderVersion
+	// This U-A prefix is hardcoded (rather than using some programmatic accessor)
+	// because doing so fixes #208, a slow down in HTTP POSTs for dashboards.
+	// Might be safe to remove later.
 	providerUserAgent := fmt.Sprintf("Go-http-client/1.1 Terraform/%s terraform-provider-signalfx/%s", sfxProvider.TerraformVersion, pv)
 
 	totalTimeoutSeconds := data.Get("timeout_seconds").(int)

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -158,7 +158,7 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 	})
 
 	pv := version.ProviderVersion
-	providerUserAgent := fmt.Sprintf("Terraform/%s terraform-provider-signalfx/%s", sfxProvider.TerraformVersion, pv)
+	providerUserAgent := fmt.Sprintf("Go-http-client/1.1 Terraform/%s terraform-provider-signalfx/%s", sfxProvider.TerraformVersion, pv)
 
 	totalTimeoutSeconds := data.Get("timeout_seconds").(int)
 	log.Printf("[DEBUG] SignalFx: HTTP Timeout is %d seconds", totalTimeoutSeconds)


### PR DESCRIPTION
# Summary
Adjust the user agent to include the standard Go string.

# Motivation
It's bloody magic. For some reason this makes it ridiculously faster and fixes #208 