### PR TITLE
Fix AWS integration poll rate validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.7.5
+
+BUGFIXES
+* resource/signalfx_aws_integration: Allow specifying a poll rate for AWS integration to up to 10 minutes. [#307](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/307)
+
 ## 6.7.4
 
 BUGFIXES

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -161,8 +161,8 @@ func integrationAWSResource() *schema.Resource {
 			"poll_rate": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Description:  "AWS poll rate (in seconds). Between `60` and `300`.",
-				ValidateFunc: validation.IntBetween(60, 300),
+				Description:  "AWS poll rate (in seconds). Between `60` and `600`.",
+				ValidateFunc: validation.IntBetween(60, 600),
 			},
 			"external_id": &schema.Schema{
 				Type:          schema.TypeString,


### PR DESCRIPTION
Signalfx API accepts a poll rate between 60 and 600.