### PR TITLE
detector: fix an issue with deleting all teams/tags/authorized users/teas=ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 9.1.5
+
+BUGFIXES:
+* Fix an issue with removing all teams/tags/authorized users/authorized teams from detector resource [#489](https://github.com/splunk-terraform/terraform-provider-signalfx/pull/489)
+
 ## 9.1.4
 
 IMPROVEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.36.1-0.20240613150536-43123c77db5e
+	github.com/signalfx/signalfx-go v1.37.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.36.0
+	github.com/signalfx/signalfx-go v1.36.1-0.20240613150536-43123c77db5e
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.6.2 h1:aIihoIOHCiLZHxyoNQ+ABL4NKhFTgKLBdMLyEAh98m0=
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/signalfx/signalfx-go v1.36.0 h1:btfNrjb/MWAku7Ibj5BUamArVkyV9XI/fYqA0ytLdEo=
-github.com/signalfx/signalfx-go v1.36.0/go.mod h1:aVrA69k02raBhDtIL1l+KBu+H5eEmS5b0IFbqgKh7eg=
+github.com/signalfx/signalfx-go v1.36.1-0.20240613150536-43123c77db5e h1:0oqoep3AQjctx69Yzgw1AUDEq4lQwek+Xipk+gny3TU=
+github.com/signalfx/signalfx-go v1.36.1-0.20240613150536-43123c77db5e/go.mod h1:aVrA69k02raBhDtIL1l+KBu+H5eEmS5b0IFbqgKh7eg=
 github.com/skeema/knownhosts v1.2.0 h1:h9r9cf0+u7wSE+M183ZtMGgOJKiL96brpaz5ekfJCpM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.6.2 h1:aIihoIOHCiLZHxyoNQ+ABL4NKhFTgKLBdMLyEAh98m0=
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/signalfx/signalfx-go v1.36.1-0.20240613150536-43123c77db5e h1:0oqoep3AQjctx69Yzgw1AUDEq4lQwek+Xipk+gny3TU=
-github.com/signalfx/signalfx-go v1.36.1-0.20240613150536-43123c77db5e/go.mod h1:aVrA69k02raBhDtIL1l+KBu+H5eEmS5b0IFbqgKh7eg=
+github.com/signalfx/signalfx-go v1.37.0 h1:AtCvcW9VGoVUnCVcoHLbRD5QUsMpy1SnViJN+jKGBU8=
+github.com/signalfx/signalfx-go v1.37.0/go.mod h1:aVrA69k02raBhDtIL1l+KBu+H5eEmS5b0IFbqgKh7eg=
 github.com/skeema/knownhosts v1.2.0 h1:h9r9cf0+u7wSE+M183ZtMGgOJKiL96brpaz5ekfJCpM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -306,7 +306,7 @@ func getPayloadDetector(d *schema.ResourceData) (*detector.CreateUpdateDetectorR
 	maxDelay := int32(d.Get("max_delay").(int) * 1000)
 	minDelay := int32(d.Get("min_delay").(int) * 1000)
 
-	var tags []string
+	tags := []string{}
 	if val, ok := d.GetOk("tags"); ok {
 		for _, tag := range val.(*schema.Set).List() {
 			tags = append(tags, tag.(string))
@@ -326,32 +326,33 @@ func getPayloadDetector(d *schema.ResourceData) (*detector.CreateUpdateDetectorR
 		Tags:              tags,
 	}
 
+	authorizedTeams := []string{}
 	if val, ok := d.GetOk("authorized_writer_teams"); ok {
-		var teams []string
 		tfValues := val.(*schema.Set).List()
 		for _, v := range tfValues {
-			teams = append(teams, v.(string))
+			authorizedTeams = append(authorizedTeams, v.(string))
 		}
-		cudr.AuthorizedWriters.Teams = teams
 	}
+	cudr.AuthorizedWriters.Teams = authorizedTeams
+
+	authorizedUsers := []string{}
 	if val, ok := d.GetOk("authorized_writer_users"); ok {
-		var users []string
 		tfValues := val.(*schema.Set).List()
 		for _, v := range tfValues {
-			users = append(users, v.(string))
+			authorizedUsers = append(authorizedUsers, v.(string))
 		}
-		cudr.AuthorizedWriters.Users = users
 	}
+	cudr.AuthorizedWriters.Users = authorizedUsers
 
 	cudr.VisualizationOptions = getVisualizationOptionsDetector(d)
 
+	teams := []string{}
 	if val, ok := d.GetOk("teams"); ok {
-		teams := []string{}
 		for _, t := range val.(*schema.Set).List() {
 			teams = append(teams, t.(string))
 		}
-		cudr.Teams = teams
 	}
+	cudr.Teams = teams
 
 	return cudr, nil
 }


### PR DESCRIPTION
detector: fix an issue with deleting all teams/tags/authorized users/authorized teams

To remove teams/tags/authorized users/authorize from detector resource, the API client must send an empty array. Sending any of these fields missing (null) has no effect