### PR TITLE
Extending signalfx_detector with tags

### DIFF
--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -80,6 +80,7 @@ resource "signalfx_detector" "application_delay" {
     description = "your application is slow"
     max_delay = 30
     min_delay = 15
+    tags = ["tag-1","tag-2"]
     teams = [signalfx_team.detectorTeam.id]
 
     program_text = <<-EOF
@@ -162,6 +163,7 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 					testAccCheckDetectorResourceExists,
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "name", "max average delay"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "description", "your application is slow"),
+					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "tags.#", "2"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "teams.#", "1"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "max_delay", "30"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "min_delay", "15"),
@@ -205,6 +207,7 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 					testAccCheckDetectorResourceExists,
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "name", "max average delay UPDATED"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "description", "your application is slowER"),
+					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "tags.#", "0"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "teams.#", "0"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "max_delay", "60"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "min_delay", "30"),

--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -21,6 +21,7 @@ resource "signalfx_detector" "application_delay" {
   name        = " max average delay - ${var.clusters[count.index]}"
   description = "your application is slow - ${var.clusters[count.index]}"
   max_delay   = 30
+  tags        = ["app-backend", "staging"]
 
   # Note that if you use these features, you must use a user's
   # admin key to authenticate the provider, lest Terraform not be able
@@ -151,6 +152,7 @@ notifications = ["Webhook,,secret,url"]
 * `time_range` - (Optional) Seconds to display in the visualization. This is a rolling range from the current time. Example: `3600` corresponds to `-1h` in web UI. `3600` by default.
 * `start_time` - (Optional) Seconds since epoch. Used for visualization. Conflicts with `time_range`.
 * `end_time` - (Optional) Seconds since epoch. Used for visualization. Conflicts with `time_range`.
+* `tags` - (Optional) Tags associated with the detector.
 * `teams` - (Optional) Team IDs to associate the detector to.
 * `rule` - (Required) Set of rules used for alerting.
     * `detect_label` - (Required) A detect label which matches a detect label within `program_text`.


### PR DESCRIPTION
Adding missing bits such as `tags` to `signalfx_detector` resource.

Both `POST` and `PUT` methods have a way to define `tags` for the detectors, but unfortunately it cant be managed via Terraform resource:
- https://dev.splunk.com/observability/reference/api/detectors/latest#endpoint-create-single-detector
- https://dev.splunk.com/observability/reference/api/detectors/latest#endpoint-update-single-detector

For the context, we're planning to use `tags` data in a search query: https://dev.splunk.com/observability/reference/api/detectors/latest#endpoint-retrieve-detectors-query