### PR TITLE
Fix token not persisting when limits is missing

### DIFF
--- a/signalfx/resource_signalfx_org_token.go
+++ b/signalfx/resource_signalfx_org_token.go
@@ -318,22 +318,22 @@ func orgTokenAPIToTF(d *schema.ResourceData, t *orgtoken.Token) error {
 				}
 			}
 		}
+	}
 
-		notifications := make([]string, len(t.Notifications))
-		for i, not := range t.Notifications {
-			tfNot, err := getNotifyStringFromAPI(not)
-			if err != nil {
-				return err
-			}
-			notifications[i] = tfNot
-		}
-		if err := d.Set("notifications", notifications); err != nil {
+	notifications := make([]string, len(t.Notifications))
+	for i, not := range t.Notifications {
+		tfNot, err := getNotifyStringFromAPI(not)
+		if err != nil {
 			return err
 		}
+		notifications[i] = tfNot
+	}
+	if err := d.Set("notifications", notifications); err != nil {
+		return err
+	}
 
-		if err := d.Set("secret", t.Secret); err != nil {
-			return err
-		}
+	if err := d.Set("secret", t.Secret); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This bug has been around for years but it's only exposed when entitlement is missing the `tokenLimits` feature.
The json response for token creation against an org with no `tokenLimits` will look like this (note: `"limits" : {...` is missing )

```
{
  "authScopes" : [ "INGEST", "API" ],
  "created" : 1662988122213,
  "description" : "test",
  "disabled" : false,
  "expiry" : 1662988122213,
  "id" : "xxxxxx",
  "lastUpdated" : 1662988122213,
  "lastUpdatedBy" : null,
  "latestRotation" : 1662988122213,
  "name" : "test",
  "permissions" : null,
  "secret" : "xxxxxx"
}
```
With `limits` missing, the provider will skip persisting the `token` and `notifications`

Fixes: https://github.com/splunk-terraform/terraform-provider-signalfx/issues/310

Signed-off-by: Dani Louca <dlouca@splunk.com>