### PR TITLE
Don't set start/end time if time_range is already there.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.26.3 (August 10, 2020)
+
+BUGFIXEDS:
+* resources/detector: Only "set" a start/end time when there isn't a time range. Fixes conflicting options on import of detectors. [#238](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/238)
+
 ## 4.26.2 (August 10, 2020)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.26.3 (August 10, 2020)
 
-BUGFIXEDS:
+BUGFIXES:
 * resources/detector: Only "set" a start/end time when there isn't a time range. Fixes conflicting options on import of detectors. [#238](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/238)
 
 ## 4.26.2 (August 10, 2020)

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -539,12 +539,14 @@ func detectorAPIToTF(d *schema.ResourceData, det *detector.Detector) error {
 				if err := d.Set("time_range", *tr.Range/1000); err != nil {
 					return err
 				}
-			}
-			if err := d.Set("start_time", tr.Start); err != nil {
-				return err
-			}
-			if err := d.Set("end_time", tr.End); err != nil {
-				return err
+			} else {
+				// Only set start/end if we didn't have a range
+				if err := d.Set("start_time", tr.Start); err != nil {
+					return err
+				}
+				if err := d.Set("end_time", tr.End); err != nil {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes an issue with detector imports failing to work due to conflicting options.