### PR TITLE
Revert to previous team behavior on detectors and dashboard groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 6.0.0 (October 23, 2020)
+
+IMPROVEMENTS:
+* resource/detector: Added back old method for setting teams.
+* resource/dashboard_group: Added back old method for setting teams.
+
+BREAKING CHANGES:
+* resource/team: Removed short-lived method of setting detectors and dashboard_groups on team object.
+
 ## 5.0.2 (October 23, 2020)
 
 BUGFIXES:

--- a/signalfx/resource_signalfx_dashboard_and_friends_test.go
+++ b/signalfx/resource_signalfx_dashboard_and_friends_test.go
@@ -480,6 +480,11 @@ func testAccCheckDashboardGroupResourceExists(s *terraform.State) error {
 			if err != nil || dl.Id != rs.Primary.ID {
 				return fmt.Errorf("Error finding data link %s: %s", rs.Primary.ID, err)
 			}
+		case "signalfx_team":
+			team, err := client.GetTeam(context.TODO(), rs.Primary.ID)
+			if team.Id != rs.Primary.ID || err != nil {
+				return fmt.Errorf("Error finding team %s: %s", rs.Primary.ID, err)
+			}
 		default:
 			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
 		}
@@ -510,6 +515,11 @@ func testAccDashboardGroupDestroy(s *terraform.State) error {
 			dl, _ := client.GetDataLink(context.TODO(), rs.Primary.ID)
 			if dl != nil {
 				return fmt.Errorf("Found deleted data link %s", rs.Primary.ID)
+			}
+		case "signalfx_team":
+			team, _ := client.GetTeam(context.TODO(), rs.Primary.ID)
+			if team != nil {
+				return fmt.Errorf("Found deleted team %s", rs.Primary.ID)
 			}
 		default:
 			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -26,7 +26,6 @@ func dashboardGroupResource() *schema.Resource {
 			"teams": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated:  "TKTK",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the dashboard group to",
 			},

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -23,6 +23,13 @@ func dashboardGroupResource() *schema.Resource {
 				Optional:    true,
 				Description: "Description of the dashboard group",
 			},
+			"teams": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Deprecated: "Setting the teams in a dashboard group has been deprecated, please see the team resource's detectors argument."
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Team IDs to associate the dashboard group to",
+			},
 			"dashboard": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -182,6 +189,14 @@ func getPayloadDashboardGroup(d *schema.ResourceData) *dashboard_group.CreateUpd
 		Name:              d.Get("name").(string),
 		Description:       d.Get("description").(string),
 		AuthorizedWriters: &dashboard_group.AuthorizedWriters{},
