### PR TITLE
Feature: new internal package 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.23"
 
 jobs:
   build:

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,13 @@
 module github.com/splunk-terraform/terraform-provider-signalfx
 
-go 1.20
+go 1.21
+
+toolchain go1.23.2
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/davecgh/go-spew v1.1.1
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -23,7 +26,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect

--- a/internal/tfextension/diag.go
+++ b/internal/tfextension/diag.go
@@ -1,0 +1,35 @@
+package tfext
+
+import (
+	"slices"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+// AppendDiagnostics is to be used similar to combining errors together
+// so they are reported at the same time to provide all details at once.
+func AppendDiagnostics(diags diag.Diagnostics, values ...diag.Diagnostic) diag.Diagnostics {
+	return slices.Concat(diags, values)
+}
+
+// AsErrorDiagnostics is the same as `diag.FromErr`, however, it allow allows
+// adding the attribute values that are provided in CRUD operations.
+func AsErrorDiagnostics(err error, path ...cty.Path) diag.Diagnostics {
+	return newDiagnostics(diag.Error, err, path...)
+}
+
+// AsWarnDiagnostics is the same as `diag.FromErr`, however, it sets the severity as Warning
+// and allows for appending the attribute path as part of the values.
+func AsWarnDiagnostics(err error, path ...cty.Path) diag.Diagnostics {
+	return newDiagnostics(diag.Warning, err, path...)
+}
+
+func newDiagnostics(sev diag.Severity, summary error, path ...cty.Path) diag.Diagnostics {
+	if summary == nil {
+		return nil
+	}
+	return diag.Diagnostics{
+		{Severity: sev, Summary: summary.Error(), AttributePath: slices.Concat(path...)},
+	}
+}

--- a/internal/tfextension/diag_test.go
+++ b/internal/tfextension/diag_test.go
@@ -1,0 +1,143 @@
+package tfext
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		orig    diag.Diagnostics
+		entries diag.Diagnostics
+		expect  diag.Diagnostics
+	}{
+		{
+			name:    "no values",
+			orig:    nil,
+			entries: nil,
+			expect:  nil,
+		},
+		{
+			name: "no additional values",
+			orig: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "Issue creating value"},
+			},
+			entries: nil,
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "Issue creating value"},
+			},
+		},
+		{
+			name: "appending values",
+			orig: nil,
+			entries: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "Issue creating value"},
+			},
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "Issue creating value"},
+			},
+		},
+		{
+			name: "combined values",
+			orig: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "a"},
+			},
+			entries: diag.Diagnostics{
+				{Severity: diag.Warning, Summary: "b"},
+			},
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "a"},
+				{Severity: diag.Warning, Summary: "b"},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				tc.expect,
+				AppendDiagnostics(tc.orig, tc.entries...),
+				"Must match the expected values",
+			)
+		})
+	}
+}
+
+func TestAsErrorDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		value  diag.Diagnostics
+		expect diag.Diagnostics
+	}{
+		{
+			name:   "nil error",
+			value:  AsErrorDiagnostics(nil),
+			expect: nil,
+		},
+		{
+			name:  "defined error",
+			value: AsErrorDiagnostics(errors.New("boo")),
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "boo"},
+			},
+		},
+		{
+			name:  "error with path",
+			value: AsErrorDiagnostics(errors.New("bad entry"), cty.IndexStringPath("attr")),
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "bad entry", AttributePath: cty.IndexStringPath("attr")},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, tc.value)
+		})
+	}
+}
+
+func TestAsWarnDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		value  diag.Diagnostics
+		expect diag.Diagnostics
+	}{
+		{
+			name:   "nil error",
+			value:  AsWarnDiagnostics(nil),
+			expect: nil,
+		},
+		{
+			name:  "defined error",
+			value: AsWarnDiagnostics(errors.New("boo")),
+			expect: diag.Diagnostics{
+				{Severity: diag.Warning, Summary: "boo"},
+			},
+		},
+		{
+			name:  "error with path",
+			value: AsWarnDiagnostics(errors.New("bad entry"), cty.IndexStringPath("attr")),
+			expect: diag.Diagnostics{
+				{Severity: diag.Warning, Summary: "bad entry", AttributePath: cty.IndexStringPath("attr")},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, tc.value)
+		})
+	}
+}

--- a/internal/tfextension/encoding.go
+++ b/internal/tfextension/encoding.go
@@ -1,0 +1,19 @@
+package tfext
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+// Using generics for the function signature instead of the typical any parameter
+// to help reduce repeated lines of code needing to cast to or from an empty interface.
+type (
+	// DecodeTerraformFunc is used to define the method signature used to convert
+	// the terraform state data into the expected API type to be used.
+	//
+	// This is to be used when interfacing with other packages.
+	DecodeTerraformFunc[T any] func(rd *schema.ResourceData) (*T, error)
+
+	// EncodeTerraformFunc is used to write the API response data into
+	// the terraform state.
+	//
+	// This is to be used when interfacing with other packages.
+	EncodeTerraformFunc[T any] func(t *T, rd *schema.ResourceData) error
+)

--- a/internal/tfextension/encoding_test.go
+++ b/internal/tfextension/encoding_test.go
@@ -1,0 +1,1 @@
+package tfext


### PR DESCRIPTION
## Context

I've been looking to improve how to provide user feedback that is not critical and help provide standards on how to process data (to and from the API types). This package is intended to be used by CRUD operations and extend the existing library to make it easier to use within those functions.

## Changes 

- Adding new typed function definitions `tfext.DecodeTerraform` and `tfext.EncodeTerraForm`
  -  Opted to use generics here to avoid needing to repeat casting to and from `any` type
- Added connivence functions for `diag.Diagnostics`
  - The tf helper library only providers support for diagnostics as an error, but I wanted to include warnings and being able to append issues together since it make more sense to report more at once.