### PR TITLE
Remove teams from dashboard_group and detectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## 5.0.0 (September 10, 2020)
 
 BREAKING CHANGES:
-* resource/dashboard_group: The field `teams` have been removed, please use the `team` resource's `dashboard_groups` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
-* resource/detector: The field `teams` has been removed, please use the `team` resource's `detectors` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
+* resource/dashboard_group: The field `teams` have been removed, please use the `team` resource's `dashboard_groups` argument. [#244](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/244)
+* resource/detector: The field `teams` has been removed, please use the `team` resource's `detectors` argument. [#244](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/244)
 
 IMPROVEMENTS:
-* resource/team: The new arguments `detectors` and `dashboard_groups` have been added. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
+* resource/team: The new arguments `detectors` and `dashboard_groups` have been added. [#244](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/244)
 
 ## 4.26.4 (August 11, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.27.0 (August 8, 2020)
+
+DEPRECATIONS:
+* resource/dashboard_group: The field `teams` have been removed, please use the `dashboard_group` resource's `dashboard_groups` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
+* resource/detector: The field `team` has been deprecated, please use the `dashboard_group` resource's `detectors` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
+
+IMPROVEMENTS:
+* resource/team: The new arguments `detectors` and `dashboard_groups` have been added. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
+
 ## 4.26.4 (August 11, 2020)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 DEPRECATIONS:
 * resource/dashboard_group: The field `teams` have been removed, please use the `dashboard_group` resource's `dashboard_groups` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
-* resource/detector: The field `team` has been deprecated, please use the `dashboard_group` resource's `detectors` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
+* resource/detector: The field `team` has been removed, please use the `dashboard_group` resource's `detectors` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
 
 IMPROVEMENTS:
 * resource/team: The new arguments `detectors` and `dashboard_groups` have been added. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 4.27.0 (August 8, 2020)
+## 5.0.0 (September 10, 2020)
 
-DEPRECATIONS:
-* resource/dashboard_group: The field `teams` have been removed, please use the `dashboard_group` resource's `dashboard_groups` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
-* resource/detector: The field `team` has been removed, please use the `dashboard_group` resource's `detectors` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
+BREAKING CHANGES:
+* resource/dashboard_group: The field `teams` have been removed, please use the `team` resource's `dashboard_groups` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
+* resource/detector: The field `teams` has been removed, please use the `team` resource's `detectors` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
 
 IMPROVEMENTS:
 * resource/team: The new arguments `detectors` and `dashboard_groups` have been added. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,6 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/mitchellh/go-homedir v1.1.0
-<<<<<<< HEAD
 	github.com/signalfx/signalfx-go v1.7.10
-=======
-	github.com/signalfx/signalfx-go v1.7.8-0.20200804172754-67ea488cfb33
->>>>>>> Version bump for new team methods
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,10 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/mitchellh/go-homedir v1.1.0
+<<<<<<< HEAD
 	github.com/signalfx/signalfx-go v1.7.10
+=======
+	github.com/signalfx/signalfx-go v1.7.8-0.20200804172754-67ea488cfb33
+>>>>>>> Version bump for new team methods
 	github.com/stretchr/testify v1.4.0
 )

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -26,7 +26,7 @@ func dashboardGroupResource() *schema.Resource {
 			"teams": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated:  "TKTK",
+				Deprecated: "Setting the teams in a dashboard group has been deprecated, please see the team resource's detectors argument."
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the dashboard group to",
 			},

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -23,13 +23,6 @@ func dashboardGroupResource() *schema.Resource {
 				Optional:    true,
 				Description: "Description of the dashboard group",
 			},
-			"teams": &schema.Schema{
-				Type:        schema.TypeList,
-				Optional:    true,
-				Deprecated: "Setting the teams in a dashboard group has been deprecated, please see the team resource's detectors argument."
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "Team IDs to associate the dashboard group to",
-			},
 			"dashboard": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -189,14 +182,6 @@ func getPayloadDashboardGroup(d *schema.ResourceData) *dashboard_group.CreateUpd
 		Name:              d.Get("name").(string),
 		Description:       d.Get("description").(string),
 		AuthorizedWriters: &dashboard_group.AuthorizedWriters{},
