### PR TITLE
Add `label_resolutions` to `signalfx_detector` resource

### DIFF
--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -222,12 +222,19 @@ func detectorResource() *schema.Resource {
 					},
 				},
 			},
+			"label_resolutions": &schema.Schema{
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Resolutions of the detector alerts in milliseconds that indicate how often data is analyzed to determine if an alert should be triggered",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
 			"url": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "URL of the detector",
-			},
-		},
+			}},
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
@@ -471,7 +478,7 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(det.Id)
 
-	return detectorAPIToTF(d, det)
+	return detectorRead(d, meta)
 }
 
 func detectorExists(d *schema.ResourceData, meta interface{}) (bool, error) {
@@ -534,6 +541,9 @@ func detectorAPIToTF(d *schema.ResourceData, det *detector.Detector) error {
 		if err := d.Set("min_delay", *det.MinDelay/1000); err != nil {
 			return err
 		}
+	}
+	if err := d.Set("label_resolutions", det.LabelResolutions); err != nil {
+		return err
 	}
 	if err := d.Set("tags", det.Tags); err != nil {
 		return err

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -231,7 +231,13 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "max_delay", "30"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "min_delay", "15"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "program_text", "signal = data('app.delay').max().publish('app delay')\ndetect(when(signal > 60, '5m')).publish('Processing old messages 5m')\ndetect(when(signal > 60, '30m')).publish('Processing old messages 30m')\n"),
+
+					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "label_resolutions.%", "2"),
+					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "label_resolutions.Processing old messages 30m", "1000"),
+					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "label_resolutions.Processing old messages 5m", "1000"),
+
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.#", "2"),
+
 					// Rule #1
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1250591008.description", "maximum > 60 for 5m"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1250591008.detect_label", "Processing old messages 5m"),
@@ -284,7 +290,13 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "show_data_markers", "true"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "show_event_lines", "true"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "disable_sampling", "true"),
+
+					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "label_resolutions.%", "2"),
+					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "label_resolutions.Processing old messages 30m", "1000"),
+					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "label_resolutions.Processing old messages 5m", "1000"),
+
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.#", "2"),
+
 					// Rule #1
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1162180415.description", "NEW maximum > 60 for 5m"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1162180415.notifications.0", "Email,foo-alerts@example.com"),
@@ -293,7 +305,8 @@ func TestAccCreateUpdateDetector(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1162180415.severity", "Warning"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1162180415.runbook_url", "https://www.example.com"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.1162180415.tip", "reboot it"),
-					// Rule #1
+
+					// Rule #2
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.3455453859.description", "NEW maximum > 60 for 30m"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.3455453859.detect_label", "Processing old messages 30m"),
 					resource.TestCheckResourceAttr("signalfx_detector.application_delay", "rule.3455453859.disabled", "false"),

--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -186,6 +186,7 @@ See [Delayed Datapoints](https://signalfx-product-docs.readthedocs-hosted.com/en
 In a addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the detector.
+* `label_resolutions` - The resolutions of the detector alerts in milliseconds that indicate how often data is analyzed to determine if an alert should be triggered.
 * `url` - The URL of the detector.
 
 ## Import


### PR DESCRIPTION
This PR adds `label_resolutions` as a computed attribute of the `signalfx_detector` resource.

See https://dev.splunk.com/observability/reference/api/detectors/latest#endpoint-retrieve-detectors-query
and 

TODO:
- [x] Use next release when published instead of [github.com/signalfx/signalfx-go@88f2f32](https://github.com/signalfx/signalfx-go/commit/88f2f325c06991d6533994b6656ec39c9db30e1d).
- [x] Add tests.
- [x] Add documentation.
