### PR TITLE
Fix PagerDuty integration datasource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.7.15
+	github.com/signalfx/signalfx-go v1.7.16
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/signalfx/signalfx-go v1.7.14-0.20201218154707-ae1dca54849a h1:Nz9TOMC
 github.com/signalfx/signalfx-go v1.7.14-0.20201218154707-ae1dca54849a/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/signalfx-go v1.7.15 h1:t6y1xMav1EKplwJvxZHy5tn7yoiHqZJhnFNPR7ZZdrY=
 github.com/signalfx/signalfx-go v1.7.15/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go v1.7.16 h1:5jqHZF/VYvmuhYQbVD0Lia6PDPpIeKGPhtO5LUU22P4=
+github.com/signalfx/signalfx-go v1.7.16/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac h1:wbW+Bybf9pXxnCFAOWZTqkRjAc7rAIwo2e1ArUhiHxg=

--- a/signalfx/data_source_pagerduty_integration.go
+++ b/signalfx/data_source_pagerduty_integration.go
@@ -14,6 +14,10 @@ func dataSourcePagerDutyIntegration() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/vendor/github.com/signalfx/signalfx-go/pagerduty_integration.go
+++ b/vendor/github.com/signalfx/signalfx-go/pagerduty_integration.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/signalfx/signalfx-go/integration"
 )
@@ -65,7 +66,11 @@ func (c *Client) GetPagerDutyIntegration(ctx context.Context, id string) (*integ
 
 // GetPagerDutyIntegrationByName retrieves a PagerDuty integration by name.
 func (c *Client) GetPagerDutyIntegrationByName(ctx context.Context, name string) (*integration.PagerDutyIntegration, error) {
-	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"?type=PagerDuty&name="+name, nil, nil)
+	params := url.Values{}
+	params.Add("type", "PagerDuty")
+	params.Add("name", name)
+
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.7.15
+# github.com/signalfx/signalfx-go v1.7.16
 ## explicit
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <smazzarino@sessionm.com>

Vendor the updated `signalfx-go` Go client and fix the Datasource adding the `enabled` computed parameter.