-	}
-
-	if val, ok := d.GetOk("teams"); ok {
-		teams := []string{}
-		for _, t := range val.([]interface{}) {
-			teams = append(teams, t.(string))
-		}
-		cudgr.Teams = teams
 	}
 
 	if val, ok := d.GetOk("authorized_writer_teams"); ok {
@@ -372,9 +357,6 @@ func dashboardGroupAPIToTF(d *schema.ResourceData, dg *dashboard_group.Dashboard
 		return err
 	}
 	if err := d.Set("description", dg.Description); err != nil {
-		return err
-	}
-	if err := d.Set("teams", dg.Teams); err != nil {
 		return err
 	}
 

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -26,6 +26,7 @@ func dashboardGroupResource() *schema.Resource {
 			"teams": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
+				Deprecated:  "TKTK",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the dashboard group to",
 			},

--- a/signalfx/resource_signalfx_dashboard_group_dashboard_configs_test.go
+++ b/signalfx/resource_signalfx_dashboard_group_dashboard_configs_test.go
@@ -18,7 +18,6 @@ resource "signalfx_time_chart" "mytimechartX0" {
 resource "signalfx_dashboard_group" "mydashboardgroupX0" {
     name = "My team dashboard group"
     description = "Cool dashboard group"
-		// No teams test cuz there's no teams resource yet!
 }
 
 resource "signalfx_dashboard" "mydashboardX0" {

--- a/signalfx/resource_signalfx_dashboard_test.go
+++ b/signalfx/resource_signalfx_dashboard_test.go
@@ -20,7 +20,6 @@ resource "signalfx_time_chart" "mytimechartX0" {
 resource "signalfx_dashboard_group" "mydashboardgroupX0" {
     name = "My team dashboard group"
     description = "Cool dashboard group"
-		// No teams test cuz there's no teams resource yet!
 }
 
 resource "signalfx_dashboard" "mydashboardX0" {

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -82,13 +82,6 @@ func detectorResource() *schema.Resource {
 				Description:   "Seconds since epoch. Used for visualization",
 				ValidateFunc:  validation.IntAtLeast(0),
 			},
-			"teams": &schema.Schema{
-				Type:        schema.TypeList,
-				Optional:    true,
-				Deprecated:  "Setting the team in a detector has been deprecated, please see the team resource's detectors argument.",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "Team IDs to associate the detector to",
-			},
 			"rule": &schema.Schema{
 				Type:        schema.TypeSet,
 				Required:    true,
@@ -342,14 +335,6 @@ func getPayloadDetector(d *schema.ResourceData) (*detector.CreateUpdateDetectorR
 
 	cudr.VisualizationOptions = getVisualizationOptionsDetector(d)
 
-	if val, ok := d.GetOk("teams"); ok {
-		teams := []string{}
-		for _, t := range val.([]interface{}) {
-			teams = append(teams, t.(string))
-		}
-		cudr.Teams = teams
-	}
-
 	return cudr, nil
 }
 
@@ -493,9 +478,6 @@ func detectorAPIToTF(d *schema.ResourceData, det *detector.Detector) error {
 		if err := d.Set("max_delay", *det.MaxDelay/1000); err != nil {
 			return err
 		}
-	}
-	if err := d.Set("teams", det.Teams); err != nil {
-		return err
 	}
 
 	if det.AuthorizedWriters != nil {

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -85,7 +85,7 @@ func detectorResource() *schema.Resource {
 			"teams": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated:  "TKTK",
+				Deprecated:  "Setting the team in a detector has been deprecated, please see the team resource's detectors argument.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the detector to",
 			},

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -85,6 +85,7 @@ func detectorResource() *schema.Resource {
 			"teams": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
+				Deprecated:  "TKTK",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the detector to",
 			},

--- a/signalfx/resource_signalfx_team.go
+++ b/signalfx/resource_signalfx_team.go
@@ -34,6 +34,18 @@ func teamResource() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Members of team",
 			},
+			"detectors": &schema.Schema{
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Detectors that belong to this team",
+			},
+			"dashboard_groups": &schema.Schema{
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Dashboard Groups that belong to this team",
+			},
 			"notifications_critical": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -123,6 +135,24 @@ func getPayloadTeam(d *schema.ResourceData) (*team.CreateUpdateTeamRequest, erro
 		}
 	}
 	t.Members = members
+
+	var dashboardGroups []string
+	if val, ok := d.GetOk("dashboard_groups"); ok {
+		tfValues := val.(*schema.Set).List()
+		for _, v := range tfValues {
+			dashboardGroups = append(dashboardGroups, v.(string))
+		}
+	}
+	t.DashboardGroups = dashboardGroups
+
+	var detectors []string
+	if val, ok := d.GetOk("detectors"); ok {
+		tfValues := val.(*schema.Set).List()
+		for _, v := range tfValues {
+			detectors = append(detectors, v.(string))
+		}
+	}
+	t.Detectors = detectors
 
 	if val, ok := d.GetOk("notifications_critical"); ok {
 		nots, err := getNotificationList(val.([]interface{}))
@@ -295,6 +325,26 @@ func teamAPIToTF(d *schema.ResourceData, t *team.Team) error {
 			members[i] = v
 		}
 		if err := d.Set("members", schema.NewSet(schema.HashString, members)); err != nil {
+			return err
+		}
+	}
+
+	if len(t.Detectors) > 0 {
+		detectors := make([]interface{}, len(t.Detectors))
+		for i, v := range t.Detectors {
+			detectors[i] = v
+		}
+		if err := d.Set("detectors", schema.NewSet(schema.HashString, detectors)); err != nil {
+			return err
+		}
+	}
+
+	if len(t.DashboardGroups) > 0 {
+		dashGroups := make([]interface{}, len(t.DashboardGroups))
+		for i, v := range t.DashboardGroups {
+			dashGroups[i] = v
+		}
+		if err := d.Set("dashboard_groups", schema.NewSet(schema.HashString, dashGroups)); err != nil {
 			return err
 		}
 	}

--- a/signalfx/resource_signalfx_team_test.go
+++ b/signalfx/resource_signalfx_team_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const newTeamConfig = `
+const (
+	newTeamConfig = `
 resource "signalfx_team" "myteamXX" {
     name = "Super Cool Team"
-		description = "Fart noise"
+	description = "Fart noise"
 
     notifications_critical = [ "Email,test@example.com" ]
     notifications_default = [ "Webhook,,secret,https://www.example.com" ]
@@ -23,10 +24,10 @@ resource "signalfx_team" "myteamXX" {
 }
 `
 
-const updatedTeamConfig = `
+	updatedTeamConfig = `
 resource "signalfx_team" "myteamXX" {
     name = "Super Cool Team NEW"
-		description = "Fart noise NEW"
+	description = "Fart noise NEW"
 
     notifications_critical = [ "Email,test@example.com" ]
     notifications_default = [ "Webhook,,secret,https://www.example.com" ]
@@ -36,6 +37,77 @@ resource "signalfx_team" "myteamXX" {
     notifications_warning = [ "Webhook,,secret,https://www.example.com/5" ]
 }
 `
+
+	teamWithDetector = `
+resource "signalfx_detector" "team_detector" {
+    name = "team detector"
+    description = "team detector"
+    max_delay = 30
+
+    program_text = <<-EOF
+        signal = data('app.delay').max().publish('app delay')
+        detect(when(signal > 60, '30m')).publish('Processing old messages 30m')
+	EOF
+    rule {
+        description = "maximum > 60 for 30m"
+        severity = "Critical"
+        detect_label = "Processing old messages 30m"
+        notifications = ["Email,foo-alerts@example.com"]
+    }
+}
+
+resource "signalfx_team" "team_with_detector" {
+	name = "Team with detector"
+	description = "Team with detector"
+	detectors = ["${signalfx_detector.team_detector.id}"]
+}
+`
+
+	teamWithDashboardGroup = `
+resource "signalfx_dashboard_group" "team_dashboard_group" {
+    name = "My team dashboard group"
+    description = "Cool dashboard group"
+}
+
+resource "signalfx_team" "team_with_dashboard_group" {
+	name = "Team with dashboard_group"
+	description = "Team with dashboard_group"
+	dashboard_groups = ["${signalfx_dashboard_group.team_dashboard_group.id}"]
+}
+`
+)
+
+func TestAccTeamWithDetector(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: teamWithDetector,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTeamResourceExists,
+					resource.TestCheckResourceAttr("signalfx_team.team_with_detector", "name", "Team with detector"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTeamWithDashboardGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: teamWithDashboardGroup,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTeamResourceExists,
+					resource.TestCheckResourceAttr("signalfx_team.team_with_dashboard_group", "name", "Team with dashboard_group"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccCreateUpdateTeam(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -87,6 +159,8 @@ func testAccCheckTeamResourceExists(s *terraform.State) error {
 			if team.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding team %s: %s", rs.Primary.ID, err)
 			}
+		case "signalfx_detector":
+		case "signalfx_dashboard_group":
 		default:
 			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
 		}
@@ -103,6 +177,8 @@ func testAccTeamDestroy(s *terraform.State) error {
 			if team != nil {
 				return fmt.Errorf("Found deleted team %s", rs.Primary.ID)
 			}
+		case "signalfx_detector":
+		case "signalfx_dashboard_group":
 		default:
 			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
 		}

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -25,6 +25,16 @@ resource "signalfx_team" "myteam0" {
     # …
   ]
 
+  detectors = [
+    "detectorId1",
+    "detectorId2",
+  ]
+
+  dashboard_groups = [
+    "dashboardGroupId1",
+    "dashboardGroupId2",
+  ]
+
   notifications_critical = [
     "PagerDuty,credentialId"
   ]
@@ -42,6 +52,8 @@ The following arguments are supported in the resource block:
 * `name` - (Required) Name of the team.
 * `description` - (Optional) Description of the team.
 * `members` - (Optional) List of user IDs to include in the team.
+* `detectors` - (Optional) List of detector IDs to include in the team.
+* `dashboardGroups` - (Optional) List of dashboard group IDs to include in the team.
 * `notifications_critical` - (Optional) Where to send notifications for critical alerts
 * `notifications_default` - (Optional) Where to send notifications for default alerts
 * `notifications_info` - (Optional) Where to send notifications for info alerts


### PR DESCRIPTION
BREAKING CHANGES:
* resource/dashboard_group: The field `teams` have been removed, please use the `team` resource's `dashboard_groups` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)
* resource/detector: The field `teams` has been removed, please use the `team` resource's `detectors` argument. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)

IMPROVEMENTS:
* resource/team: The new arguments `detectors` and `dashboard_groups` have been added. [#232](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/232)

---

These fields are being removed from the backend soon so a major version bump is being done since there's no backwards compatibility.