### PR TITLE
 Enable support for darwin_arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,8 +24,6 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-    - goos: darwin
-      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
## Why?

- Enable support for Apple silicon devices