### PR TITLE
Upgrade `signalfx-go` to 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+BUGFIXES:
+* upgrade signalfx-go to fix issue with `show_data_markers` field on detector resource
+
 ## 6.12.1
 IMPROVEMENTS:
 * resource/signalfx_aws_integration: documentation update (metric_stats_to_sync parameter) [#369](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## UNRELEASED
 
 BUGFIXES:
-* upgrade signalfx-go to fix issue with `show_data_markers` field on detector resource
+* upgrade signalfx-go to fix issue with `show_data_markers` field on detector resource [#371](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/371)
 
 ## 6.12.1
 IMPROVEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.18.0
+	github.com/signalfx/signalfx-go v1.19.0
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/signalfx/golib/v3 v3.3.37 h1:CvL6Q8hySjm7D82P039qH2lFWJvBa18IJdAwa4LH
 github.com/signalfx/golib/v3 v3.3.37/go.mod h1:zH70SVnrzVUqDmUFEwDk1HSwS71Pi2w3bSsNpnOtYuQ=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
 github.com/signalfx/sapm-proto v0.4.0/go.mod h1:x3gtwJ1GRejtkghB4nYpwixh2zqJrLbPU959ZNhM0Fk=
-github.com/signalfx/signalfx-go v1.18.0 h1:Mu7c/f/7rjOj/I1ouJ9JrVd4cA1xk/jVtEJyzbs4dF8=
-github.com/signalfx/signalfx-go v1.18.0/go.mod h1:YhPTMdQJDfphcRBdk+9acbbAw1gYY7z5BIHUWzLmGlA=
+github.com/signalfx/signalfx-go v1.19.0 h1:ZjHL7DRLsKfM1j87q0FjqVMx3zxYfd5zyRg2Kx0Nbec=
+github.com/signalfx/signalfx-go v1.19.0/go.mod h1:YhPTMdQJDfphcRBdk+9acbbAw1gYY7z5BIHUWzLmGlA=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac h1:wbW+Bybf9pXxnCFAOWZTqkRjAc7rAIwo2e1ArUhiHxg=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=


### PR DESCRIPTION
Upgrade `signalfx-go` to fix issue with sending `false` value for `show_data_markers` in `detector` resource