### PR TITLE
Rename provider module path to match GH organisation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-signalfx
+module github.com/splunk-terraform/terraform-provider-signalfx
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-signalfx/signalfx"
+	"github.com/splunk-terraform/terraform-provider-signalfx/signalfx"
 )
 
 func main() {


### PR DESCRIPTION
This matches what other providers have done:

e.g. https://github.com/digitalocean/terraform-provider-digitalocean/pull/463