### PR TITLE
[chore]: Removing deprecated packages from being used

### DIFF
--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -3,7 +3,6 @@ package signalfx
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -216,7 +215,7 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 }
 
 func readConfigFile(configPath string, config *signalfxConfig) error {
-	configFile, err := ioutil.ReadFile(configPath)
+	configFile, err := os.ReadFile(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to open config file. %s", err.Error())
 	}

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -110,7 +110,7 @@ func sendRequest(method string, url string, token string, payload []byte) (int, 
 		return -1, nil, fmt.Errorf("Failed sending %s request to Signalfx: %s", method, err.Error())
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
 	if err != nil {


### PR DESCRIPTION
## Context

This is to remove some of the deprecated packages that are being used within the provider and cleaning up some redundant calls being made.