### PR TITLE
datalinks: Handle extraneous empty targets 

### DIFF
--- a/signalfx/resource_signalfx_data_link.go
+++ b/signalfx/resource_signalfx_data_link.go
@@ -216,6 +216,14 @@ func getPayloadDataLink(d *schema.ResourceData) (*datalink.CreateUpdateDataLinkR
 				Type:              datalink.EXTERNAL_LINK,
 			}
 
+			// When changes are made to an existing target, the Terraform plugin SDK seems
+			// to be creating an extraneous target with all empty values. Since name is a
+			// required field on targets, skip when we encounter empty names. Ideally this
+			// issue would be fixed at the Terraform SDK level - this is only a workaround.
+			if dl.Name == "" {
+				continue
+			}
+
 			switch tfLink["time_format"].(string) {
 			case "Epoch":
 				dl.TimeFormat = datalink.Epoch

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -469,9 +469,9 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(det.Id)
 
-    // Gives time to the API to properly update info before read them again
-    // required to make the acceptance tests always passing, see:
-    // https://github.com/splunk-terraform/terraform-provider-signalfx/pull/306#issuecomment-870417521
+	// Gives time to the API to properly update info before read them again
+	// required to make the acceptance tests always passing, see:
+	// https://github.com/splunk-terraform/terraform-provider-signalfx/pull/306#issuecomment-870417521
 	time.Sleep(1 * time.Second)
 	return detectorAPIToTF(d, det)
 }
@@ -667,9 +667,9 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(det.Id)
 
-    // Gives time to the API to properly update info before read them again
-    // required to make the acceptance tests always passing, see:
-    // https://github.com/splunk-terraform/terraform-provider-signalfx/pull/306#issuecomment-870417521
+	// Gives time to the API to properly update info before read them again
+	// required to make the acceptance tests always passing, see:
+	// https://github.com/splunk-terraform/terraform-provider-signalfx/pull/306#issuecomment-870417521
 	time.Sleep(1 * time.Second)
 	return detectorAPIToTF(d, det)
 }


### PR DESCRIPTION
When changes are made to an existing target, the Terraform plugin SDK seems to be creating an extraneous target with all empty values. Since name is a required field on target, skip when we encounter empty names. Ideally this issue would be fixed at the Terraform SDK level - this is only a workaround.

This PR also fixes formatting from a previous merge.