### PR TITLE
Fix AWS integration resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased Changes
+
+BUGFIXES
+* resource/signalfx_aws_integration: Custom namespaces listed using `custom_namespace_sync_rule` will now correctly emit metrics. [#300](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/300)
+
 ## 6.7.3
 
 IMPROVEMENTS:

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -441,7 +441,7 @@ func getCustomNamespaceRules(tfRules []interface{}) []*integration.AwsCustomName
 			da := da.(string)
 			if da == string(integration.INCLUDE) {
 				defaultAction = integration.INCLUDE
-			} else {
+			} else if da == string(integration.EXCLUDE) {
 				defaultAction = integration.EXCLUDE
 			}
 		}

--- a/signalfx/resource_signalfx_aws_integration_test.go
+++ b/signalfx/resource_signalfx_aws_integration_test.go
@@ -34,6 +34,10 @@ resource "signalfx_aws_integration" "aws_myteamXX" {
 			namespace = "fart"
 		}
 
+		custom_namespace_sync_rule {
+			namespace = "custom"
+		}
+
 		namespace_sync_rule {
 			default_action = "Exclude"
 			filter_action = "Include"
@@ -63,6 +67,10 @@ resource "signalfx_aws_integration" "aws_myteam_tokXX" {
 			filter_action = "Include"
 			filter_source = "filter('code', '200')"
 			namespace = "fart"
+		}
+
+		custom_namespace_sync_rule {
+			namespace = "custom"
 		}
 
 		namespace_sync_rule {
@@ -97,6 +105,10 @@ resource "signalfx_aws_integration" "aws_myteamXX" {
 			namespace = "fart"
 		}
 
+		custom_namespace_sync_rule {
+			namespace = "custom"
+		}
+
 		namespace_sync_rule {
 			default_action = "Exclude"
 			filter_action = "Include"
@@ -126,6 +138,10 @@ resource "signalfx_aws_integration" "aws_myteam_tokXX" {
 			filter_action = "Include"
 			filter_source = "filter('code', '200')"
 			namespace = "fart"
+		}
+
+		custom_namespace_sync_rule {
+			namespace = "custom"
 		}
 
 		namespace_sync_rule {

--- a/signalfx/resource_signalfx_data_link.go
+++ b/signalfx/resource_signalfx_data_link.go
@@ -188,8 +188,8 @@ func getPayloadDataLink(d *schema.ResourceData) (*datalink.CreateUpdateDataLinkR
 		for _, tfLink := range splkDashes {
 			tfLink := tfLink.(map[string]interface{})
 			dl := &datalink.Target{
-				Name:      tfLink["name"].(string),
-				Type:      datalink.SPLUNK_LINK,
+				Name: tfLink["name"].(string),
+				Type: datalink.SPLUNK_LINK,
 			}
 
 			if v, ok := tfLink["property_key_mapping"]; ok {


### PR DESCRIPTION
The AWS integration resource currently sets `default_action` to `Exclude` for `custom_namespace_sync_rule`. It should be left empty instead like for `namespace_sync_rule`.  This will ensure metrics are properly collected from custom namespaces when no explicit filters are provided, right now they're being excluded.