### PR TITLE
teams should not impose ordering on dashboard_groups by using list

### DIFF
--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -25,7 +25,7 @@ func dashboardGroupResource() *schema.Resource {
 				Description: "Description of the dashboard group",
 			},
 			"teams": &schema.Schema{
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the dashboard group to",


### PR DESCRIPTION
The use of typelist is causing our repo to constantly update dashboard groups as the teams order varies between environments.
Teams has no order so a set is the correct type to use surely.