### PR TITLE
Improve the way dashboard group tells what mirrored dashboards are

### DIFF
--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -220,7 +220,7 @@ func dashboardgroupExists(d *schema.ResourceData, meta interface{}) (bool, error
 }
 
 /*
-  Use Resource object to construct json payload in order to create a dasboard group
+Use Resource object to construct json payload in order to create a dasboard group
 */
 func getPayloadDashboardGroup(d *schema.ResourceData) *dashboard_group.CreateUpdateDashboardGroupRequest {
 	cudgr := &dashboard_group.CreateUpdateDashboardGroupRequest{
@@ -604,7 +604,9 @@ func dashboardgroupUpdate(d *schema.ResourceData, meta interface{}) error {
 func getNonMirroredDashes(config *signalfxConfig, d *schema.ResourceData) ([]*dashboard_group.DashboardConfig, error) {
 	mirrorIDsToBeOmitted := map[string]bool{}
 	mirroredDashboardConfigs, err := getMirroredDashboardConfigs(config, d)
-	if err == nil {
+	if err != nil {
+		return nil, fmt.Errorf("failed to get mirrored dashboard list for %s: %v", d.Id(), err)
+	} else {
 		for _, dc := range mirroredDashboardConfigs {
 			mirrorIDsToBeOmitted[dc.DashboardId] = true
 		}

--- a/website/docs/r/dashboard_group.html.markdown
+++ b/website/docs/r/dashboard_group.html.markdown
@@ -109,3 +109,4 @@ The following arguments are supported in the resource block:
 In a addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the integration.
+* `dashboard.config_id` - The ID of the association between the dashboard group and the dashboard


### PR DESCRIPTION
Dashboard group is telling if a dashboard is mirrored or not based on whether there is any override field or not in the dashboard config object.

This makes wrong judgements often times and skips adding mirrored dashboard that should have been added to the dashboard group.

Then, this misjudgement leads to the existing dashboard in the config not being recognized and being added over and over whenever the config is applied instead of being idempotent with the config.

This change also improves dashboard trackability by keeping track of config_id of dashboard configs.