### PR TITLE
Add tags to the signalfx_dashboard resource

### DIFF
--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -36,6 +36,12 @@ func dashboardResource() *schema.Resource {
 				Optional:    true,
 				Description: "Description of the dashboard (Optional)",
 			},
+			"tags": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Tags of the dashboard",
+			},
 			"charts_resolution": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -437,6 +443,15 @@ func getPayloadDashboard(d *schema.ResourceData) (*dashboard.CreateUpdateDashboa
 			users = append(users, v.(string))
 		}
 		cudr.AuthorizedWriters.Users = users
+	}
+
+	if val, ok := d.GetOk("tags"); ok {
+		var tags []string
+		tfValues := val.([]interface{})
+		for _, v := range tfValues {
+			tags = append(tags, v.(string))
+		}
+		cudr.Tags = tags
 	}
 
 	allFilters := &dashboard.ChartsFilters{}

--- a/signalfx/resource_signalfx_dashboard_test.go
+++ b/signalfx/resource_signalfx_dashboard_test.go
@@ -26,6 +26,7 @@ resource "signalfx_dashboard" "mydashboardX0" {
     name = "My Dashboard Test 1"
     description = "Cool dashboard"
     dashboard_group = "${signalfx_dashboard_group.mydashboardgroupX0.id}"
+    tags = ["cool tag", "not so cool tag"]
 
     time_range = "-30m"
 
@@ -69,6 +70,25 @@ func TestChartWidthAllowed(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("signalfx_dashboard.mydashboardX0", "grid.#", "1"),
 					resource.TestCheckResourceAttr("signalfx_dashboard.mydashboardX0", "grid.0.width", "12"),
+				),
+			},
+		},
+	})
+}
+
+func TestDashboardTagsApplied(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDashboardGroupDestroy,
+		Steps: []resource.TestStep{
+			// Create resource with tags
+			{
+				Config: fmt.Sprintf(widthTestDashConfig, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("signalfx_dashboard.mydashboardX0", "tags.#", "2"),
+					resource.TestCheckResourceAttr("signalfx_dashboard.mydashboardX0", "tags.0", "cool tag"),
+					resource.TestCheckResourceAttr("signalfx_dashboard.mydashboardX0", "tags.1", "not so cool tag"),
 				),
 			},
 		},

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported in the resource block:
 * `name` - (Required) Name of the dashboard.
 * `dashboard_group` - (Required) The ID of the dashboard group that contains the dashboard.
 * `description` - (Optional) Description of the dashboard.
+* `tags` - (Optional) Tags of the dashboard.
 * `authorized_writer_teams` - (Optional) Team IDs that have write access to this dashboard group. Remember to use an admin's token if using this feature and to include that admin's team (or user id in `authorized_writer_teams`).
 * `authorized_writer_users` - (Optional) User IDs that have write access to this dashboard group. Remember to use an admin's token if using this feature and to include that admin's user id (or team id in `authorized_writer_teams`).
 * `charts_resolution` - (Optional) Specifies the chart data display resolution for charts in this dashboard. Value can be one of `"default"`,  `"low"`, `"high"`, or  `"highest"`.


### PR DESCRIPTION
This change allows tags to be specified for the signalfx_dashboard resource.

The existing functionality to specify tags for a dashboard [already existed in the signalfx-go library API](https://github.com/signalfx/signalfx-go/blob/master/dashboard/model_create_update_dashboard_request.go#L32).