### PR TITLE
Put back old UA now that API is ok with it.

### DIFF
--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -158,10 +158,7 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 	})
 
 	pv := version.ProviderVersion
-	// This U-A prefix is hardcoded (rather than using some programmatic accessor)
-	// because doing so fixes #208, a slow down in HTTP POSTs for dashboards.
-	// Might be safe to remove later.
-	providerUserAgent := fmt.Sprintf("Go-http-client/1.1 Terraform/%s terraform-provider-signalfx/%s", sfxProvider.TerraformVersion, pv)
+	providerUserAgent := fmt.Sprintf("Terraform/%s terraform-provider-signalfx/%s", sfxProvider.TerraformVersion, pv)
 
 	totalTimeoutSeconds := data.Get("timeout_seconds").(int)
 	log.Printf("[DEBUG] SignalFx: HTTP Timeout is %d seconds", totalTimeoutSeconds)


### PR DESCRIPTION
# Summary
Put user agent back to older version

# Motivation
In #221 the User-Agent was changed such that the API no longer took overly long to create dashboards with large numbers of charts. The API has been adjusted to make this change unnecessary, so we'll adjust to a more informative, accurate user agent again.