+	}
+
+	if val, ok := d.GetOk("teams"); ok {
+		teams := []string{}
+		for _, t := range val.([]interface{}) {
+			teams = append(teams, t.(string))
+		}
+		cudgr.Teams = teams
 	}
 
 	if val, ok := d.GetOk("authorized_writer_teams"); ok {
@@ -357,6 +372,9 @@ func dashboardGroupAPIToTF(d *schema.ResourceData, dg *dashboard_group.Dashboard
 		return err
 	}
 	if err := d.Set("description", dg.Description); err != nil {
+		return err
+	}
+	if err := d.Set("teams", dg.Teams); err != nil {
 		return err
 	}
 

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -26,7 +26,7 @@ func dashboardGroupResource() *schema.Resource {
 			"teams": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated: "Setting the teams in a dashboard group has been deprecated, please see the team resource's detectors argument."
+				Deprecated:  "TKTK",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the dashboard group to",
 			},

--- a/signalfx/resource_signalfx_dashboard_group_dashboard_configs_test.go
+++ b/signalfx/resource_signalfx_dashboard_group_dashboard_configs_test.go
@@ -15,15 +15,26 @@ resource "signalfx_time_chart" "mytimechartX0" {
         EOF
 }
 
+resource "signalfx_team" "dashboardGroupTeam" {
+    name = "Super Cool Team"
+    description = "Dashboard Group Team"
+
+    notifications_critical = [ "Email,test@example.com" ]
+    notifications_default = [ "Webhook,,secret,https://www.example.com" ]
+    notifications_info = [ "Webhook,,secret,https://www.example.com/2" ]
+    notifications_major = [ "Webhook,,secret,https://www.example.com/3" ]
+    notifications_minor = [ "Webhook,,secret,https://www.example.com/4" ]
+    notifications_warning = [ "Webhook,,secret,https://www.example.com/5" ]
+}
+
 resource "signalfx_dashboard_group" "mydashboardgroupX0" {
     name = "My team dashboard group"
     description = "Cool dashboard group"
-		// No teams test cuz there's no teams resource yet!
 }
 
 resource "signalfx_dashboard" "mydashboardX0" {
     name = "My Dashboard Test 1"
-		description = "Cool dashboard"
+    description = "Cool dashboard"
     dashboard_group = "${signalfx_dashboard_group.mydashboardgroupX0.id}"
 
     time_range = "-30m"
@@ -56,6 +67,7 @@ resource "signalfx_dashboard" "mydashboardX0" {
 resource "signalfx_dashboard_group" "mydashboardgroupX1" {
     name = "My team dashboard group"
     description = "Cool dashboard group"
+    teams = [signalfx_team.dashboardGroupTeam.id]
 
     // Test Mirrors!
     dashboard {
@@ -78,12 +90,11 @@ resource "signalfx_time_chart" "mytimechartX0" {
 resource "signalfx_dashboard_group" "mydashboardgroupX0" {
     name = "My team dashboard group"
     description = "Cool dashboard group"
-		// No teams test cuz there's no teams resource yet!
 }
 
 resource "signalfx_dashboard" "mydashboardX0" {
     name = "My Dashboard Test 1"
-		description = "Cool dashboard"
+    description = "Cool dashboard"
     dashboard_group = "${signalfx_dashboard_group.mydashboardgroupX0.id}"
 
     time_range = "-30m"
@@ -154,6 +165,7 @@ func TestAccCreateUpdateDashboardGroupWithConfig(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_dashboard_group.mydashboardgroupX1", "dashboard.#", "1"),
 					resource.TestCheckResourceAttr("signalfx_dashboard_group.mydashboardgroupX1", "dashboard.0.filter_override.#", "0"),
 					resource.TestCheckResourceAttr("signalfx_dashboard_group.mydashboardgroupX1", "dashboard.0.variable_override.#", "0"),
+					resource.TestCheckResourceAttr("signalfx_dashboard_group.mydashboardgroupX1", "teams.#", "1"),
 				),
 			},
 			// Update Everything

--- a/signalfx/resource_signalfx_dashboard_group_dashboard_configs_test.go
+++ b/signalfx/resource_signalfx_dashboard_group_dashboard_configs_test.go
@@ -18,6 +18,7 @@ resource "signalfx_time_chart" "mytimechartX0" {
 resource "signalfx_dashboard_group" "mydashboardgroupX0" {
     name = "My team dashboard group"
     description = "Cool dashboard group"
+		// No teams test cuz there's no teams resource yet!
 }
 
 resource "signalfx_dashboard" "mydashboardX0" {

--- a/signalfx/resource_signalfx_dashboard_test.go
+++ b/signalfx/resource_signalfx_dashboard_test.go
@@ -20,12 +20,11 @@ resource "signalfx_time_chart" "mytimechartX0" {
 resource "signalfx_dashboard_group" "mydashboardgroupX0" {
     name = "My team dashboard group"
     description = "Cool dashboard group"
-		// No teams test cuz there's no teams resource yet!
 }
 
 resource "signalfx_dashboard" "mydashboardX0" {
     name = "My Dashboard Test 1"
-		description = "Cool dashboard"
+    description = "Cool dashboard"
     dashboard_group = "${signalfx_dashboard_group.mydashboardgroupX0.id}"
 
     time_range = "-30m"

--- a/signalfx/resource_signalfx_dashboard_test.go
+++ b/signalfx/resource_signalfx_dashboard_test.go
@@ -20,6 +20,7 @@ resource "signalfx_time_chart" "mytimechartX0" {
 resource "signalfx_dashboard_group" "mydashboardgroupX0" {
     name = "My team dashboard group"
     description = "Cool dashboard group"
+		// No teams test cuz there's no teams resource yet!
 }
 
 resource "signalfx_dashboard" "mydashboardX0" {

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -85,7 +85,6 @@ func detectorResource() *schema.Resource {
 			"teams": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated:  "TKTK",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the detector to",
 			},

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -85,7 +85,7 @@ func detectorResource() *schema.Resource {
 			"teams": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated:  "Setting the team in a detector has been deprecated, please see the team resource's detectors argument.",
+				Deprecated:  "TKTK",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the detector to",
 			},

--- a/signalfx/resource_signalfx_team.go
+++ b/signalfx/resource_signalfx_team.go
@@ -34,18 +34,6 @@ func teamResource() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Members of team",
 			},
-			"detectors": &schema.Schema{
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "Detectors that belong to this team",
-			},
-			"dashboard_groups": &schema.Schema{
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "Dashboard Groups that belong to this team",
-			},
 			"notifications_critical": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -135,24 +123,6 @@ func getPayloadTeam(d *schema.ResourceData) (*team.CreateUpdateTeamRequest, erro
 		}
 	}
 	t.Members = members
-
-	var dashboardGroups []string
-	if val, ok := d.GetOk("dashboard_groups"); ok {
-		tfValues := val.(*schema.Set).List()
-		for _, v := range tfValues {
-			dashboardGroups = append(dashboardGroups, v.(string))
-		}
-	}
-	t.DashboardGroups = dashboardGroups
-
-	var detectors []string
-	if val, ok := d.GetOk("detectors"); ok {
-		tfValues := val.(*schema.Set).List()
-		for _, v := range tfValues {
-			detectors = append(detectors, v.(string))
-		}
-	}
-	t.Detectors = detectors
 
 	if val, ok := d.GetOk("notifications_critical"); ok {
 		nots, err := getNotificationList(val.([]interface{}))
@@ -325,26 +295,6 @@ func teamAPIToTF(d *schema.ResourceData, t *team.Team) error {
 			members[i] = v
 		}
 		if err := d.Set("members", schema.NewSet(schema.HashString, members)); err != nil {
-			return err
-		}
-	}
-
-	if len(t.Detectors) > 0 {
-		detectors := make([]interface{}, len(t.Detectors))
-		for i, v := range t.Detectors {
-			detectors[i] = v
-		}
-		if err := d.Set("detectors", schema.NewSet(schema.HashString, detectors)); err != nil {
-			return err
-		}
-	}
-
-	if len(t.DashboardGroups) > 0 {
-		dashGroups := make([]interface{}, len(t.DashboardGroups))
-		for i, v := range t.DashboardGroups {
-			dashGroups[i] = v
-		}
-		if err := d.Set("dashboard_groups", schema.NewSet(schema.HashString, dashGroups)); err != nil {
 			return err
 		}
 	}

--- a/signalfx/resource_signalfx_team_test.go
+++ b/signalfx/resource_signalfx_team_test.go
@@ -9,11 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const (
-	newTeamConfig = `
+const newTeamConfig = `
 resource "signalfx_team" "myteamXX" {
     name = "Super Cool Team"
-	description = "Fart noise"
+		description = "Fart noise"
 
     notifications_critical = [ "Email,test@example.com" ]
     notifications_default = [ "Webhook,,secret,https://www.example.com" ]
@@ -24,10 +23,10 @@ resource "signalfx_team" "myteamXX" {
 }
 `
 
-	updatedTeamConfig = `
+const updatedTeamConfig = `
 resource "signalfx_team" "myteamXX" {
     name = "Super Cool Team NEW"
-	description = "Fart noise NEW"
+		description = "Fart noise NEW"
 
     notifications_critical = [ "Email,test@example.com" ]
     notifications_default = [ "Webhook,,secret,https://www.example.com" ]
@@ -37,77 +36,6 @@ resource "signalfx_team" "myteamXX" {
     notifications_warning = [ "Webhook,,secret,https://www.example.com/5" ]
 }
 `
-
-	teamWithDetector = `
-resource "signalfx_detector" "team_detector" {
-    name = "team detector"
-    description = "team detector"
-    max_delay = 30
-
-    program_text = <<-EOF
-        signal = data('app.delay').max().publish('app delay')
-        detect(when(signal > 60, '30m')).publish('Processing old messages 30m')
-	EOF
-    rule {
-        description = "maximum > 60 for 30m"
-        severity = "Critical"
-        detect_label = "Processing old messages 30m"
-        notifications = ["Email,foo-alerts@example.com"]
-    }
-}
-
-resource "signalfx_team" "team_with_detector" {
-	name = "Team with detector"
-	description = "Team with detector"
-	detectors = ["${signalfx_detector.team_detector.id}"]
-}
-`
-
-	teamWithDashboardGroup = `
-resource "signalfx_dashboard_group" "team_dashboard_group" {
-    name = "My team dashboard group"
-    description = "Cool dashboard group"
-}
-
-resource "signalfx_team" "team_with_dashboard_group" {
-	name = "Team with dashboard_group"
-	description = "Team with dashboard_group"
-	dashboard_groups = ["${signalfx_dashboard_group.team_dashboard_group.id}"]
-}
-`
-)
-
-func TestAccTeamWithDetector(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: teamWithDetector,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTeamResourceExists,
-					resource.TestCheckResourceAttr("signalfx_team.team_with_detector", "name", "Team with detector"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTeamWithDashboardGroup(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: teamWithDashboardGroup,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTeamResourceExists,
-					resource.TestCheckResourceAttr("signalfx_team.team_with_dashboard_group", "name", "Team with dashboard_group"),
-				),
-			},
-		},
-	})
-}
 
 func TestAccCreateUpdateTeam(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -159,8 +87,6 @@ func testAccCheckTeamResourceExists(s *terraform.State) error {
 			if team.Id != rs.Primary.ID || err != nil {
 				return fmt.Errorf("Error finding team %s: %s", rs.Primary.ID, err)
 			}
-		case "signalfx_detector":
-		case "signalfx_dashboard_group":
 		default:
 			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
 		}
@@ -177,8 +103,6 @@ func testAccTeamDestroy(s *terraform.State) error {
 			if team != nil {
 				return fmt.Errorf("Found deleted team %s", rs.Primary.ID)
 			}
-		case "signalfx_detector":
-		case "signalfx_dashboard_group":
 		default:
 			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
 		}

--- a/signalfx/resource_signalfx_team_test.go
+++ b/signalfx/resource_signalfx_team_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const newTeamConfig = `
+const (
+	newTeamConfig = `
 resource "signalfx_team" "myteamXX" {
     name = "Super Cool Team"
-		description = "Fart noise"
+    description = "Fart noise"
 
     notifications_critical = [ "Email,test@example.com" ]
     notifications_default = [ "Webhook,,secret,https://www.example.com" ]
@@ -23,10 +24,10 @@ resource "signalfx_team" "myteamXX" {
 }
 `
 
-const updatedTeamConfig = `
+	updatedTeamConfig = `
 resource "signalfx_team" "myteamXX" {
     name = "Super Cool Team NEW"
-		description = "Fart noise NEW"
+    description = "Fart noise NEW"
 
     notifications_critical = [ "Email,test@example.com" ]
     notifications_default = [ "Webhook,,secret,https://www.example.com" ]
@@ -36,6 +37,7 @@ resource "signalfx_team" "myteamXX" {
     notifications_warning = [ "Webhook,,secret,https://www.example.com/5" ]
 }
 `
+)
 
 func TestAccCreateUpdateTeam(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/website/docs/r/dashboard_group.html.markdown
+++ b/website/docs/r/dashboard_group.html.markdown
@@ -62,6 +62,7 @@ The following arguments are supported in the resource block:
 
 * `name` - (Required) Name of the dashboard group.
 * `description` - (Required) Description of the dashboard group.
+* `teams` - (Optional) Team IDs to associate the dashboard group to.
 * `authorized_writer_teams` - (Optional) Team IDs that have write access to this dashboard group. Remember to use an admin's token if using this feature and to include that admin's team (or user id in `authorized_writer_teams`).
 * `authorized_writer_users` - (Optional) User IDs that have write access to this dashboard group. Remember to use an admin's token if using this feature and to include that admin's user id (or team id in `authorized_writer_teams`).
 * `dashboard` - (Optional) [Mirrored dashboards](https://docs.signalfx.com/en/latest/dashboards/dashboard-mirrors.html) in this dashboard group. **Note:** This feature is not present in all accounts. Please contact support if you are unsure.

--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -150,6 +150,7 @@ notifications = ["Webhook,,secret,url"]
 * `time_range` - (Optional) Seconds to display in the visualization. This is a rolling range from the current time. Example: `3600` corresponds to `-1h` in web UI. `3600` by default.
 * `start_time` - (Optional) Seconds since epoch. Used for visualization. Conflicts with `time_range`.
 * `end_time` - (Optional) Seconds since epoch. Used for visualization. Conflicts with `time_range`.
+* `teams` - (Optional) Team IDs to associate the detector to.
 * `rule` - (Required) Set of rules used for alerting.
     * `detect_label` - (Required) A detect label which matches a detect label within `program_text`.
     * `severity` - (Required) The severity of the rule, must be one of: `"Critical"`, `"Major"`, `"Minor"`, `"Warning"`, `"Info"`.

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -25,16 +25,6 @@ resource "signalfx_team" "myteam0" {
     # …
   ]
 
-  detectors = [
-    "detectorId1",
-    "detectorId2",
-  ]
-
-  dashboard_groups = [
-    "dashboardGroupId1",
-    "dashboardGroupId2",
-  ]
-
   notifications_critical = [
     "PagerDuty,credentialId"
   ]
@@ -52,8 +42,6 @@ The following arguments are supported in the resource block:
 * `name` - (Required) Name of the team.
 * `description` - (Optional) Description of the team.
 * `members` - (Optional) List of user IDs to include in the team.
-* `detectors` - (Optional) List of detector IDs to include in the team.
-* `dashboardGroups` - (Optional) List of dashboard group IDs to include in the team.
 * `notifications_critical` - (Optional) Where to send notifications for critical alerts
 * `notifications_default` - (Optional) Where to send notifications for default alerts
 * `notifications_info` - (Optional) Where to send notifications for info alerts


### PR DESCRIPTION
IMPROVEMENTS:
* resource/detector: Added back old method for setting teams.
* resource/dashboard_group: Added back old method for setting teams.

BREAKING CHANGES:
* resource/team: Removed short-lived method of setting detectors and dashboard_groups on team object.

---

Resolves #255 
