### PR TITLE
Add AWS metric streams support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,32 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 *Note:* Acceptance tests create real resources, and often cost money to run.
 
 ```sh
+$ export SFX_API_URL=https://api.signalfx.com # or https://api.eu0.signalfx.com
+$ export SFX_AUTH_TOKEN=XXXXXX
 $ make testacc
 ```
+
+To also run the AWS integration tests for Cloudwatch Metric Streams synchronization, you must create an actual AWS IAM user with an access key and secret that SignalFx can use to manage AWS Cloudwatch Metric Streams resources, and define the `SFX_TEST_AWS_ACCESS_KEY_ID` and `SFX_TEST_AWS_SECRET_ACCESS_KEY` environment variables:
+
+```sh
+export SFX_TEST_AWS_ACCESS_KEY_ID=AKIAXXXXXX
+export SFX_TEST_AWS_SECRET_ACCESS_KEY=XXXXXX
+```
+
+The policies that this user must be granted are:
+
+```
+"cloudwatch:ListMetricStreams",
+"cloudwatch:GetMetricStream",
+"cloudwatch:PutMetricStream",
+"cloudwatch:DeleteMetricStream",
+"cloudwatch:StartMetricStreams",
+"cloudwatch:StopMetricStreams",
+"iam:PassRole"
+```
+
+See [Connect to AWS using the guided setup in Splunk Observability Cloud](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-wizardconfig.html) and [Enable CloudWatch Metric Streams](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-apiconfig.html#enable-cloudwatch-metric-streams) in Splunk documentation for more details about creating that IAM policy.
+Note that we use an IAM user instead of an IAM role as the latter requires an External ID that is only know at AWS integration creation time.
 
 Releasing the Provider
 ----------------------

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ The policies that this user must be granted are:
 ```
 
 See [Connect to AWS using the guided setup in Splunk Observability Cloud](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-wizardconfig.html) and [Enable CloudWatch Metric Streams](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-apiconfig.html#enable-cloudwatch-metric-streams) in Splunk documentation for more details about creating that IAM policy.
-Note that we use an IAM user instead of an IAM role as the latter requires an External ID that is only know at AWS integration creation time.
+
+Note that we use an IAM user instead of an IAM role as the latter requires an External ID that is only known at AWS integration creation time.
 
 Releasing the Provider
 ----------------------

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.8.6
+	github.com/signalfx/signalfx-go v1.8.7
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/signalfx/golib/v3 v3.3.37 h1:CvL6Q8hySjm7D82P039qH2lFWJvBa18IJdAwa4LH
 github.com/signalfx/golib/v3 v3.3.37/go.mod h1:zH70SVnrzVUqDmUFEwDk1HSwS71Pi2w3bSsNpnOtYuQ=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
 github.com/signalfx/sapm-proto v0.4.0/go.mod h1:x3gtwJ1GRejtkghB4nYpwixh2zqJrLbPU959ZNhM0Fk=
-github.com/signalfx/signalfx-go v1.8.6 h1:ntMMzwR+xeLOCrKT7QOpinctNuy7ltU5tH3TmIERs54=
-github.com/signalfx/signalfx-go v1.8.6/go.mod h1:YhPTMdQJDfphcRBdk+9acbbAw1gYY7z5BIHUWzLmGlA=
+github.com/signalfx/signalfx-go v1.8.7 h1:05lfikNYb1ef8+RxmxZS1JnS5DgRoBK1a0bgRzJoA+s=
+github.com/signalfx/signalfx-go v1.8.7/go.mod h1:YhPTMdQJDfphcRBdk+9acbbAw1gYY7z5BIHUWzLmGlA=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac h1:wbW+Bybf9pXxnCFAOWZTqkRjAc7rAIwo2e1ArUhiHxg=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/signalfx/resource_signalfx_aws_external_integration.go
+++ b/signalfx/resource_signalfx_aws_external_integration.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/signalfx/signalfx-go/integration"
 )
@@ -122,7 +124,68 @@ func integrationAWSExternalCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func integrationAWSExternalDelete(d *schema.ResourceData, meta interface{}) error {
+	return DoIntegrationAWSDelete(d, meta)
+}
+
+// DoIntegrationAWSDelete is public because it is also used by integrationAWSTokenDelete
+func DoIntegrationAWSDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
+	// Retrieve current integration state
+	int, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Id())
+	if err != nil {
+		return fmt.Errorf("Error fetching existing integration for integration %s, %s", d.Id(), err.Error())
+	}
+
+	// Only disable the Cloudwatch Metric Stream synchronization if needed
+	if int.MetricStreamsSyncState != "" && int.MetricStreamsSyncState != "DISABLED" {
+		int.MetricStreamsSyncState = "CANCELLING"
+		_, err := config.Client.UpdateAWSCloudWatchIntegration(context.TODO(), d.Id(), int)
+		if err != nil {
+			if strings.Contains(err.Error(), "40") {
+				err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
+			}
+			return err
+		}
+		// Wait for expected Cloudwatch Metric Streams sync state to be disabled
+		if _, err = waitForAWSIntegrationMetricStreamsSyncStateDelete(d, config, int.Id); err != nil {
+			return err
+		}
+	}
+
 	return config.Client.DeleteAWSCloudWatchIntegration(context.TODO(), d.Id())
+}
+
+func waitForAWSIntegrationMetricStreamsSyncStateDelete(d *schema.ResourceData, config *signalfxConfig, id string) (*integration.AwsCloudWatchIntegration, error) {
+	pending := []string{
+		"ENABLED",
+		"CANCELLING",
+	}
+	target := []string{
+		"",
+		"DISABLED",
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: pending,
+		Target:  target,
+		Refresh: func() (interface{}, string, error) {
+			int, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), id)
+			if err != nil {
+				return 0, "", err
+			}
+			return int, int.MetricStreamsSyncState, nil
+		},
+		Timeout:    d.Timeout(schema.TimeoutUpdate) - time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	int, err := stateConf.WaitForState()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error waiting for integration (%s) Cloudwatch Metric Streams sync state to become disabled: %s",
+			id, err)
+	}
+	return int.(*integration.AwsCloudWatchIntegration), nil
 }

--- a/signalfx/resource_signalfx_aws_external_integration.go
+++ b/signalfx/resource_signalfx_aws_external_integration.go
@@ -134,7 +134,7 @@ func DoIntegrationAWSDelete(d *schema.ResourceData, meta interface{}) error {
 	// Retrieve current integration state
 	int, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Id())
 	if err != nil {
-		return fmt.Errorf("Error fetching existing integration for integration %s, %s", d.Id(), err.Error())
+		return fmt.Errorf("Error fetching existing integration %s, %s", d.Id(), err.Error())
 	}
 
 	// Only disable the Cloudwatch Metric Stream synchronization if needed

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/signalfx/signalfx-go/integration"
@@ -177,6 +179,12 @@ func integrationAWSResource() *schema.Resource {
 				Default:     false,
 				Description: "Enables the use of Amazon's GetMetricData API. Defaults to `false`.",
 			},
+			"use_metric_streams_sync": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Enables the use of Cloudwatch Metric Streams for metrics synchronization.",
+			},
 			"named_token": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -261,6 +269,9 @@ func awsIntegrationAPIToTF(d *schema.ResourceData, aws *integration.AwsCloudWatc
 		return err
 	}
 	if err := d.Set("use_get_metric_data_method", aws.UseGetMetricDataMethod); err != nil {
+		return err
+	}
+	if err := d.Set("use_metric_streams_sync", aws.MetricStreamsSyncState == "ENABLED"); err != nil {
 		return err
 	}
 	if err := d.Set("enable_check_large_volume", aws.EnableCheckLargeVolume); err != nil {
@@ -356,7 +367,7 @@ func awsIntegrationAPIToTF(d *schema.ResourceData, aws *integration.AwsCloudWatc
 	return nil
 }
 
-func getPayloadAWSIntegration(d *schema.ResourceData) (*integration.AwsCloudWatchIntegration, error) {
+func getPayloadAWSIntegration(d *schema.ResourceData, useMetricStreamHasChange bool) (*integration.AwsCloudWatchIntegration, error) {
 
 	aws := &integration.AwsCloudWatchIntegration{
 		Name:                   d.Get("name").(string),
@@ -366,6 +377,13 @@ func getPayloadAWSIntegration(d *schema.ResourceData) (*integration.AwsCloudWatc
 		ImportCloudWatch:       d.Get("import_cloud_watch").(bool),
 		UseGetMetricDataMethod: d.Get("use_get_metric_data_method").(bool),
 		EnableCheckLargeVolume: d.Get("enable_check_large_volume").(bool),
+	}
+
+	if d.Get("use_metric_streams_sync").(bool) {
+		aws.MetricStreamsSyncState = "ENABLED"
+	} else if useMetricStreamHasChange {
+		// Only set to CANCELLING state if use_metric_streams_sync is false and it has changed, meaning it was ENABLED before
+		aws.MetricStreamsSyncState = "CANCELLING"
 	}
 
 	if d.Get("external_id").(string) != "" {
@@ -510,30 +528,16 @@ func integrationAWSCreate(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("name", preInt.Name); err != nil {
 		return err
 	}
-	payload, err := getPayloadAWSIntegration(d)
-	if err != nil {
-		return fmt.Errorf("Failed creating json payload: %s", err.Error())
-	}
+	d.SetId(preInt.Id)
 
-	debugOutput, _ := json.Marshal(payload)
-	log.Printf("[DEBUG] SignalFx: Create (Update) AWS Integration Payload: %s", string(debugOutput))
-
-	int, err := config.Client.UpdateAWSCloudWatchIntegration(context.TODO(), d.Get("integration_id").(string), payload)
-	if err != nil {
-		if strings.Contains(err.Error(), "40") {
-			err = fmt.Errorf("%s\nPlease verify you are using an admin token when working with integrations", err.Error())
-		}
-		return err
-	}
-	d.SetId(int.Id)
-
-	return awsIntegrationAPIToTF(d, int)
+	return integrationAWSUpdate(d, meta)
 }
 
 func integrationAWSUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
-	payload, err := getPayloadAWSIntegration(d)
+	useMetricStreamsSyncHasChange := d.HasChange("use_metric_streams_sync")
+	payload, err := getPayloadAWSIntegration(d, useMetricStreamsSyncHasChange)
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
@@ -548,9 +552,65 @@ func integrationAWSUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		return err
 	}
-	d.SetId(int.Id)
+
+	if useMetricStreamsSyncHasChange {
+		// Wait for expected Cloudwatch Metric Streams sync state to be reached
+		if int, err = waitForAWSIntegrationMetricStreamsSyncState(d, config, int.Id); err != nil {
+			return err
+		}
+	}
 
 	return awsIntegrationAPIToTF(d, int)
+}
+
+func waitForAWSIntegrationMetricStreamsSyncState(d *schema.ResourceData, config *signalfxConfig, id string) (*integration.AwsCloudWatchIntegration, error) {
+	var pending, target []string
+	useMetricStreamsSync := d.Get("use_metric_streams_sync").(bool)
+	var expectedState string
+	if useMetricStreamsSync {
+		expectedState = "enabled"
+		pending = []string{
+			"DISABLED",
+			"CANCELLING",
+			"CANCELLATION_FAILED",
+		}
+		target = []string{
+			"ENABLED",
+		}
+	} else {
+		expectedState = "disabled"
+		pending = []string{
+			"ENABLED",
+			"CANCELLING",
+		}
+		target = []string{
+			"",
+			"DISABLED",
+		}
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: pending,
+		Target:  target,
+		Refresh: func() (interface{}, string, error) {
+			int, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), id)
+			if err != nil {
+				return 0, "", err
+			}
+			return int, int.MetricStreamsSyncState, nil
+		},
+		Timeout:    d.Timeout(schema.TimeoutUpdate) - time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	int, err := stateConf.WaitForState()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error waiting for integration (%s) Cloudwatch Metric Streams sync state to become %s: %s",
+			id, expectedState, err)
+	}
+	return int.(*integration.AwsCloudWatchIntegration), nil
 }
 
 func integrationAWSDelete(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_aws_integration_test.go
+++ b/signalfx/resource_signalfx_aws_integration_test.go
@@ -3,6 +3,7 @@ package signalfx
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -12,148 +13,222 @@ import (
 )
 
 const newIntegrationAWSConfig = `
-resource "signalfx_aws_external_integration" "aws_ext_myteamXX" {
+  resource "signalfx_aws_external_integration" "aws_ext_myteamXX" {
 	name = "AWSFoo"
-}
+  }
 
-resource "signalfx_aws_integration" "aws_myteamXX" {
-    enabled = false
+  resource "signalfx_aws_integration" "aws_myteamXX" {
+	enabled = false
 
-		integration_id = "${signalfx_aws_external_integration.aws_ext_myteamXX.id}"
-		external_id = "${signalfx_aws_external_integration.aws_ext_myteamXX.external_id}"
-		role_arn = "arn:aws:iam::XXX:role/SignalFx-Read-Role"
-		regions = ["us-east-1"]
-		poll_rate = 300
-		import_cloud_watch = true
-		enable_aws_usage = true
+	integration_id     = signalfx_aws_external_integration.aws_ext_myteamXX.id
+	external_id        = signalfx_aws_external_integration.aws_ext_myteamXX.external_id
+	role_arn           = "arn:aws:iam::XXX:role/SignalFx-Read-Role"
+	regions            = ["us-east-1"]
+	poll_rate          = 300
+	import_cloud_watch = true
+	enable_aws_usage   = true
 
-		custom_namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "fart"
-		}
+	custom_namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "fart"
+	}
 
-		custom_namespace_sync_rule {
-			namespace = "custom"
-		}
+	custom_namespace_sync_rule {
+	  namespace = "custom"
+	}
 
-		namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "AWS/EC2"
-		}
-}
+	namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "AWS/EC2"
+	}
+  }
 
