### PR TITLE
Move named_token on aws_integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.25.0 (August 4, 2020)
+
+BUGFIXES:
+* resource/aws_integration: Moved `named_token` to `signalfx_aws_integration`. [#231](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/231)
+
 ## 4.24.0 (July 28, 2020)
 
 FEATURES:

--- a/signalfx/resource_signalfx_aws_external_integration.go
+++ b/signalfx/resource_signalfx_aws_external_integration.go
@@ -32,12 +32,6 @@ func integrationAWSExternalResource() *schema.Resource {
 				Sensitive:   true,
 				Description: "The SignalFx AWS account ID to use with an AWS role.",
 			},
-			"named_token": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "A named token to use for ingest",
-				ForceNew:    true,
-			},
 		},
 
 		Create: integrationAWSExternalCreate,
@@ -78,10 +72,6 @@ func integrationAWSExternalRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	if err := d.Set("named_token", int.NamedToken); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -94,10 +84,6 @@ func getPayloadAWSExternalIntegration(d *schema.ResourceData) (*integration.AwsC
 		AuthMethod: integration.EXTERNAL_ID,
 		Name:       d.Get("name").(string),
 		PollRate:   &defaultPollRate,
-	}
-
-	if val, ok := d.GetOk("named_token"); ok {
-		aws.NamedToken = val.(string)
 	}
 
 	return aws, nil

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -179,8 +179,9 @@ func integrationAWSResource() *schema.Resource {
 			},
 			"named_token": &schema.Schema{
 				Type:        schema.TypeString,
-				Computed:    true,
+				Optional:    true,
 				Description: "A named token to use for ingest",
+				ForceNew:    true,
 			},
 		},
 

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -177,6 +177,12 @@ func integrationAWSResource() *schema.Resource {
 				Default:     false,
 				Description: "Enables the use of Amazon's GetMetricData API. Defaults to `false`.",
 			},
+			"named_token": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A named token to use for ingest",
+				ForceNew:    true,
+			},
 		},
 
 		Create: integrationAWSCreate,
@@ -250,6 +256,9 @@ func awsIntegrationAPIToTF(d *schema.ResourceData, aws *integration.AwsCloudWatc
 		return err
 	}
 	if err := d.Set("use_get_metric_data_method", aws.UseGetMetricDataMethod); err != nil {
+		return err
+	}
+	if err := d.Set("named_token", aws.NamedToken); err != nil {
 		return err
 	}
 
@@ -412,6 +421,10 @@ func getPayloadAWSIntegration(d *schema.ResourceData) (*integration.AwsCloudWatc
 			}
 			aws.Services = services
 		}
+	}
+
+	if val, ok := d.GetOk("named_token"); ok {
+		aws.NamedToken = val.(string)
 	}
 
 	return aws, nil

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -179,9 +179,8 @@ func integrationAWSResource() *schema.Resource {
 			},
 			"named_token": &schema.Schema{
 				Type:        schema.TypeString,
-				Optional:    true,
+				Computed:    true,
 				Description: "A named token to use for ingest",
-				ForceNew:    true,
 			},
 		},
 

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -181,7 +181,6 @@ func integrationAWSResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "A named token to use for ingest",
-				ForceNew:    true,
 			},
 		},
 

--- a/signalfx/resource_signalfx_aws_token_integration.go
+++ b/signalfx/resource_signalfx_aws_token_integration.go
@@ -32,12 +32,6 @@ func integrationAWSTokenResource() *schema.Resource {
 				Sensitive:   true,
 				Description: "The SignalFx AWS account ID to use with an AWS role.",
 			},
-			"named_token": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "A named token to use for ingest",
-				ForceNew:    true,
-			},
 		},
 
 		Create: integrationAWSTokenCreate,
@@ -83,10 +77,6 @@ func getPayloadAWSTokenIntegration(d *schema.ResourceData) (*integration.AwsClou
 		PollRate:   &defaultPollRate,
 	}
 
-	if val, ok := d.GetOk("named_token"); ok {
-		aws.NamedToken = val.(string)
-	}
-
 	return aws, nil
 }
 
@@ -112,9 +102,6 @@ func integrationAWSTokenCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	if err := d.Set("signalfx_aws_account", int.SfxAwsAccountArn); err != nil {
-		return err
-	}
-	if err := d.Set("named_token", int.NamedToken); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Summary
Fix #230 

# Motivation
The interplay between `aws_*_integration` and `aws_integration` are to accommodate the returned `external_id`. Putting `named_token` on external/token was a mistake, as it needs to be a part of the larger integration represented by `aws_integration`. This made sense when first added, as we didn't really support updating the value. That's changed, so we should move it to the proper place.

# Note
This is a breaking change, but the field is undocumented and anyone using it will see the change explicitly as an error.