### PR TITLE
Team links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.0.0 (October 2, 2020)
+
+FEATURES:
+* resource/signalfx_team_links: This new resource can be used to manage linking of detectors and dashboard groups to teams. Multiple links can be used to a single team.
+
+BREAKING CHANGES:
+* resource/signalfx_team: The recently added dashboard group and detector entries have been removed from teams and must now be managed with the `signalfx_team_links` resource. 
+
 ## 5.0.1 (September 23, 2020)
 
 BUGFIXES:

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	homedir "github.com/mitchellh/go-homedir"
 	sfx "github.com/signalfx/signalfx-go"
+
 	"github.com/splunk-terraform/terraform-provider-signalfx/version"
 )
 
@@ -92,6 +93,7 @@ func Provider() terraform.ResourceProvider {
 			"signalfx_text_chart":               textChartResource(),
 			"signalfx_victor_ops_integration":   integrationVictorOpsResource(),
 			"signalfx_webhook_integration":      integrationWebhookResource(),
+			"signalfx_team_links":               teamLinksResource(),
 		},
 		ConfigureFunc: signalfxConfigure,
 	}

--- a/signalfx/resource_signalfx_team.go
+++ b/signalfx/resource_signalfx_team.go
@@ -34,20 +34,6 @@ func teamResource() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Members of team",
 			},
-			"detectors": &schema.Schema{
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "Detectors that belong to this team",
-				Deprecated:  "Use signalfx_team_links resource",
-			},
-			"dashboard_groups": &schema.Schema{
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "Dashboard Groups that belong to this team",
-				Deprecated:  "Use signalfx_team_links resource",
-			},
 			"notifications_critical": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -137,24 +123,6 @@ func getPayloadTeam(d *schema.ResourceData) (*team.CreateUpdateTeamRequest, erro
 		}
 	}
 	t.Members = members
-
-	var dashboardGroups []string
-	if val, ok := d.GetOk("dashboard_groups"); ok {
-		tfValues := val.(*schema.Set).List()
-		for _, v := range tfValues {
-			dashboardGroups = append(dashboardGroups, v.(string))
-		}
-	}
-	t.DashboardGroups = dashboardGroups
-
-	var detectors []string
-	if val, ok := d.GetOk("detectors"); ok {
-		tfValues := val.(*schema.Set).List()
-		for _, v := range tfValues {
-			detectors = append(detectors, v.(string))
-		}
-	}
-	t.Detectors = detectors
 
 	if val, ok := d.GetOk("notifications_critical"); ok {
 		nots, err := getNotificationList(val.([]interface{}))
@@ -327,26 +295,6 @@ func teamAPIToTF(d *schema.ResourceData, t *team.Team) error {
 			members[i] = v
 		}
 		if err := d.Set("members", schema.NewSet(schema.HashString, members)); err != nil {
-			return err
-		}
-	}
-
-	if len(t.Detectors) > 0 {
-		detectors := make([]interface{}, len(t.Detectors))
-		for i, v := range t.Detectors {
-			detectors[i] = v
-		}
-		if err := d.Set("detectors", schema.NewSet(schema.HashString, detectors)); err != nil {
-			return err
-		}
-	}
-
-	if len(t.DashboardGroups) > 0 {
-		dashGroups := make([]interface{}, len(t.DashboardGroups))
-		for i, v := range t.DashboardGroups {
-			dashGroups[i] = v
-		}
-		if err := d.Set("dashboard_groups", schema.NewSet(schema.HashString, dashGroups)); err != nil {
 			return err
 		}
 	}