-resource "signalfx_aws_token_integration" "aws_tok_myteamXX" {
+  resource "signalfx_aws_token_integration" "aws_tok_myteamXX" {
 	name = "AWSFooToken"
-}
+  }
 
-resource "signalfx_aws_integration" "aws_myteam_tokXX" {
-    enabled = false
+  resource "signalfx_aws_integration" "aws_myteam_tokXX" {
+	enabled = false
 
-		integration_id = "${signalfx_aws_token_integration.aws_tok_myteamXX.id}"
-		token = "token123"
-		key = "key123"
-		regions = ["us-east-1"]
-		poll_rate = 300
-		import_cloud_watch = true
-		enable_aws_usage = true
-		use_get_metric_data_method = true
+	integration_id             = signalfx_aws_token_integration.aws_tok_myteamXX.id
+	token                      = "token123"
+	key                        = "key123"
+	regions                    = ["us-east-1"]
+	poll_rate                  = 300
+	import_cloud_watch         = true
+	enable_aws_usage           = true
+	use_get_metric_data_method = true
 
-		custom_namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "fart"
-		}
+	custom_namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "fart"
+	}
 
-		custom_namespace_sync_rule {
-			namespace = "custom"
-		}
+	custom_namespace_sync_rule {
+	  namespace = "custom"
+	}
 
