### PR TITLE
Teams in dashboard groups  should be an unordered set rather than a list

### DIFF
--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -193,7 +193,7 @@ func getPayloadDashboardGroup(d *schema.ResourceData) *dashboard_group.CreateUpd
 
 	if val, ok := d.GetOk("teams"); ok {
 		teams := []string{}
-		for _, t := range val.([]interface{}) {
+		for _, t := range val.(*schema.Set).List() {
 			teams = append(teams, t.(string))
 		}
 		cudgr.Teams = teams

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -25,7 +25,7 @@ func dashboardGroupResource() *schema.Resource {
 				Description: "Description of the dashboard group",
 			},
 			"teams": &schema.Schema{
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Team IDs to associate the dashboard group to",


### PR DESCRIPTION
I had previously missed off converting the set to a list in the get causing errors for anyone using the new provider