### PR TITLE
bug fix - adding color option to viz_options of table chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 6.20.0
+## Unreleased
+BUGFIXES
+* resource/signalfx_table_chart: Added `color` option to `viz_options` to fix `Error: Invalid address to set: []string{"viz_options", "0", "color"}` [#410](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/410)
 
- IMPROVEMENTS:
- * resource/signalfx_table_chart: Added `viz_options` option [#402](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/402)
+## 6.20.0
+IMPROVEMENTS:
+* resource/signalfx_table_chart: Added `viz_options` option [#402](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/402)
 
 ## 6.19.0
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.22.0
 BUGFIXES
 * resource/signalfx_table_chart: Added `color` option to `viz_options` to fix `Error: Invalid address to set: []string{"viz_options", "0", "color"}` [#410](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/410)
 

--- a/signalfx/resource_signalfx_table_chart.go
+++ b/signalfx/resource_signalfx_table_chart.go
@@ -98,6 +98,12 @@ func tableChartResource() *schema.Resource {
 							Required:    true,
 							Description: "The label used in the publish statement that displays the plot (metric time series data) you want to customize",
 						},
+						"color": &schema.Schema{
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Color to use",
+							ValidateFunc: validatePerSignalColor,
+						},
 						"display_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/signalfx/resource_signalfx_table_chart_test.go
+++ b/signalfx/resource_signalfx_table_chart_test.go
@@ -26,6 +26,7 @@ resource "signalfx_table_chart" "mychartTB" {
 		value_unit = "Bit"
 		value_prefix = "foo"
 		value_suffix = "bar"
+		color = "green"
 	}
 }
 `
@@ -47,6 +48,7 @@ resource "signalfx_table_chart" "mychartTB" {
 		value_unit = "Bit"
 		value_prefix = "Updated foo"
 		value_suffix = "Updated bar"
+		color = "blue"
 	}
 }
 `
@@ -75,6 +77,7 @@ func TestAccCreateUpdateTableChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_table_chart.mychartTB", "viz_options.value_unit", "Bit"),
 					resource.TestCheckResourceAttr("signalfx_table_chart.mychartTB", "viz_options.value_prefix", "foo"),
 					resource.TestCheckResourceAttr("signalfx_table_chart.mychartTB", "viz_options.value_suffix", "bar"),
+					resource.TestCheckResourceAttr("signalfx_table_chart.mychartTB", "viz_options.color", "green"),
 				),
 			},
 			{
@@ -94,6 +97,8 @@ func TestAccCreateUpdateTableChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_table_chart.mychartTB", "viz_options.display_name", "Updated CPU Idle Display"),
 					resource.TestCheckResourceAttr("signalfx_table_chart.mychartTB", "viz_options.value_prefix", "Updated foo"),
 					resource.TestCheckResourceAttr("signalfx_table_chart.mychartTB", "viz_options.value_suffix", "Updated bar"),
+					resource.TestCheckResourceAttr("signalfx_table_chart.mychartTB", "viz_options.value_suffix", "Updated bar"),
+					resource.TestCheckResourceAttr("signalfx_table_chart.mychartTB", "viz_options.color", "blue"),
 				),
 			},
 		},


### PR DESCRIPTION
SignalFX terraform provider version 6.20.0 throws following error while using table chart

Error: Invalid address to set: []string{"viz_options", "0", "color"}
│ 
│   with module.chart-test-dashboards.module.table-chart-test.signalfx_table_chart.chart0,
│   on ../../charts/table_charts/table-chart/main.tf line 1, in resource "signalfx_table_chart" "chart0":
│    1: resource "signalfx_table_chart" "chart0" {
│ 
╵

Though SignalFX UI does not support color for table chart, adding color to viz_options to fix above error.