-		namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "AWS/EC2"
-		}
-}
+	namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "AWS/EC2"
+	}
+  }
 `
 
 const updatedIntegrationAWSConfig = `
-resource "signalfx_aws_external_integration" "aws_ext_myteamXX" {
+  resource "signalfx_aws_external_integration" "aws_ext_myteamXX" {
 	name = "AWSFoo"
-}
+  }
 
-resource "signalfx_aws_integration" "aws_myteamXX" {
-    enabled = false
+  resource "signalfx_aws_integration" "aws_myteamXX" {
+	enabled = false
 
-		integration_id = "${signalfx_aws_external_integration.aws_ext_myteamXX.id}"
-		external_id = "${signalfx_aws_external_integration.aws_ext_myteamXX.external_id}"
-		role_arn = "arn:aws:iam::XXX:role/SignalFx-Read-Role"
-		regions = ["us-east-1"]
-		poll_rate = 300
-		import_cloud_watch = true
-		enable_aws_usage = true
+	integration_id     = signalfx_aws_external_integration.aws_ext_myteamXX.id
+	external_id        = signalfx_aws_external_integration.aws_ext_myteamXX.external_id
+	role_arn           = "arn:aws:iam::XXX:role/SignalFx-Read-Role"
+	regions            = ["us-east-1"]
+	poll_rate          = 300
+	import_cloud_watch = true
+	enable_aws_usage   = true
 
-		custom_namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "fart"
-		}
+	custom_namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "fart"
+	}
 
