### PR TITLE
Fix AWS integration tests

### DIFF
--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -288,14 +288,15 @@ func awsIntegrationAPIToTF(d *schema.ResourceData, aws *integration.AwsCloudWatc
 	if len(aws.CustomNamespaceSyncRules) > 0 {
 		var rules []map[string]interface{}
 		for _, v := range aws.CustomNamespaceSyncRules {
-			if v.Filter != nil {
-				rules = append(rules, map[string]interface{}{
-					"default_action": string(v.DefaultAction),
-					"filter_action":  v.Filter.Action,
-					"filter_source":  v.Filter.Source,
-					"namespace":      v.Namespace,
-				})
+			rule := map[string]interface{}{
+				"default_action": string(v.DefaultAction),
+				"namespace":      v.Namespace,
 			}
+			if v.Filter != nil {
+				rule["filter_action"] = v.Filter.Action
+				rule["filter_source"] = v.Filter.Source
+			}
+			rules = append(rules, rule)
 		}
 		if len(rules) > 0 {
 			if err := d.Set("custom_namespace_sync_rule", rules); err != nil {


### PR DESCRIPTION
This PR fixes acceptance tests for the AWS integration.

Without this PR:

```
make testacc TESTARGS='-run=TestAccCreateUpdateIntegrationAWS -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccCreateUpdateIntegrationAWS -count=1 -timeout 120m
?       github.com/splunk-terraform/terraform-provider-signalfx [no test files]
=== RUN   TestAccCreateUpdateIntegrationAWS
    testing.go:684: Step 0 error: After applying this step and refreshing, the plan was not empty:

        DIFF:

        UPDATE: signalfx_aws_integration.aws_myteamXX
          auth_method:                                 "ExternalId" => "ExternalId"
          custom_namespace_sync_rule.#:                "1" => "2"
          custom_namespace_sync_rule.0.default_action: "Exclude" => ""
          custom_namespace_sync_rule.0.filter_action:  "Include" => ""
          custom_namespace_sync_rule.0.filter_source:  "filter('code', '200')" => ""
          custom_namespace_sync_rule.0.namespace:      "fart" => "custom"
          custom_namespace_sync_rule.1.default_action: "" => "Exclude"
          custom_namespace_sync_rule.1.filter_action:  "" => "Include"
          custom_namespace_sync_rule.1.filter_source:  "" => "filter('code', '200')"
          custom_namespace_sync_rule.1.namespace:      "" => "fart"
          enable_aws_usage:                            "true" => "true"
          enable_check_large_volume:                   "false" => "false"
          enabled:                                     "false" => "false"
          external_id:                                 "hkpibkceabvwtydjkpby" => "hkpibkceabvwtydjkpby"
          id:                                          "FLP9ZHdAEAE" => "FLP9ZHdAEAE"
          import_cloud_watch:                          "true" => "true"
          integration_id:                              "FLP9ZHdAEAE" => "FLP9ZHdAEAE"
          name:                                        "AWSFoo" => "AWSFoo"
          named_token:                                 "" => ""
          namespace_sync_rule.#:                       "1" => "1"
          namespace_sync_rule.0.default_action:        "Exclude" => "Exclude"
          namespace_sync_rule.0.filter_action:         "Include" => "Include"
          namespace_sync_rule.0.filter_source:         "filter('code', '200')" => "filter('code', '200')"
          namespace_sync_rule.0.namespace:             "AWS/EC2" => "AWS/EC2"
          poll_rate:                                   "300" => "300"
          regions.#:                                   "1" => "1"
          regions.0:                                   "us-east-1" => "us-east-1"
          role_arn:                                    "arn:aws:iam::XXX:role/SignalFx-Read-Role" => "arn:aws:iam::XXX:role/SignalFx-Read-Role"
          use_get_metric_data_method:                  "false" => "false"
        UPDATE: signalfx_aws_integration.aws_myteam_tokXX
          auth_method:                                 "SecurityToken" => "SecurityToken"
          custom_namespace_sync_rule.#:                "1" => "2"
          custom_namespace_sync_rule.0.default_action: "Exclude" => ""
          custom_namespace_sync_rule.0.filter_action:  "Include" => ""
          custom_namespace_sync_rule.0.filter_source:  "filter('code', '200')" => ""
          custom_namespace_sync_rule.0.namespace:      "fart" => "custom"
          custom_namespace_sync_rule.1.default_action: "" => "Exclude"
          custom_namespace_sync_rule.1.filter_action:  "" => "Include"
          custom_namespace_sync_rule.1.filter_source:  "" => "filter('code', '200')"
          custom_namespace_sync_rule.1.namespace:      "" => "fart"
          enable_aws_usage:                            "true" => "true"
          enable_check_large_volume:                   "false" => "false"
          enabled:                                     "false" => "false"
          id:                                          "FLP9Q_tAAAE" => "FLP9Q_tAAAE"
          import_cloud_watch:                          "true" => "true"
          integration_id:                              "FLP9Q_tAAAE" => "FLP9Q_tAAAE"
          key:                                         "key123" => "key123"
          name:                                        "AWSFooToken" => "AWSFooToken"
          named_token:                                 "" => ""
          namespace_sync_rule.#:                       "1" => "1"
          namespace_sync_rule.0.default_action:        "Exclude" => "Exclude"
          namespace_sync_rule.0.filter_action:         "Include" => "Include"
          namespace_sync_rule.0.filter_source:         "filter('code', '200')" => "filter('code', '200')"
          namespace_sync_rule.0.namespace:             "AWS/EC2" => "AWS/EC2"
          poll_rate:                                   "300" => "300"
          regions.#:                                   "1" => "1"
          regions.0:                                   "us-east-1" => "us-east-1"
          token:                                       "token123" => "token123"
          use_get_metric_data_method:                  "true" => "true"



        STATE:

        signalfx_aws_external_integration.aws_ext_myteamXX:
          ID = FLP9ZHdAEAE
          provider = provider.signalfx
          external_id = hkpibkceabvwtydjkpby
          name = AWSFoo
          signalfx_aws_account = arn:aws:iam::214014584948:root
        signalfx_aws_integration.aws_myteamXX:
          ID = FLP9ZHdAEAE
          provider = provider.signalfx
          auth_method = ExternalId
          custom_namespace_sync_rule.# = 1
          custom_namespace_sync_rule.0.default_action = Exclude
          custom_namespace_sync_rule.0.filter_action = Include
          custom_namespace_sync_rule.0.filter_source = filter('code', '200')
          custom_namespace_sync_rule.0.namespace = fart
          enable_aws_usage = true
          enable_check_large_volume = false
          enabled = false
          external_id = hkpibkceabvwtydjkpby
          import_cloud_watch = true
          integration_id = FLP9ZHdAEAE
          name = AWSFoo
          named_token =
          namespace_sync_rule.# = 1
          namespace_sync_rule.0.default_action = Exclude
          namespace_sync_rule.0.filter_action = Include
          namespace_sync_rule.0.filter_source = filter('code', '200')
          namespace_sync_rule.0.namespace = AWS/EC2
          poll_rate = 300
          regions.# = 1
          regions.0 = us-east-1
          role_arn = arn:aws:iam::XXX:role/SignalFx-Read-Role
          use_get_metric_data_method = false

          Dependencies:
            signalfx_aws_external_integration.aws_ext_myteamXX
        signalfx_aws_integration.aws_myteam_tokXX:
          ID = FLP9Q_tAAAE
          provider = provider.signalfx
          auth_method = SecurityToken
          custom_namespace_sync_rule.# = 1
          custom_namespace_sync_rule.0.default_action = Exclude
          custom_namespace_sync_rule.0.filter_action = Include
          custom_namespace_sync_rule.0.filter_source = filter('code', '200')
          custom_namespace_sync_rule.0.namespace = fart
          enable_aws_usage = true
          enable_check_large_volume = false
          enabled = false
          import_cloud_watch = true
          integration_id = FLP9Q_tAAAE
          key = key123
          name = AWSFooToken
          named_token =
          namespace_sync_rule.# = 1
          namespace_sync_rule.0.default_action = Exclude
          namespace_sync_rule.0.filter_action = Include
          namespace_sync_rule.0.filter_source = filter('code', '200')
          namespace_sync_rule.0.namespace = AWS/EC2
          poll_rate = 300
          regions.# = 1
          regions.0 = us-east-1
          token = token123
          use_get_metric_data_method = true

          Dependencies:
            signalfx_aws_token_integration.aws_tok_myteamXX
        signalfx_aws_token_integration.aws_tok_myteamXX:
          ID = FLP9Q_tAAAE
          provider = provider.signalfx
          name = AWSFooToken
          signalfx_aws_account = arn:aws:iam::214014584948:root
--- FAIL: TestAccCreateUpdateIntegrationAWS (1.27s)
FAIL
FAIL    github.com/splunk-terraform/terraform-provider-signalfx/signalfx        1.277s
?       github.com/splunk-terraform/terraform-provider-signalfx/version [no test files]
FAIL
make: *** [GNUmakefile:17: testacc] Error 1
```

With this PR:

```
make testacc TESTARGS='-run=TestAccCreateUpdateIntegrationAWS -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccCreateUpdateIntegrationAWS -count=1 -timeout 120m
?       github.com/splunk-terraform/terraform-provider-signalfx [no test files]
=== RUN   TestAccCreateUpdateIntegrationAWS
--- PASS: TestAccCreateUpdateIntegrationAWS (1.80s)
PASS
ok      github.com/splunk-terraform/terraform-provider-signalfx/signalfx        1.808s
?       github.com/splunk-terraform/terraform-provider-signalfx/version [no test files]
```