### PR TITLE
Fix and update org token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.8.4
+	github.com/signalfx/signalfx-go v1.8.6
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/signalfx/golib/v3 v3.3.37 h1:CvL6Q8hySjm7D82P039qH2lFWJvBa18IJdAwa4LH
 github.com/signalfx/golib/v3 v3.3.37/go.mod h1:zH70SVnrzVUqDmUFEwDk1HSwS71Pi2w3bSsNpnOtYuQ=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
 github.com/signalfx/sapm-proto v0.4.0/go.mod h1:x3gtwJ1GRejtkghB4nYpwixh2zqJrLbPU959ZNhM0Fk=
-github.com/signalfx/signalfx-go v1.8.4 h1:bFW26x6Md+nMggAfj/oZTemmDnTReywQNqDApP9EW/w=
-github.com/signalfx/signalfx-go v1.8.4/go.mod h1:YhPTMdQJDfphcRBdk+9acbbAw1gYY7z5BIHUWzLmGlA=
+github.com/signalfx/signalfx-go v1.8.6 h1:ntMMzwR+xeLOCrKT7QOpinctNuy7ltU5tH3TmIERs54=
+github.com/signalfx/signalfx-go v1.8.6/go.mod h1:YhPTMdQJDfphcRBdk+9acbbAw1gYY7z5BIHUWzLmGlA=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac h1:wbW+Bybf9pXxnCFAOWZTqkRjAc7rAIwo2e1ArUhiHxg=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/signalfx/resource_signalfx_org_token_test.go
+++ b/signalfx/resource_signalfx_org_token_test.go
@@ -47,6 +47,30 @@ resource "signalfx_org_token" "myorgtokenTOK1" {
 }
 `
 
+const newOrgTokenLimitConfig = `
+resource "signalfx_org_token" "mylimitorgtokenTOK1" {
+  name = "LimitToken"
+  description = "Limits"
+  auth_scopes = ["INGEST"]
+
+  dpm_limits {
+    dpm_limit = 1000
+  }
+}
+`
+
+const updatedOrgTokenLimitConfig = `
+resource "signalfx_org_token" "mylimitorgtokenTOK1" {
+  name = "LimitToken"
+  description = "Limits NEW"
+  auth_scopes = ["INGEST"]
+
+  dpm_limits {
+    dpm_limit = 2000
+  }
+}
+`
+
 func TestAccCreateUpdateOrgToken(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -75,6 +99,42 @@ func TestAccCreateUpdateOrgToken(t *testing.T) {
 					testAccCheckOrgTokenResourceExists,
 					resource.TestCheckResourceAttr("signalfx_org_token.myorgtokenTOK1", "name", "FarToken"),
 					resource.TestCheckResourceAttr("signalfx_org_token.myorgtokenTOK1", "description", "Farts NEW"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCreateUpdateLimitOrgToken(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrgTokenDestroy,
+		Steps: []resource.TestStep{
+			// Create It
+			{
+				Config: newOrgTokenLimitConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.mylimitorgtokenTOK1", "name", "LimitToken"),
+					resource.TestCheckResourceAttr("signalfx_org_token.mylimitorgtokenTOK1", "description", "Limits"),
+					resource.TestCheckResourceAttr("signalfx_org_token.mylimitorgtokenTOK1", "dpm_limits.#", "1"),
+				),
+			},
+			{
+				ResourceName:      "signalfx_org_token.mylimitorgtokenTOK1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_org_token.mylimitorgtokenTOK1"),
+				ImportStateVerify: true,
+			},
+			// Update Everything
+			{
+				Config: updatedOrgTokenLimitConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.mylimitorgtokenTOK1", "name", "LimitToken"),
+					resource.TestCheckResourceAttr("signalfx_org_token.mylimitorgtokenTOK1", "description", "Limits NEW"),
+					resource.TestCheckResourceAttr("signalfx_org_token.mylimitorgtokenTOK1", "dpm_limits.#", "1"),
 				),
 			},
 		},


### PR DESCRIPTION
This PR fixes the `dpm_limits` , which a single [line](https://github.com/splunk-terraform/terraform-provider-signalfx/compare/SWAT-4236?expand=1#diff-6db680519113a56285c31717f8f0159ebf84939fdfc348fa8d4dfb3a32a84fc7R280) fix; but fixing this and/or running the existing test `TestAccCreateUpdateOrgToken` will fail with a server side error:
```
"code" : 500,
  "message" : "Server error occurred. Unique error identifier [24df50a1-e751-4a42-9adb-8eb759e875b9]"
```

This error is returned when the provider attempts to update an org token with a DPM/Category limit and not setting the `authScopes` in its payload.

In this PR I added `auth_scopes` to the token schema and I made it optional to keep it backward compatible;
Note, when you create a token, the server defaults to setting the value to `["API", "INGEST"]` so the initial creation succeeds whether you set `authScopes` or not; but due to the TF SDK not supporting `Default` [for complex types](https://github.com/hashicorp/terraform-plugin-sdk/issues/142) , in this case `TypeList`, I opted to set `Computed` to true; this will prevent false positive plan diffs .

I also added new test.

NOTE: ~~Do Not Merge as this depends on this PR https://github.com/signalfx/signalfx-go/pull/146 , once the it's merged, I need to update this PR to pull the new version of signalfx-go~~

update:  signalfx-go is updated

Signed-off-by: Dani Louca <dlouca@splunk.com>