-		custom_namespace_sync_rule {
-			namespace = "custom"
-		}
+	custom_namespace_sync_rule {
+	  namespace = "custom"
+	}
 
-		namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "AWS/EC2"
-		}
-}
+	namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "AWS/EC2"
+	}
+  }
 
-resource "signalfx_aws_token_integration" "aws_tok_myteamXX" {
+  resource "signalfx_aws_token_integration" "aws_tok_myteamXX" {
 	name = "AWSFooToken"
-}
+  }
 
-resource "signalfx_aws_integration" "aws_myteam_tokXX" {
-    enabled = false
+  resource "signalfx_aws_integration" "aws_myteam_tokXX" {
+	enabled = false
 
-		integration_id = "${signalfx_aws_token_integration.aws_tok_myteamXX.id}"
-		token = "token123"
-		key = "key123"
-		regions = ["us-east-1"]
-		poll_rate = 300
-		import_cloud_watch = true
-		enable_aws_usage = true
-		use_get_metric_data_method = true
+	integration_id             = signalfx_aws_token_integration.aws_tok_myteamXX.id
+	token                      = "token123"
+	key                        = "key123"
+	regions                    = ["us-east-1"]
+	poll_rate                  = 300
+	import_cloud_watch         = true
+	enable_aws_usage           = true
+	use_get_metric_data_method = true
 
-		custom_namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "fart"
-		}
+	custom_namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "fart"
+	}
 
