### PR TITLE
Fix external-id when token-based AWS integration is created in two steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 8.0.0
 IMPROVEMENTS:
-* Removed AWS/Azure/GCP service (a.k.a. namespace) validation to make TF provider more flexible 
+* Remove AWS/Azure/GCP service (a.k.a. namespace) validation to make TF provider more flexible 
   and rely on the Splunk Observability Cloud API validation logic.
-* Removed data resources signalfx_aws_services, signalfx_azure_services, signalfx_gcp_services 
+* Remove data resources signalfx_aws_services, signalfx_azure_services, signalfx_gcp_services 
   as they were based on a no longer maintained lists in the signalfx-go library. Users may use 
   empty list to specify "all services" instead or use strings to specify selected services.
+* Fix external-id field handling when token based AWS integration is created in two separate
+  Terraform runs.
 
 ## 7.0.0
 BUGFIXES:

--- a/signalfx/resource_signalfx_aws_integration_ops.go
+++ b/signalfx/resource_signalfx_aws_integration_ops.go
@@ -32,7 +32,7 @@ func IntegrationAWSRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if int.ExternalId != "" {
+	if int.AuthMethod == integration.EXTERNAL_ID && int.ExternalId != "" {
 		if err := d.Set("external_id", int.ExternalId); err != nil {
 			return err
 		}

--- a/signalfx/resource_signalfx_aws_integration_test.go
+++ b/signalfx/resource_signalfx_aws_integration_test.go
@@ -62,36 +62,6 @@ const newIntegrationAWSConfig = `
   resource "signalfx_aws_token_integration" "aws_tok_myteamXX" {
 	name = "AWS TF Test (token/new)"
   }
-
-  resource "signalfx_aws_integration" "aws_myteam_tokXX" {
-	enabled = false
-
-	integration_id             = signalfx_aws_token_integration.aws_tok_myteamXX.id
-	token                      = "token123"
-	key                        = "key123"
-	regions                    = ["us-east-1"]
-	poll_rate                  = 300
-	import_cloud_watch         = true
-	enable_aws_usage           = true
-
-	custom_namespace_sync_rule {
-	  default_action = "Exclude"
-	  filter_action  = "Include"
-	  filter_source  = "filter('code', '200')"
-	  namespace      = "AWS/SomeCustomNamespace"
-	}
-
-	custom_namespace_sync_rule {
-	  namespace = "custom"
-	}
-
-	namespace_sync_rule {
-	  default_action = "Exclude"
-	  filter_action  = "Include"
-	  filter_source  = "filter('code', '200')"
-	  namespace      = "AWS/EC2"
-	}
-  }
 `
 
 const updatedIntegrationAWSConfig = `


### PR DESCRIPTION
This change fixes an issue when signalfx_aws_token_integration and signalfx_aws_integration resources were created in two separate Terraform runs.

The issue was "panic: Invalid address to set: []string{"external_id"}".