### PR TITLE
Change `rules` from Set to List in detector resource

### DIFF
--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -109,9 +109,9 @@ func detectorResource() *schema.Resource {
 				Description: "Team IDs to associate the detector to",
 			},
 			"rule": &schema.Schema{
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Required:    true,
-				Description: "Set of rules used for alerting",
+				Description: "List of rules used for alerting",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"severity": &schema.Schema{
@@ -167,7 +167,7 @@ func detectorResource() *schema.Resource {
 						},
 					},
 				},
-				Set: resourceRuleHash,
+				//Set: resourceRuleHash,
 			},
 			"authorized_writer_teams": &schema.Schema{
 				Type:        schema.TypeSet,
@@ -288,7 +288,7 @@ func timeRangeStateUpgradeV0(rawState map[string]interface{}, meta interface{}) 
 */
 func getPayloadDetector(d *schema.ResourceData) (*detector.CreateUpdateDetectorRequest, error) {
 
-	tfRules := d.Get("rule").(*schema.Set).List()
+	tfRules := d.Get("rule").([]interface{}).List()
 	rulesList := make([]*detector.Rule, len(tfRules))
 	for i, tfRule := range tfRules {
 		tfRule := tfRule.(map[string]interface{})
@@ -790,7 +790,7 @@ func validateProgramTextCondition(d *schema.ResourceDiff, meta interface{}) bool
 */
 func validateProgramText(d *schema.ResourceDiff, meta interface{}) error {
 
-	tfRules := d.Get("rule").(*schema.Set).List()
+	tfRules := d.Get("rule").([]interface{}).List()
 	rulesList := make([]*detector.Rule, len(tfRules))
 	for i, tfRule := range tfRules {
 		tfRule := tfRule.(map[string]interface{})


### PR DESCRIPTION
We've faced a several issues when started migrating hundreds of existing detectors into Terraform due to `rule` being Set.

1. We can't ignore only changes in specific attributes of the `rule`, but rule block as a whole.
Taking into account that any threshold change introduced via SignalFX UI or API would diverge the `description` attribute of modified rule to some autogenerated text, it became very hard to keep our Terraform states with 0 drifts.
At the end we're used to completely ignore changes in the `rule` block, effectively loosing the possibility to modify other rule attributes from within Terraform code.

2. Another downside of TypeSet is that Terraform plan outputs always show re-creation of all rule objects instead of showing actual diff. 
For example, if I have 3 rules and wants to change the `disabled` attribute in one of them - TF plan would show that all old rules should be removed and 3 new ones would be added as it can't match old Set items with new ones.

P.s. I've built the provider locally & tested it on several existing detectors & internally developed modules without any compatibility issues noticed.
Please let me know if there're some technical constrains to merge this change