### PR TITLE
move sleep to acceptance tests

### DIFF
--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -469,10 +468,6 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(det.Id)
 
-	// Gives time to the API to properly update info before read them again
-	// required to make the acceptance tests always passing, see:
-	// https://github.com/splunk-terraform/terraform-provider-signalfx/pull/306#issuecomment-870417521
-	time.Sleep(1 * time.Second)
 	return detectorAPIToTF(d, det)
 }
 
@@ -667,10 +662,6 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(det.Id)
 
-	// Gives time to the API to properly update info before read them again
-	// required to make the acceptance tests always passing, see:
-	// https://github.com/splunk-terraform/terraform-provider-signalfx/pull/306#issuecomment-870417521
-	time.Sleep(1 * time.Second)
 	return detectorAPIToTF(d, det)
 }
 

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -163,6 +164,7 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 				Config: newDetectorConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDetectorResourceExists,
+					waitBeforeTest,
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "name", "max average delay"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "description", "your application is slow"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "timezone", "Europe/Paris"),
@@ -247,6 +249,14 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 			},
 		},
 	})
+}
+
+func waitBeforeTest(s *terraform.State) error {
+	// Gives time to the API to properly update info before read them again
+	// required to make the acceptance tests always passing, see:
+	// https://github.com/splunk-terraform/terraform-provider-signalfx/pull/306#issuecomment-870417521
+	time.Sleep(1 * time.Second)
+	return nil
 }
 
 func testAccCheckDetectorResourceExists(s *terraform.State) error {

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -199,7 +199,7 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1714348016.severity", "Critical"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1714348016.tip", ""),
 
-                    // Force sleep before refresh at the end of test execution
+					// Force sleep before refresh at the end of test execution
 					waitBeforeTestStepPlanRefresh,
 				),
 			},

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -251,7 +251,7 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 	})
 }
 
-func waitBeforeTest(s *terraform.State) error {
+func waitBeforeTestStepPlanRefresh(s *terraform.State) error {
 	// Gives time to the API to properly update info before read them again
 	// required to make the acceptance tests always passing, see:
 	// https://github.com/splunk-terraform/terraform-provider-signalfx/pull/306#issuecomment-870417521

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -164,7 +164,6 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 				Config: newDetectorConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDetectorResourceExists,
-					waitBeforeTest,
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "name", "max average delay"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "description", "your application is slow"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "timezone", "Europe/Paris"),
@@ -199,6 +198,9 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1714348016.runbook_url", ""),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1714348016.severity", "Critical"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1714348016.tip", ""),
+
+                    // Force sleep before refresh at the end of test execution
+					waitBeforeTestStepPlanRefresh,
 				),
 			},
 			{


### PR DESCRIPTION
sleeps have been introduced in https://github.com/splunk-terraform/terraform-provider-signalfx/pull/306#issuecomment-870446998 to fix acceptances tests.

while `detectorAPIToTF(d, det)` does not call the splunk api, it seems better to move them to tests only to prevent useless slowing the provider.