### PR TITLE
Removed example is_default ref

### DIFF
--- a/website/docs/r/data_link.html.markdown
+++ b/website/docs/r/data_link.html.markdown
@@ -33,7 +33,6 @@ resource "signalfx_data_link" "my_data_link_dash" {
   property_value       = "pvalue"
 
   target_external_url {
-    is_default  = false
     name        = "ex_url"
     time_format = "ISO8601"
     url         = "https://www.example.com"


### PR DESCRIPTION
Removed the example reference to 'is_default' for the 'target_external_url'
block. This option was removed in PR #267 