### PR TITLE
Restore whitelist for backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,28 @@
-## Unreleased
+## Unreleased 
+
+## 6.24.0
+BUGFIXES:
+* Fixes backwards incompatibility for GCP integration resource introduced in `6.21.0`
 
 IMPROVEMENTS:
 * Deprecate `use_get_metric_data_method` in AWS integration resource
 
 ## 6.23.0
+WARNING: This version is NOT backward compatible for GCP integration resource. This is fixed in 6.24.0
+
 IMPROVEMENTS:
 * provider: Use go-retryablehttp for automatic retries with exponential backoff. Add `retry_max_attempts` (default=4), `retry_wait_min_seconds` (default=1), and `retry_wait_max_seconds` (default=30) configuration options. [#416](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/416)
 * resource/signalfx_metric_ruleset: added along with docs
 
 ## 6.22.0
+WARNING: This version is NOT backward compatible for GCP integration resource. This is fixed in 6.24.0
+
 BUGFIXES
 * resource/signalfx_table_chart: Added `color` option to `viz_options` to fix `Error: Invalid address to set: []string{"viz_options", "0", "color"}` [#410](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/410)
 
 ## 6.21.0
+WARNING: This version is NOT backward compatible for GCP integration resource. This is fixed in 6.24.0
+
 IMPROVEMENTS:
 * resource/signalfx_gcp_integration: Add `custom_metric_type_domains` option and rename deprecated field `whitelist` to `include_list` [#412](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/412)
 

--- a/signalfx/resource_signalfx_gcp_integration.go
+++ b/signalfx/resource_signalfx_gcp_integration.go
@@ -75,9 +75,22 @@ func integrationGCPResource() *schema.Resource {
 				Description: "When this value is set to true Observability Cloud will force usage of a quota from the project where metrics are stored. For this to work the service account provided for the project needs to be provided with serviceusage.services.use permission or Service Usage Consumer role in this project. When set to false default quota settings are used.",
 			},
 			"include_list": &schema.Schema{
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Description: "List of custom metadata keys that you want Observability Cloud to collect for Compute Engine instances. This field replaces the deprecated field `whiteList`.",
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				Description:   "List of custom metadata keys that you want Observability Cloud to collect for Compute Engine instances.",
+				ConflictsWith: []string{"whitelist"},
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"whitelist": &schema.Schema{
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				Description:   "Compute Metadata Whitelist",
+				Deprecated:    "Please use include_list instead",
+				ConflictsWith: []string{"include_list"},
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -177,6 +190,10 @@ func getGCPPayloadIntegration(d *schema.ResourceData) *integration.GCPIntegratio
 		gcp.IncludeList = expandStringSetToSlice(val.(*schema.Set))
 	}
 
+	if val, ok := d.GetOk("whitelist"); ok {
+		gcp.Whitelist = expandStringSetToSlice(val.(*schema.Set))
+	}
+
 	if val, ok := d.GetOk("custom_metric_type_domains"); ok {
 		gcp.CustomMetricTypeDomains = expandStringSetToSlice(val.(*schema.Set))
 	}
@@ -221,6 +238,10 @@ func gcpIntegrationAPIToTF(d *schema.ResourceData, gcp *integration.GCPIntegrati
 	// because there's not much reason to poke at just the project id.
 
 	if err := d.Set("include_list", flattenStringSliceToSet(gcp.IncludeList)); err != nil {
+		return err
+	}
+
+	if err := d.Set("whitelist", flattenStringSliceToSet(gcp.Whitelist)); err != nil {
 		return err
 	}
 

--- a/signalfx/resource_signalfx_gcp_integration_test.go
+++ b/signalfx/resource_signalfx_gcp_integration_test.go
@@ -51,7 +51,7 @@ resource "signalfx_gcp_integration" "gcp_myteamXX" {
 
     use_metric_source_project_for_quota = true
 
-    custom_metric_type_domains = ["networking.googleapis.com/google_service/request_bytes_count"]
+    custom_metric_type_domains = ["networking.googleapis.com"]
 
 	import_gcp_metrics = false
 }

--- a/website/docs/r/gcp_integration.html.markdown
+++ b/website/docs/r/gcp_integration.html.markdown
@@ -34,13 +34,14 @@ resource "signalfx_gcp_integration" "gcp_myteam" {
 ## Argument Reference
 
 * `enabled` - (Required) Whether the integration is enabled.
+* `include_list` - (Optional) [Compute Metadata Include List](https://dev.splunk.com/observability/docs/integrations/gcp_integration_overview/).
 * `name` - (Required) Name of the integration.
 * `named_token` - (Optional) Name of the org token to be used for data ingestion. If not specified then default access token is used.
 * `poll_rate` - (Optional) GCP integration poll rate (in seconds). Value between `60` and `600`. Default: `300`.
 * `project_service_keys` - (Required) GCP projects to add.
 * `services` - (Optional) GCP service metrics to import. Can be an empty list, or not included, to import 'All services'. See the documentation for [Creating Integrations](https://dev.splunk.com/observability/reference/api/integrations/latest#endpoint-create-integration) for valid values.
 * `use_metric_source_project_for_quota` - (Optional) When this value is set to true Observability Cloud will force usage of a quota from the project where metrics are stored. For this to work the service account provided for the project needs to be provided with serviceusage.services.use permission or Service Usage Consumer role in this project. When set to false default quota settings are used.
-* `include_list` - (Optional) [Compute Metadata Include List](https://dev.splunk.com/observability/docs/integrations/gcp_integration_overview/).
+* `whitelist` - (Optional, Deprecated) [Compute Metadata Include List](https://dev.splunk.com/observability/docs/integrations/gcp_integration_overview/).
 
 ## Attributes Reference
 


### PR DESCRIPTION
This MR fixes backward incompatibility introduced in https://github.com/splunk-terraform/terraform-provider-signalfx/pull/412