### PR TITLE
upgrade go lib to fix aws namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.8.2-0.20210913192807-72cc233ffe3c
+	github.com/signalfx/signalfx-go v1.8.2-0.20210915131150-ef9961af55b6
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adP
 github.com/signalfx/golib/v3 v3.0.0 h1:7jU1iitxa4qsLMbOlquaHHaUf0GJ86P8ZFxnE5hTUVA=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
-github.com/signalfx/signalfx-go v1.8.2-0.20210913192807-72cc233ffe3c h1:MVShzVLGl9sOQBCWbgCEo6EXP1eBkgVPmRaTEh+qQck=
-github.com/signalfx/signalfx-go v1.8.2-0.20210913192807-72cc233ffe3c/go.mod h1:EtCwkwvLv+wfjDQVAs1O37yVn3hp2xAKmXA6BFKkRT4=
+github.com/signalfx/signalfx-go v1.8.2-0.20210915131150-ef9961af55b6 h1:k9ygCeL+sambOb2S1r/yCDOpkLEGausx/fZ+VDjew0k=
+github.com/signalfx/signalfx-go v1.8.2-0.20210915131150-ef9961af55b6/go.mod h1:EtCwkwvLv+wfjDQVAs1O37yVn3hp2xAKmXA6BFKkRT4=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac h1:wbW+Bybf9pXxnCFAOWZTqkRjAc7rAIwo2e1ArUhiHxg=

--- a/vendor/github.com/signalfx/signalfx-go/integration/model_aws_service.go
+++ b/vendor/github.com/signalfx/signalfx-go/integration/model_aws_service.go
@@ -70,7 +70,7 @@ const (
 	AWSPOLLY                     AwsService = "AWS/Polly"
 	AWSREDSHIFT                  AwsService = "AWS/Redshift"
 	AWSRDS                       AwsService = "AWS/RDS"
-	AWSROBOMAKER                 AwsService = "AWS/RoboMaker"
+	AWSROBOMAKER                 AwsService = "AWS/Robomaker"
 	AWSROUTE53                   AwsService = "AWS/Route53"
 	AWSSAGE_MAKER                AwsService = "AWS/SageMaker"
 	AWSSAGE_MAKER_TRAINING_JOBS  AwsService = "aws/sagemaker/TrainingJobs"
@@ -95,7 +95,7 @@ const (
 	AWSWORK_MAIL                 AwsService = "AWS/WorkMail"
 	AWSWORK_SPACES               AwsService = "AWS/WorkSpaces"
 	AWSNEPTUNE                   AwsService = "AWS/Neptune"
-	AWSMEDIA_LIVE                AwsService = "AWS/MediaLive"
+	AWSMEDIA_LIVE                AwsService = "MediaLive"
 	AWS_SYSTEM_LINUX             AwsService = "System/Linux"
 )
 
@@ -156,7 +156,7 @@ var AWSServiceNames = map[string]AwsService{
 	"AWS/Polly":                   AWSPOLLY,
 	"AWS/Redshift":                AWSREDSHIFT,
 	"AWS/RDS":                     AWSRDS,
-	"AWS/RoboMaker":               AWSROBOMAKER,
+	"AWS/Robomaker":               AWSROBOMAKER,
 	"AWS/Route53":                 AWSROUTE53,
 	"AWS/SageMaker":               AWSSAGE_MAKER,
 	"aws/sagemaker/TrainingJobs":  AWSSAGE_MAKER_TRAINING_JOBS,
@@ -181,6 +181,6 @@ var AWSServiceNames = map[string]AwsService{
 	"AWS/WorkMail":                AWSWORK_MAIL,
 	"AWS/WorkSpaces":              AWSWORK_SPACES,
 	"AWS/Neptune":                 AWSNEPTUNE,
-	"AWS/MediaLive":               AWSMEDIA_LIVE,
+	"MediaLive":                   AWSMEDIA_LIVE,
 	"System/Linux":                AWS_SYSTEM_LINUX,
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/signalfx/golib/v3 v3.0.0
 github.com/signalfx/golib/v3/pointer
-# github.com/signalfx/signalfx-go v1.8.2-0.20210913192807-72cc233ffe3c
+# github.com/signalfx/signalfx-go v1.8.2-0.20210915131150-ef9961af55b6
 ## explicit
 github.com/signalfx/signalfx-go
 github.com/signalfx/signalfx-go/alertmuting


### PR DESCRIPTION
follow up https://github.com/signalfx/signalfx-go/pull/133#issuecomment-920067172 @keitwb I used the commit hash while there is not tag on signalfx-go including the last fix.

I also `go mod vendor && go mod tidy`