--- a/signalfx/resource_signalfx_team.go
+++ b/signalfx/resource_signalfx_team.go
@@ -39,12 +39,14 @@ func teamResource() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Detectors that belong to this team",
+				Deprecated:  "Use signalfx_team_links resource",
 			},
 			"dashboard_groups": &schema.Schema{
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Dashboard Groups that belong to this team",
+				Deprecated:  "Use signalfx_team_links resource",
 			},
 			"notifications_critical": &schema.Schema{
 				Type:     schema.TypeList,

--- a/signalfx/resource_signalfx_team_links.go
+++ b/signalfx/resource_signalfx_team_links.go
@@ -1,0 +1,183 @@
+package signalfx
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func teamLinksResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"team": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Team ID to link the configured dashboard groups or detectos to.",
+			},
+			"dashboard_groups": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Dashboard group IDs to link to the team.",
+				Optional:    true,
+			},
+			"detectors": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Detector IDs to link to the team.",
+				Optional:    true,
+			},
+		},
+		Create: teamLinksCreate,
+		Read:   teamLinksRead,
+		Update: teamLinksUpdate,
+		Delete: teamLinksDelete,
+		Exists: teamLinksExists,
+	}
+}
+
+func teamLinksExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	return true, nil
+}
+
+func teamLinksRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	teamId := d.Get("team").(string)
+	res, err := config.Client.GetTeam(context.TODO(), teamId)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			d.SetId("")
+		}
+		return err
+	}
+
+	_, new := d.GetChange("detectors")
+	detectors := new.(*schema.Set)
+
+	dets := make([]interface{}, len(res.Detectors))
+	for i, detector := range res.Detectors {
+		dets[i] = detector
+	}
+
+	teamDets := schema.NewSet(schema.HashString, dets)
+	// XXX: For some reason the same sets are hashing to different values (maybe to interface{} vs string types).
+	// Rehash the set so intersection, etc. will work.
+	detectors = schema.NewSet(schema.HashString, detectors.List())
+
+	if err := d.Set("detectors", teamDets.Intersection(detectors)); err != nil {
+		return err
+	}
+
+	_, new = d.GetChange("dashboard_groups")
+	dashboardGroups := new.(*schema.Set)
+
+	dbgs := make([]interface{}, len(res.DashboardGroups))
+	for i, dbg := range res.DashboardGroups {
+		dbgs[i] = dbg
+	}
+
+	teamDbg := schema.NewSet(schema.HashString, dbgs)
+	// XXX: Rehash for same reason above.
+	dashboardGroups = schema.NewSet(schema.HashString, dashboardGroups.List())
+
+	if err := d.Set("dashboard_groups", teamDbg.Intersection(dashboardGroups)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func teamLinksCreate(d *schema.ResourceData, meta interface{}) error {
+	return teamLinksUpdate(d, meta)
+}
+
+func teamLinksUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	team := d.Get("team").(string)
+
+	old, new := d.GetChange("detectors")
+	oldD := old.(*schema.Set)
+	newD := new.(*schema.Set)
+
+	removed := oldD.Difference(newD)
+	added := newD.Difference(oldD)
+
+	log.Printf("[DEBUG] SignalFx: Unlinking detectors from team %v: %v", team, removed.List())
+
+	for _, rd := range removed.List() {
+		det := rd.(string)
+		if err := config.Client.UnlinkDetectorFromTeam(context.TODO(), team, det); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("[DEBUG] SignalFx: Linking detectors to team %v: %v", team, added.List())
+
+	for _, d := range added.List() {
+		det := d.(string)
+		if err := config.Client.LinkDetectorToTeam(context.TODO(), team, det); err != nil {
+			return err
+		}
+	}
+
+	if err := d.Set("detectors", new); err != nil {
+		return err
+	}
+
+	old, new = d.GetChange("dashboard_groups")
+	oldDbg := old.(*schema.Set)
+	newDbg := new.(*schema.Set)
+
+	removed = oldDbg.Difference(newDbg)
+	added = newDbg.Difference(oldDbg)
+
+	log.Printf("[DEBUG] SignalFx: Unlinking dashboard groups from team %v: %v", team, removed.List())
+
+	for _, d := range removed.List() {
+		det := d.(string)
+		if err := config.Client.UnlinkDashboardGroupFromTeam(context.TODO(), team, det); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("[DEBUG] SignalFx: Linking dashboard groups to team %v: %v", team, added.List())
+
+	for _, d := range added.List() {
+		det := d.(string)
+		if err := config.Client.LinkDashboardGroupToTeam(context.TODO(), team, det); err != nil {
+			return err
+		}
+	}
+
+	if err := d.Set("dashboard_groups", new); err != nil {
+		return err
+	}
+
+	d.SetId("0")
+
+	return nil
+}
+
+func teamLinksDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	team := d.Get("team").(string)
+	detectors := d.Get("detectors").(*schema.Set)
+	dashboardGroups := d.Get("dashboard_groups").(*schema.Set)
+
+	for _, d := range dashboardGroups.List() {
+		dbg := d.(string)
+		if err := config.Client.UnlinkDashboardGroupFromTeam(context.TODO(), team, dbg); err != nil {
+			return err
+		}
+	}
+
+	for _, d := range detectors.List() {
+		det := d.(string)
+		if err := config.Client.UnlinkDetectorFromTeam(context.TODO(), team, det); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/signalfx/resource_signalfx_team_links_test.go
+++ b/signalfx/resource_signalfx_team_links_test.go
@@ -1,0 +1,335 @@
+package signalfx
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+const (
+	teamA = `
+resource "signalfx_team" "a" {
+    name = "Test team A"
+    description = "Terraform test"
+}
+`
+	detectorA = `
+resource "signalfx_detector" "a" {
+    name = "Test team detector a"
+    description = "Terraform test"
+    max_delay = 30
+
+    program_text = <<-EOF
+        signal = data('app.delay').max().publish('app delay')
+        detect(when(signal > 60, '30m')).publish('Processing old messages 30m')
+	EOF
+    rule {
+        description = "maximum > 60 for 30m"
+        severity = "Critical"
+        detect_label = "Processing old messages 30m"
+        notifications = ["Email,noreply@signalfx.com"]
+    }
+}
+`
+	detectorB = `
+resource "signalfx_detector" "b" {
+    name = "Test team detector b"
+    description = "Terraform test"
+    max_delay = 30
+
+    program_text = <<-EOF
+        signal = data('app.delay').max().publish('app delay')
+        detect(when(signal > 60, '30m')).publish('Processing old messages 30m')
+	EOF
+    rule {
+        description = "maximum > 60 for 30m"
+        severity = "Critical"
+        detect_label = "Processing old messages 30m"
+        notifications = ["Email,noreply@signalfx.com"]
+    }
+}
+`
+	dashboardGroupA = `
+resource "signalfx_dashboard_group" "a" {
+    name = "Test team dashboard group a"
+    description = "Terraform test"
+}
+`
+	dashboardGroupB = `
+resource "signalfx_dashboard_group" "b" {
+    name = "Test team dashboard group b"
+    description = "Terraform test"
+}
+`
+	linkDetectorAtoTeamA = `
+resource "signalfx_team_links" "link1" {
+	team = signalfx_team.a.id
+	detectors = [signalfx_detector.a.id]
+}
+`
+	linkDetectorABtoTeamA = `
+resource "signalfx_team_links" "link2" {
+	team = signalfx_team.a.id
+	detectors = [signalfx_detector.a.id, signalfx_detector.b.id]
+}
+`
+	linkDetectorBtoTeamA = `
+resource "signalfx_team_links" "link2" {
+	team = signalfx_team.a.id
+	detectors = [signalfx_detector.b.id]
+}
+`
+	linkDashboardGroupAtoTeamA = `
+resource "signalfx_team_links" "link1" {
+	team = signalfx_team.a.id
+	dashboard_groups = [signalfx_dashboard_group.a.id]
+}
+`
+	linkDashboardGroupBtoTeamA = `
+resource "signalfx_team_links" "link2" {
+	team = signalfx_team.a.id
+	dashboard_groups = [signalfx_dashboard_group.b.id]
+}
+`
+	linkDashboardGroupABtoTeamA = `
+resource "signalfx_team_links" "link2" {
+	team = signalfx_team.a.id
+	dashboard_groups = [signalfx_dashboard_group.a.id, signalfx_dashboard_group.b.id]
+}
+`
+)
+
+func TestLinkingModifyDetectorLink(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create link and make sure team reflects it being linked.
+				Config: teamA + detectorA + linkDetectorAtoTeamA,
+				Check:  testAccCheckDetectorTeamLink("a", "a", true),
+			},
+			{
+				// Add link and make sure team reflects it being linked.
+				Config: teamA + detectorA + detectorB + linkDetectorABtoTeamA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDetectorTeamLink("a", "a", true),
+					testAccCheckDetectorTeamLink("a", "b", true),
+				),
+			},
+			{
+				// Remove a single link.
+				Config: teamA + detectorA + detectorB + linkDetectorBtoTeamA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDetectorTeamLink("a", "a", false),
+					testAccCheckDetectorTeamLink("a", "b", true),
+				),
+			},
+		},
+	})
+}
+
+func TestLinkingModifyDashboardGroupsLink(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create link and make sure team reflects it being linked.
+				Config: teamA + dashboardGroupA + linkDashboardGroupAtoTeamA,
+				Check:  testAccCheckDashboardGroupsTeamLink("a", "a", true),
+			},
+			{
+				// Add link and make sure team reflects it being linked.
+				Config: teamA + dashboardGroupA + dashboardGroupB + linkDashboardGroupABtoTeamA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDashboardGroupsTeamLink("a", "a", true),
+					testAccCheckDashboardGroupsTeamLink("a", "b", true),
+				),
+			},
+			{
+				// Remove a single link.
+				Config: teamA + dashboardGroupA + dashboardGroupB + linkDashboardGroupBtoTeamA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDashboardGroupsTeamLink("a", "a", false),
+					testAccCheckDashboardGroupsTeamLink("a", "b", true),
+				),
+			},
+		},
+	})
+}
+
+func TestLinkingDetector(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create link and make sure team reflects it being linked.
+				Config: teamA + detectorA + linkDetectorAtoTeamA,
+				Check:  testAccCheckDetectorTeamLink("a", "a", true),
+			},
+			{
+				// Remove link and make sure team reflects it being unlinked.
+				Config: teamA + detectorA,
+				Check:  testAccCheckDetectorTeamLink("a", "a", false),
+			},
+		},
+	})
+}
+
+func TestLinkingDashboardGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create link and make sure team reflects it being linked.
+				Config: teamA + dashboardGroupA + linkDashboardGroupAtoTeamA,
+				Check:  testAccCheckDashboardGroupsTeamLink("a", "a", true),
+			},
+			{
+				// Remove link and make sure team reflects it being unlinked.
+				Config: teamA + dashboardGroupA,
+				Check:  testAccCheckDashboardGroupsTeamLink("a", "a", false),
+			},
+		},
+	})
+}
+
+func TestLinkingToTeamWithUnrelatedDetectors(t *testing.T) {
+	// This ensures that if two different link resources link to the same team that
+	// modifying the links don't impact one another.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create link and make sure team reflects it being linked.
+				Config: teamA + detectorA + detectorB + linkDetectorAtoTeamA + linkDetectorBtoTeamA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDetectorTeamLink("a", "a", true),
+					testAccCheckDetectorTeamLink("a", "b", true),
+				),
+			},
+			{
+				// Make sure the A link stays.
+				Config: teamA + detectorA + detectorB + linkDetectorAtoTeamA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDetectorTeamLink("a", "a", true),
+					testAccCheckDetectorTeamLink("a", "b", false),
+				),
+			},
+		},
+	})
+}
+
+func TestLinkingToTeamWithUnrelatedDashboardGroups(t *testing.T) {
+	// This ensures that if two different link resources link to the same team that
+	// modifying the links don't impact one another.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create link and make sure team reflects it being linked.
+				Config: teamA + dashboardGroupA + dashboardGroupB + linkDashboardGroupAtoTeamA + linkDashboardGroupBtoTeamA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDashboardGroupsTeamLink("a", "a", true),
+					testAccCheckDashboardGroupsTeamLink("a", "b", true),
+				),
+			},
+			{
+				// Make sure the A link stays.
+				Config: teamA + dashboardGroupA + dashboardGroupB + linkDashboardGroupAtoTeamA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDashboardGroupsTeamLink("a", "a", true),
+					testAccCheckDashboardGroupsTeamLink("a", "b", false),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDetectorTeamLink(teamName string, detectorName string, wantLink bool) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := newTestClient()
+
+		rs := state.RootModule().Resources
+		teamResource, ok := rs["signalfx_team."+teamName]
+		if !ok {
+			return fmt.Errorf("no team named %v", teamName)
+		}
+		detectorResource, ok := rs["signalfx_detector."+detectorName]
+		if !ok {
+			return fmt.Errorf("no detector named %v", detectorName)
+		}
+
+		teamId := teamResource.Primary.ID
+		detectorId := detectorResource.Primary.ID
+
+		team, err := client.GetTeam(context.TODO(), teamId)
+		if err != nil {
+			return err
+		}
+
+		if wantLink {
+			for _, d := range team.Detectors {
+				if d == detectorId {
+					return nil
+				}
+			}
+			return fmt.Errorf("did not find detector id %v in team %v", detectorId, teamId)
+		}
+
+		for _, d := range team.Detectors {
+			if d == detectorId {
+				return fmt.Errorf("found detector id %v in team %v", detectorId, teamId)
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckDashboardGroupsTeamLink(teamName string, dashboardGroupName string, wantLink bool) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := newTestClient()
+
+		rs := state.RootModule().Resources
+		teamResource, ok := rs["signalfx_team."+teamName]
+		if !ok {
+			return fmt.Errorf("no team named %v", teamName)
+		}
+		dashboardGroupResource, ok := rs["signalfx_dashboard_group."+dashboardGroupName]
+		if !ok {
+			return fmt.Errorf("no dashboard_group named %v", dashboardGroupName)
+		}
+
+		teamId := teamResource.Primary.ID
+		dashboardGroupId := dashboardGroupResource.Primary.ID
+
+		team, err := client.GetTeam(context.TODO(), teamId)
+		if err != nil {
+			return err
+		}
+
+		if wantLink {
+			for _, d := range team.DashboardGroups {
+				if d == dashboardGroupId {
+					return nil
+				}
+			}
+			return fmt.Errorf("did not find dashboard_group id %v in team %v", dashboardGroupId, teamId)
+		}
+
+		for _, d := range team.DashboardGroups {
+			if d == dashboardGroupId {
+				return fmt.Errorf("found dashboard_group id %v in team %v", dashboardGroupId, teamId)
+			}
+		}
+		return nil
+	}
+}

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -25,16 +25,6 @@ resource "signalfx_team" "myteam0" {
     # …
   ]
 
-  detectors = [
-    "detectorId1",
-    "detectorId2",
-  ]
-
-  dashboard_groups = [
-    "dashboardGroupId1",
-    "dashboardGroupId2",
-  ]
-
   notifications_critical = [
     "PagerDuty,credentialId"
   ]

--- a/website/docs/r/team_links.html.markdown
+++ b/website/docs/r/team_links.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "signalfx"
+page_title: "SignalFx: signalfx_resource"
+sidebar_current: "docs-signalfx-resource-team-links"
+description: |-
+  Allows Terraform to link dashboard groups and detectors to teams.
+---
+
+# Resource: signalfx_team_links
+
+Handles management of linking dashboard groups and detectors to SignalFx teams. Multiple links can link to the same team but they should link to unique detectors and dashboard groups.
+
+## Example Usage
+
+```tf
+resource "signalfx_team" "prod" {
+  name        = "prod"
+  description = "Production on-call"
+}
+
+resource "signalfx_dashboard_group" "infra" {
+    name = "infra"
+    description = "infra dashboard"
+}
+
+resource "signalfx_team_links" "link1" {
+  team = signalfx_team.prod.id
+  dashboard_groups = [signalfx_dashboard_group.infra.id]
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported in the resource block:
+
+* `team` - (Required) ID of team to link to.
+* `detectors` - (Optional) List of detector IDs to include in the team.
+* `dashboard_groups` - (Optional) List of dashboard group IDs to include in the team.
+
+## Attributes Reference
+
+None.

--- a/website/signalfx.erb
+++ b/website/signalfx.erb
@@ -91,6 +91,9 @@
             <li<%= sidebar_current("docs-signalfx-resource-team") %>>
               <a href="/docs/providers/signalfx/r/team.html">signalfx_team</a>
             </li>
+            <li<%= sidebar_current("docs-signalfx-resource-team-links") %>>
+              <a href="/docs/providers/signalfx/r/team_links.html">signalfx_team_links</a>
+            </li>
             <li<%= sidebar_current("docs-signalfx-resource-text-chart") %>>
               <a href="/docs/providers/signalfx/r/text_chart.html">signalfx_text_chart</a>
             </li>


### PR DESCRIPTION
FEATURES:
* resource/signalfx_team_links: This new resource can be used to manage linking of detectors and dashboard groups to teams. Multiple links can be used to a single team.

BREAKING CHANGES:
* resource/signalfx_team: The recently added dashboard group and detector entries have been removed from teams and must now be managed with the `signalfx_team_links` resource. 