-		custom_namespace_sync_rule {
-			namespace = "custom"
-		}
+	custom_namespace_sync_rule {
+	  namespace = "custom"
+	}
 
-		namespace_sync_rule {
-			default_action = "Exclude"
-			filter_action = "Include"
-			filter_source = "filter('code', '200')"
-			namespace = "AWS/EC2"
-		}
-}
+	namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "AWS/EC2"
+	}
+  }
+`
+
+const updatedIntegrationAWSConfigMetricStreams = `
+  resource "signalfx_aws_external_integration" "aws_ext_myteamXX" {
+	name = "AWSFoo"
+  }
+
+  resource "signalfx_aws_integration" "aws_myteamXX" {
+	enabled = false
+
+	integration_id     = signalfx_aws_external_integration.aws_ext_myteamXX.id
+	external_id        = signalfx_aws_external_integration.aws_ext_myteamXX.external_id
+	role_arn           = "arn:aws:iam::XXX:role/SignalFx-Read-Role"
+	regions            = ["us-east-1"]
+	poll_rate          = 300
+	import_cloud_watch = true
+	enable_aws_usage   = true
+
+	custom_namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "fart"
+	}
+
+	custom_namespace_sync_rule {
+	  namespace = "custom"
+	}
+
+	namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "AWS/EC2"
+	}
+  }
+
+  resource "signalfx_aws_token_integration" "aws_tok_myteamXX" {
+	name = "AWSFooToken"
+  }
+
+  resource "signalfx_aws_integration" "aws_myteam_tokXX" {
+	enabled = true # This is required to be able to cancel AWS Metric Streams synchronization.
+
+	integration_id          = signalfx_aws_token_integration.aws_tok_myteamXX.id
+	token                   = "%s"
+	key                     = "%s"
+	regions                 = ["us-east-1"]
+	poll_rate               = 300
+	import_cloud_watch      = true
+	enable_aws_usage        = true
+	use_metric_streams_sync = %s
+
+	custom_namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "fart"
+	}
+
+	custom_namespace_sync_rule {
+	  namespace = "custom"
+	}
+
+	namespace_sync_rule {
+	  default_action = "Exclude"
+	  filter_action  = "Include"
+	  filter_source  = "filter('code', '200')"
+	  namespace      = "AWS/EC2"
+	}
+  }
 `
 
 func TestAccCreateUpdateIntegrationAWS(t *testing.T) {
+	awsAccessKeyID := os.Getenv("SFX_TEST_AWS_ACCESS_KEY_ID")
+	awsSecretAccessKey := os.Getenv("SFX_TEST_AWS_SECRET_ACCESS_KEY")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -170,6 +245,53 @@ func TestAccCreateUpdateIntegrationAWS(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIntegrationAWSResourceExists,
 					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteamXX", "name", "AWSFoo"),
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteam_tokXX", "name", "AWSFooToken"),
+				),
+			},
+			// Update It again to enable Cloudwatch Metric Streams synchronization
+			{
+				SkipFunc: testAccIntegrationAWSSkipAWSMetricStreamsMissingCredentials(t, awsAccessKeyID, awsSecretAccessKey),
+				Config:   fmt.Sprintf(updatedIntegrationAWSConfigMetricStreams, awsAccessKeyID, awsSecretAccessKey, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationAWSResourceExists,
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteamXX", "name", "AWSFoo"),
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteam_tokXX", "name", "AWSFooToken"),
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteam_tokXX", "use_metric_streams_sync", "true"),
+				),
+			},
+			// Update It again to disable Cloudwatch Metric Streams synchronization
+			{
+				SkipFunc: testAccIntegrationAWSSkipAWSMetricStreamsMissingCredentials(t, awsAccessKeyID, awsSecretAccessKey),
+				Config:   fmt.Sprintf(updatedIntegrationAWSConfigMetricStreams, awsAccessKeyID, awsSecretAccessKey, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationAWSResourceExists,
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteamXX", "name", "AWSFoo"),
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteam_tokXX", "name", "AWSFooToken"),
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteam_tokXX", "use_metric_streams_sync", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCreateDeleteIntegrationAWSMetricStream(t *testing.T) {
+	awsAccessKeyID := os.Getenv("SFX_TEST_AWS_ACCESS_KEY_ID")
+	awsSecretAccessKey := os.Getenv("SFX_TEST_AWS_SECRET_ACCESS_KEY")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccIntegrationAWSDestroy,
+		Steps: []resource.TestStep{
+			// Create integration with Cloudwatch Metric Streams synchronization enabled without any additional step to disable it before deletion. That should automatically be done in the delete phase.
+			{
+				SkipFunc: testAccIntegrationAWSSkipAWSMetricStreamsMissingCredentials(t, awsAccessKeyID, awsSecretAccessKey),
+				Config:   fmt.Sprintf(updatedIntegrationAWSConfigMetricStreams, awsAccessKeyID, awsSecretAccessKey, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationAWSResourceExists,
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteamXX", "name", "AWSFoo"),
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteam_tokXX", "name", "AWSFooToken"),
+					resource.TestCheckResourceAttr("signalfx_aws_integration.aws_myteam_tokXX", "use_metric_streams_sync", "true"),
 				),
 			},
 		},
@@ -228,4 +350,14 @@ func TestValidateFilterAction(t *testing.T) {
 
 	_, errors = validateFilterAction("Fart", "")
 	assert.Equal(t, 1, len(errors), "Errors for invalid value")
+}
+
+func testAccIntegrationAWSSkipAWSMetricStreamsMissingCredentials(t *testing.T, awsAccessKeyID, awsSecretAccessKey string) func() (bool, error) {
+	return func() (bool, error) {
+		if awsAccessKeyID != "" && awsSecretAccessKey != "" {
+			return false, nil
+		}
+		t.Log("Skipping step: Environment variables SFX_TEST_AWS_ACCESS_KEY_ID and SFX_TEST_AWS_SECRET_ACCESS_KEY must be set for testing AWS Cloudwatch Metric Streams synchronization.")
+		return true, nil
+	}
 }

--- a/signalfx/resource_signalfx_aws_token_integration.go
+++ b/signalfx/resource_signalfx_aws_token_integration.go
@@ -110,7 +110,5 @@ func integrationAWSTokenCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func integrationAWSTokenDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*signalfxConfig)
-
-	return config.Client.DeleteAWSCloudWatchIntegration(context.TODO(), d.Id())
+	return DoIntegrationAWSDelete(d, meta)
 }

--- a/website/docs/r/aws_integration.html.markdown
+++ b/website/docs/r/aws_integration.html.markdown
@@ -76,10 +76,12 @@ resource "signalfx_aws_integration" "aws_myteam" {
   * `namespace` - (Required) An AWS custom namespace having custom AWS metrics that you want to sync with SignalFx. See the AWS documentation on publishing metrics for more information.
 * `enable_aws_usage` - (Optional) Flag that controls how SignalFx imports usage metrics from AWS to use with AWS Cost Optimizer. If `true`, SignalFx imports the metrics.
 * `import_cloud_watch` - (Optional) Flag that controls how SignalFx imports Cloud Watch metrics. If true, SignalFx imports Cloud Watch metrics from AWS.
-* `key` - (Optional) If you specify `auth_method = \"SecurityToken\"` in your request to create an AWS integration object, use this property to specify the key.
+* `key` - (Optional) If you specify `auth_method = \"SecurityToken\"` in your request to create an AWS integration object, use this property to specify the key (this is typically equivalent to the `AWS_SECRET_ACCESS_KEY` environment variable).
+* `token` - (Optional) If you specify `auth_method = \"SecurityToken\"` in your request to create an AWS integration object, use this property to specify the token (this is typically equivalent to the `AWS_ACCESS_KEY_ID` environment variable).
 * `regions` - (Optional) List of AWS regions that SignalFx should monitor.
 * `role_arn` - (Optional) Role ARN that you add to an existing AWS integration object. **Note**: Ensure you use the `arn` property of your role, not the id!
 * `services` - (Optional) List of AWS services that you want SignalFx to monitor. Each element is a string designating an AWS service. Conflicts with `namespace_sync_rule`. See the documentation for [Creating Integrations](https://developers.signalfx.com/integrations_reference.html#operation/Create%20Integration) for valida values.
 * `poll_rate` - (Optional) AWS poll rate (in seconds). Value between `60` and `300`.
 * `use_get_metric_data_method` - (Optional) Enable the use of Amazon's `GetMetricData` for collecting metrics. Note that this requires the inclusion of the `"cloudwatch:GetMetricData"` permission.
+* `use_metric_streams_sync` - (Optional) Enable the use of Amazon Cloudwatch Metric Streams for ingesting metrics. Note that this requires the inclusion of `"cloudwatch:ListMetricStreams"`,`"cloudwatch:GetMetricStream"`, `"cloudwatch:PutMetricStream"`, `"cloudwatch:DeleteMetricStream"`, `"cloudwatch:StartMetricStreams"`, `"cloudwatch:StopMetricStreams"` and `"iam:PassRole"` permissions.
 * `enable_check_large_volume` - (Optional) Controls how SignalFx checks for large amounts of data for this AWS integration. If `true`, SignalFx monitors the amount of data coming in from the integration.


### PR DESCRIPTION
This PR adds `use_metric_streams_sync` field to the `signalfx_aws_integration` resource.

Parly resolves https://github.com/splunk-terraform/terraform-provider-signalfx/issues/318 (does not address the log part which is going to be added soon in a separate PR).

Heavily based on @pdecat [work](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/344) (thanks!).