### PR TITLE
resource/dashboardgroup: Handle updates with mirrors correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.7.8
+
+BUGFIXES:
+* resource/signalfx_dashboard_group: Correctly handle mirrored dashboards [#319](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/319)
+
 ## 6.7.7
 
 BUGFIXES:

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -518,8 +518,11 @@ func dashboardgroupUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func getNonMirroredDashes(config *signalfxConfig, d *schema.ResourceData) ([]*dashboard_group.DashboardConfig, error) {
-	oldDashboardList, newDashboardList := d.GetChange("dashboard")
-	mirrorIDsToBeOmitted := getMirrorsToBeOmitted(oldDashboardList, newDashboardList)
+	var mirrorIDsToBeOmitted map[string]bool
+	if d.HasChange("dashboard") {
+		oldDashboardList, newDashboardList := d.GetChange("dashboard")
+		mirrorIDsToBeOmitted = getMirrorsToBeOmitted(oldDashboardList, newDashboardList)
+	}
 
 	dg, err := config.Client.GetDashboardGroup(context.TODO(), d.Id())
 	if err != nil {

--- a/signalfx/resource_signalfx_dashboard_group_test.go
+++ b/signalfx/resource_signalfx_dashboard_group_test.go
@@ -1,0 +1,66 @@
+package signalfx
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetMirrorsToBeOmitted(t *testing.T) {
+	type args struct {
+		oldDashboardList interface{}
+		newDashboardList interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]bool
+	}{
+		{
+			"Same values result in empty omit list",
+			args{
+				oldDashboardList: []interface{}{
+					map[string]interface{}{
+						"dashboard_id": "A",
+					},
+				},
+				newDashboardList: []interface{}{
+					map[string]interface{}{
+						"dashboard_id": "A",
+					},
+				},
+			},
+			map[string]bool{},
+		},
+		{
+			"Omit values absent in new list",
+			args{
+				oldDashboardList: []interface{}{
+					map[string]interface{}{
+						"dashboard_id": "A",
+					},
+					map[string]interface{}{
+						"dashboard_id": "B",
+					},
+				},
+				newDashboardList: []interface{}{
+					map[string]interface{}{
+						"dashboard_id": "B",
+					},
+					map[string]interface{}{
+						"dashboard_id": "C",
+					},
+				},
+			},
+			map[string]bool{
+				"A": true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getMirrorsToBeOmitted(tt.args.oldDashboardList, tt.args.newDashboardList); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getMirrorsToBeOmitted() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Terraform provider does not track non-mirrored dashboards in dashboard groups. It keeps track dashboardgroup membership on the respective dashboards. However, the backend modifies dashboard groups object to hold a list of all dashboards it holds, both mirrored and non-mirrored. The API expects this full list of dashboards whenever mirrored dashboards are added/present. This behavior is noted in step 4 of the API docs [here](https://dev.splunk.com/observability/docs/chartsdashboards/dashboard_groups_overview#Add-the-mirrored-dashboard). 

Currently, it does not seem possible to track info about dashboard membership on dashboard group resources with Terraform state as that will introduce a cyclic dependency. The API requires a dashboard group ID for dashboards, so the the dashboard group will need to be created before the member dashboards themselves. As a workaround, this PR attempts to fix the issue by doing a get on the dashboard group to collect all member dashboard ids and append it to list of dashboards with every update request. For this to work as expected it will also be required to set `-parallelism=1` .

Fixes #264 