### PR TITLE
Deprecate use_get_metric_data_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+IMPROVEMENTS:
+* Deprecate `use_get_metric_data_method` in AWS integration resource
+
 ## 6.23.0
 IMPROVEMENTS:
 * provider: Use go-retryablehttp for automatic retries with exponential backoff. Add `retry_max_attempts` (default=4), `retry_wait_min_seconds` (default=1), and `retry_wait_max_seconds` (default=30) configuration options. [#416](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/416)

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -188,6 +188,7 @@ func integrationAWSResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
+				Deprecated:  "This field will be removed",
 				Description: "Enables the use of Amazon's GetMetricData API. Defaults to `false`.",
 			},
 			"use_metric_streams_sync": &schema.Schema{


### PR DESCRIPTION
`GetMetricData` will be enforced by default and this field won't be necessary anymore.
See https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-api-notice.html#nav-GetMetricStatistics-API-deprecation-notice