### PR TITLE
Allow signalfx_dashboard_group.import_qualifier to be set to empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## UNRELEASED
+
+BUGFIXES:
+* resource/dashboard_group: The field `import_qualifiers` would not resolve to a clean plan if the dashboard group had an entry like:
+
+    ```json
+    "importQualifiers" : [ {
+      "filters" : [ ],
+      "metric" : ""
+    } ]
+    ```
+
+  With this change the plan will at least be clean when the empty resource is included in tf:
+
+    ```
+    import_qualifiers {
+    }
+    ```
+
+    This can be removed by sending a manual API request to update the dashboard group by setting `importQualifiers: []`. However if you modify the dashboard group in the UI the empty importQualifiers entry will return.
+
 ## 5.0.0 (September 10, 2020)
 
 BREAKING CHANGES:

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -118,7 +118,7 @@ func dashboardGroupResource() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"metric": &schema.Schema{
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 						"filters": &schema.Schema{
 							Type:        schema.TypeSet,


### PR DESCRIPTION
import_qualifier is sometimes set to this in the API in a dashboard group:

```json
"importQualifiers" : [ {
  "filters" : [ ],
  "metric" : ""
} ]
```

This results in not being able to resolve to a clean plan because removing the entry in tf doesn't remove the entry in the API. That's because the field is set to omitempty which results in the field not being sent when encoded to JSON. (In our API if you don't include a field in a PUT request the field isn't modified which makes this harder to deal with).

With this change the plan will at least be clean when the empty resource is included in tf:

```
import_qualifiers {
}
```

This can be removed by sending a manual API request to update the dashboard group by setting `importQualifiers: []`. However if you modify the dashboard group in the UI the empty importQualifiers entry will return.

Resolves #252