### PR TITLE
Prevent dashboard_group resource from adding empty dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+BUGFIXES:
+* remove empty dashboards in tfstate when non-mirrored dashboards are included in a dashboard group [#413](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/413)
+
 ## 6.20.0
 
  IMPROVEMENTS:

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -484,8 +484,6 @@ func dashboardGroupAPIToTF(d *schema.ResourceData, dg *dashboard_group.Dashboard
 	}
 
 	if len(dg.DashboardConfigs) > 0 {
-		dConfigs := make([]map[string]interface{}, len(dg.DashboardConfigs))
-
 		// Collect a list of mirrored dashboard configs
 		config := meta.(*signalfxConfig)
 		mirroredDashboardConfigs, err := getMirroredDashboardConfigs(config, d)
@@ -493,6 +491,7 @@ func dashboardGroupAPIToTF(d *schema.ResourceData, dg *dashboard_group.Dashboard
 			return err
 		}
 
+		dConfigs := make([]map[string]interface{}, len(mirroredDashboardConfigs))
 		for i, dc := range mirroredDashboardConfigs {
 			dConf := make(map[string]interface{})
 			dConf["config_id"] = dc.ConfigId


### PR DESCRIPTION
This change fixes an issue that dashboard_group getting empty dashboards when it has non-mirrored dashboards associated with it.

The root cause of the issue was an inaccurate length of dashboard slice of the dashboard group, and this change fixes the issue by making the slice have the proper number of items.