### PR TITLE
Feature: adding new package `check`

### DIFF
--- a/internal/check/doc.go
+++ b/internal/check/doc.go
@@ -1,0 +1,4 @@
+// Package check is used to provide more specific validations
+// across the different packages and named as such to avoid package
+// collisions with the terraform provided helpers
+package check

--- a/internal/check/severity.go
+++ b/internal/check/severity.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
 )
 

--- a/internal/check/severity.go
+++ b/internal/check/severity.go
@@ -1,0 +1,36 @@
+package check
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+func SeverityLevel() schema.SchemaValidateDiagFunc {
+	return func(i interface{}, p cty.Path) diag.Diagnostics {
+		value, ok := i.(string)
+		if !ok {
+			return tfext.AsErrorDiagnostics(
+				fmt.Errorf("expected %v to be of type string", i),
+				p,
+			)
+		}
+
+		labels := []string{
+			"Critical", "Major", "Minor", "Warning", "Info",
+		}
+
+		if slices.Contains(labels, value) {
+			return nil
+		}
+
+		return tfext.AsErrorDiagnostics(
+			fmt.Errorf("value %q is not allowed; must be one of: %v", value, labels),
+			p,
+		)
+	}
+}

--- a/internal/check/severity_test.go
+++ b/internal/check/severity_test.go
@@ -1,0 +1,50 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeverityLevel(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		val    any
+		expect diag.Diagnostics
+	}{
+		{
+			name: "No value provided",
+			val:  nil,
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "expected <nil> to be of type string"},
+			},
+		},
+		{
+			name:   "expected value",
+			val:    "Major",
+			expect: nil,
+		},
+		{
+			name: "invalid value",
+			val:  "Fatal",
+			expect: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "value \"Fatal\" is not allowed; must be one of: [Critical Major Minor Warning Info]",
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := SeverityLevel()(tc.val, cty.Path{})
+			assert.Equal(t, tc.expect, actual, "Must match the expected value")
+		})
+	}
+}

--- a/internal/check/timezone.go
+++ b/internal/check/timezone.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
 )
 
@@ -21,9 +22,6 @@ func TimeZoneLocation() schema.SchemaValidateDiagFunc {
 			)
 		}
 		_, err := time.LoadLocation(tz)
-		if err == nil {
-			return nil
-		}
 		return tfext.AsErrorDiagnostics(err, p)
 
 	}

--- a/internal/check/timezone.go
+++ b/internal/check/timezone.go
@@ -1,0 +1,30 @@
+package check
+
+import (
+	"fmt"
+	"time"
+	_ "time/tzdata" // Importing time zone database to ensure there is failover option
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+func TimeZoneLocation() schema.SchemaValidateDiagFunc {
+	return func(i interface{}, p cty.Path) diag.Diagnostics {
+		tz, ok := i.(string)
+		if !ok {
+			return tfext.AsErrorDiagnostics(
+				fmt.Errorf("expected %v as string", i),
+				p,
+			)
+		}
+		_, err := time.LoadLocation(tz)
+		if err == nil {
+			return nil
+		}
+		return tfext.AsErrorDiagnostics(err, p)
+
+	}
+}

--- a/internal/check/timezone_test.go
+++ b/internal/check/timezone_test.go
@@ -1,0 +1,52 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeZoneLocation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		val    any
+		expect diag.Diagnostics
+	}{
+		{
+			name: "no value provided",
+			val:  nil,
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "expected <nil> as string"},
+			},
+		},
+		{
+			name:   "default value provided",
+			val:    "UTC",
+			expect: nil,
+		},
+		{
+			name:   "configured tz location set",
+			val:    "Australia/Adelaide",
+			expect: nil,
+		},
+		{
+			name: "Invalid tz location set",
+			val:  "planet/earth",
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "unknown time zone planet/earth"},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := TimeZoneLocation()(tc.val, cty.Path{})
+			assert.Equal(t, tc.expect, d, "Must match the expected value")
+		})
+	}
+}

--- a/internal/check/unit.go
+++ b/internal/check/unit.go
@@ -1,0 +1,61 @@
+package check
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+func ValueUnit() schema.SchemaValidateDiagFunc {
+	return func(i interface{}, p cty.Path) diag.Diagnostics {
+		s, ok := i.(string)
+		if !ok {
+			return tfext.AsErrorDiagnostics(
+				fmt.Errorf("expected %v to be type string", i),
+				p,
+			)
+		}
+
+		units := []string{
+			"Bit",
+			"Kilobit",
+			"Megabit",
+			"Gigabit",
+			"Terabit",
+			"Petabit",
+			"Exabit",
+			"Zettabit",
+			"Yottabit",
+			"Byte",
+			"Kibibyte",
+			"Mebibyte",
+			"Gibibyte",
+			"Tebibyte",
+			"Pebibyte",
+			"Exbibyte",
+			"Zebibyte",
+			"Yobibyte",
+			"Nanosecond",
+			"Microsecond",
+			"Millisecond",
+			"Second",
+			"Minute",
+			"Hour",
+			"Day",
+			"Week",
+		}
+
+		if slices.Contains(units, s) {
+			return nil
+		}
+		return tfext.AsErrorDiagnostics(
+			fmt.Errorf("expected %q to be one of %v", s, units),
+			p,
+		)
+	}
+}

--- a/internal/check/unit_test.go
+++ b/internal/check/unit_test.go
@@ -1,0 +1,53 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValueUnit(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		value    any
+		expected diag.Diagnostics
+	}{
+		{
+			name:  "no value provided",
+			value: nil,
+			expected: diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "expected <nil> to be type string",
+				},
+			},
+		},
+		{
+			name:     "Unit set",
+			value:    "Byte",
+			expected: nil,
+		},
+		{
+			name:  "Invalid unit",
+			value: "Tuesday",
+			expected: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "expected \"Tuesday\" to be one of [Bit Kilobit Megabit Gigabit Terabit Petabit Exabit Zettabit Yottabit Byte Kibibyte Mebibyte Gibibyte Tebibyte Pebibyte Exbibyte Zebibyte Yobibyte Nanosecond Microsecond Millisecond Second Minute Hour Day Week]",
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diag := ValueUnit()(tc.value, cty.Path{})
+			assert.Equal(t, tc.expected, diag, "Must match the expected value")
+		})
+	}
+}


### PR DESCRIPTION
## Context

Extends https://github.com/splunk-terraform/terraform-provider-signalfx/pull/504

The existing checks for custom values use a deprecated method signatures and they are not easily discoverable. This bundles all validation functions together as one package so it easy to determine the test coverage and ensure the behaviour is consistent the different schemas using them.

I've opted to name the package `check` over `validation` since there is already a terraform provided package named `validation` and I didn't want to cause any confusion or package import conflicts.

## Changes

- Adding methods to validate `Unit`, `Timezone`, and `Severity`
  - Test coverage for these is currently 100% however, I am not sure it covers every condition (since I did this somewhat rushed)