### PR TITLE
Feature: Adding package `common` for shared functionality across resources

### DIFF
--- a/internal/check/notification.go
+++ b/internal/check/notification.go
@@ -2,27 +2,29 @@ package check
 
 import (
 	"fmt"
-	"time"
-	_ "time/tzdata" // Importing time zone database to ensure there is failover option
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
 	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
 )
 
-func TimeZoneLocation() schema.SchemaValidateDiagFunc {
+func Notification() schema.SchemaValidateDiagFunc {
 	return func(i interface{}, p cty.Path) diag.Diagnostics {
-		tz, ok := i.(string)
+		s, ok := i.(string)
 		if !ok {
 			return tfext.AsErrorDiagnostics(
-				fmt.Errorf("expected %v as string", i),
+				fmt.Errorf("expected %v to be of type string", i),
 				p,
 			)
 		}
-		_, err := time.LoadLocation(tz)
+		// Using the helper library to avoid repeating code
+		_, err := common.NewNotificationFromString(s)
+		if err == nil {
+			return nil
+		}
 		return tfext.AsErrorDiagnostics(err, p)
-
 	}
 }

--- a/internal/check/notification_test.go
+++ b/internal/check/notification_test.go
@@ -1,0 +1,208 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNotification(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		val    any
+		expect diag.Diagnostics
+	}{
+		{
+			name: "no value provided",
+			val:  nil,
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "expected <nil> to be of type string"},
+			},
+		},
+		{
+			name: "incomplete notification string",
+			val:  "notification",
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: `invalid notification string "notification", not enough commas`},
+			},
+		},
+		{
+			name:   "amazon event bridge",
+			val:    "AmazonEventBridge,....",
+			expect: nil,
+		},
+		{
+			name:   "big panda",
+			val:    "BigPanda,",
+			expect: nil,
+		},
+		{
+			name:   "Jira",
+			val:    "Jira,",
+			expect: nil,
+		},
+		{
+			name:   "Office 365",
+			val:    "Office365,",
+			expect: nil,
+		},
+		{
+			name:   "PagerDuty",
+			val:    "PagerDuty,",
+			expect: nil,
+		},
+		{
+			name:   "Microsoft Teams",
+			val:    "Team,",
+			expect: nil,
+		},
+		{
+			name:   "Microsoft Teams Email",
+			val:    "TeamEmail,",
+			expect: nil,
+		},
+		{
+			name:   "XMatters",
+			val:    "XMatters,",
+			expect: nil,
+		},
+		{
+			name:   "email",
+			val:    "Email,example@example",
+			expect: nil,
+		},
+		{
+			name:   "email pseudo email",
+			val:    "Email,example+alert@example",
+			expect: nil,
+		},
+		{
+			name: "email invalid",
+			val:  "Email,derp",
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "mail: missing '@' or angle-addr"},
+			},
+		},
+		{
+			name:   "Opsgenie",
+			val:    "Opsgenie,,,,",
+			expect: nil,
+		},
+		{
+			name: "Opsgenie invalid",
+			val:  "Opsgenie,",
+			expect: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "invalid OpsGenie notification string, please consult the documentation (not enough parts)",
+				},
+			},
+		},
+		{
+			name:   "Slack Notification",
+			val:    "Slack,cool-slack,my-channel",
+			expect: nil,
+		},
+		{
+			name: "Slack invalid",
+			val:  "Slack,",
+			expect: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "invalid Slack notification string, please consult the documentation (not enough parts)",
+				},
+			},
+		},
+		{
+			name: "slack syntax error",
+			val:  "Slack,,#channel",
+			expect: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  `exclude the # from channel names in "#channel"`,
+				},
+			},
+		},
+		{
+			name:   "VictorOps",
+			val:    "VictorOps,,",
+			expect: nil,
+		},
+		{
+			name: "VictorOps invalid",
+			val:  "VictorOps,",
+			expect: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "invalid VictorOps notification string, please consult the documentation (not enough parts)",
+				},
+			},
+		},
+		{
+			name:   "Webhook using creditial id",
+			val:    "Webhook,Aaaaaa,,",
+			expect: nil,
+		},
+		{
+			name:   "Webhook using secret and URL",
+			val:    "Webhook,,verysercretsecret,http://example.com",
+			expect: nil,
+		},
+		{
+			name: "Webhook not enough parts",
+			val:  "Webhook,,",
+			expect: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "invalid Webhook notification string, please consult the documentation (not enough parts)",
+				},
+			},
+		},
+		{
+			name: "Webhook no values set",
+			val:  "Webhook,,,",
+			expect: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)",
+				},
+			},
+		},
+		{
+			name: "Webhook set all values",
+			val:  "Webhook,aaa,mysecret,http://example.com",
+			expect: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)",
+				},
+			},
+		},
+		{
+			name: "Webhook url invalid",
+			val:  "Webhook,,verysercretsecret,foo",
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "invalid Webhook URL \"verysercretsecret\""},
+			},
+		},
+		{
+			name: "Unknown notification",
+			val:  "alertatron,",
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "invalid notification type \"alertatron\""},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := Notification()(tc.val, cty.Path{})
+			assert.Equal(t, tc.expect, actual, "Must match the expected value")
+		})
+	}
+}

--- a/internal/common/notification_api.go
+++ b/internal/common/notification_api.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/signalfx/signalfx-go/notification"
+)
+
+func NewStringFromAPI(n *notification.Notification) (string, error) {
+	if n == nil {
+		return "", fmt.Errorf("nil value provided")
+	}
+	switch v := n.Value.(type) {
+	case *notification.AmazonEventBrigeNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.CredentialId), nil
+	case *notification.BigPandaNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.CredentialId), nil
+	case *notification.EmailNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.Email), nil
+	case *notification.JiraNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.CredentialId), nil
+	case *notification.Office365Notification:
+		return fmt.Sprintf("%s,%s", n.Type, v.CredentialId), nil
+	case *notification.OpsgenieNotification:
+		return fmt.Sprintf("%s,%s,%s,%s,%s", n.Type, v.CredentialId, v.ResponderName, v.ResponderId, v.ResponderType), nil
+	case *notification.PagerDutyNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.CredentialId), nil
+	case *notification.ServiceNowNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.CredentialId), nil
+	case *notification.SlackNotification:
+		return fmt.Sprintf("%s,%s,%s", n.Type, v.CredentialId, v.Channel), nil
+	case *notification.TeamNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.Team), nil
+	case *notification.TeamEmailNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.Team), nil
+	case *notification.VictorOpsNotification:
+		return fmt.Sprintf("%s,%s,%s", n.Type, v.CredentialId, v.RoutingKey), nil
+	case *notification.WebhookNotification:
+		return fmt.Sprintf("%s,%s,%s,%s", n.Type, v.CredentialId, v.Secret, v.Url), nil
+	case *notification.XMattersNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.CredentialId), nil
+	}
+	return "", fmt.Errorf("unknown type %T provided", n.Value)
+}

--- a/internal/common/notification_api_test.go
+++ b/internal/common/notification_api_test.go
@@ -1,0 +1,223 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/signalfx/signalfx-go/notification"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStringFromAPI(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		nt     *notification.Notification
+		expect string
+		errVal string
+	}{
+		{
+			name:   "no value set",
+			nt:     nil,
+			expect: "",
+			errVal: "nil value provided",
+		},
+		{
+			name: "invalid type set",
+			nt: &notification.Notification{
+				Type:  "brrr",
+				Value: nil,
+			},
+			expect: "",
+			errVal: "unknown type <nil> provided",
+		},
+		{
+			name: "amazon event bridge",
+			nt: &notification.Notification{
+				Type: AmazonEventBrigeNotificationType,
+				Value: &notification.AmazonEventBrigeNotification{
+					Type:         AmazonEventBrigeNotificationType,
+					CredentialId: "aaa",
+				},
+			},
+			expect: "AmazonEventBridge,aaa",
+			errVal: "",
+		},
+		{
+			name: "big panda",
+			nt: &notification.Notification{
+				Type: BigPandaNotificationType,
+				Value: &notification.BigPandaNotification{
+					Type:         BigPandaNotificationType,
+					CredentialId: "bbb",
+				},
+			},
+			expect: "BigPanda,bbb",
+			errVal: "",
+		},
+		{
+			name: "email",
+			nt: &notification.Notification{
+				Type: EmailNotificationType,
+				Value: &notification.EmailNotification{
+					Type:  EmailNotificationType,
+					Email: "example@localhost",
+				},
+			},
+			expect: "Email,example@localhost",
+			errVal: "",
+		},
+		{
+			name: "jira",
+			nt: &notification.Notification{
+				Type: JiraNotificationType,
+				Value: &notification.JiraNotification{
+					Type:         JiraNotificationType,
+					CredentialId: "ccc",
+				},
+			},
+			expect: "Jira,ccc",
+			errVal: "",
+		},
+		{
+			name: "office 365",
+			nt: &notification.Notification{
+				Type: Office365NotificationType,
+				Value: &notification.Office365Notification{
+					Type:         Office365NotificationType,
+					CredentialId: "ddd",
+				},
+			},
+			expect: "Office365,ddd",
+			errVal: "",
+		},
+		{
+			name: "opsgenie",
+			nt: &notification.Notification{
+				Type: OpsgenieNotificationType,
+				Value: &notification.OpsgenieNotification{
+					Type:          OpsgenieNotificationType,
+					CredentialId:  "eee",
+					ResponderName: "john",
+					ResponderId:   "id",
+					ResponderType: "human",
+				},
+			},
+			expect: "Opsgenie,eee,john,id,human",
+			errVal: "",
+		},
+		{
+			name: "pager duty",
+			nt: &notification.Notification{
+				Type: PagerDutyNotificationType,
+				Value: &notification.PagerDutyNotification{
+					Type:         PagerDutyNotificationType,
+					CredentialId: "fff",
+				},
+			},
+			expect: "PagerDuty,fff",
+			errVal: "",
+		},
+		{
+			name: "service now",
+			nt: &notification.Notification{
+				Type: ServiceNowNotificationType,
+				Value: &notification.ServiceNowNotification{
+					Type:         ServiceNowNotificationType,
+					CredentialId: "ggg",
+				},
+			},
+			expect: "ServiceNow,ggg",
+			errVal: "",
+		},
+		{
+			name: "slack",
+			nt: &notification.Notification{
+				Type: SlackNotificationType,
+				Value: &notification.SlackNotification{
+					Type:         SlackNotificationType,
+					CredentialId: "hhh",
+					Channel:      "announcements",
+				},
+			},
+			expect: "Slack,hhh,announcements",
+			errVal: "",
+		},
+		{
+			name: "team",
+			nt: &notification.Notification{
+				Type: TeamNotificationType,
+				Value: &notification.TeamNotification{
+					Type: TeamNotificationType,
+					Team: "default",
+				},
+			},
+			expect: "Team,default",
+			errVal: "",
+		},
+		{
+			name: "team email",
+			nt: &notification.Notification{
+				Type: TeamEmailNotificationType,
+				Value: &notification.TeamEmailNotification{
+					Type: TeamEmailNotificationType,
+					Team: "default",
+				},
+			},
+			expect: "TeamEmail,default",
+			errVal: "",
+		},
+		{
+			name: "victor ops",
+			nt: &notification.Notification{
+				Type: VictorOpsNotificationType,
+				Value: &notification.VictorOpsNotification{
+					Type:         VictorOpsNotificationType,
+					CredentialId: "iii",
+					RoutingKey:   "sre",
+				},
+			},
+			expect: "VictorOps,iii,sre",
+			errVal: "",
+		},
+		{
+			name: "webhook",
+			nt: &notification.Notification{
+				Type: WebhookNotificationType,
+				Value: &notification.WebhookNotification{
+					Type:         WebhookNotificationType,
+					CredentialId: "jjj",
+					Secret:       "hunter2",
+					Url:          "http://localhost",
+				},
+			},
+			expect: "Webhook,jjj,hunter2,http://localhost",
+			errVal: "",
+		},
+		{
+			name: "x matters",
+			nt: &notification.Notification{
+				Type: XMattersNotificationType,
+				Value: &notification.XMattersNotification{
+					Type:         XMattersNotificationType,
+					CredentialId: "lll",
+				},
+			},
+			expect: "XMatters,lll",
+			errVal: "",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := NewStringFromAPI(tc.nt)
+			require.Equal(t, tc.expect, actual, "Must match the expected error string")
+			if tc.errVal != "" {
+				require.EqualError(t, err, tc.errVal, "Must match the expected error message")
+			} else {
+				require.NoError(t, err, "Must not error ")
+			}
+		})
+	}
+}

--- a/internal/common/notification_list.go
+++ b/internal/common/notification_list.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"github.com/signalfx/signalfx-go/notification"
+)
+
+func NewNotificationList(items []any) ([]*notification.Notification, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	values := make([]*notification.Notification, len(items))
+	for i, v := range items {
+		n, err := NewNotificationFromString(v.(string))
+		if err != nil {
+			return nil, err
+		}
+		values[i] = n
+	}
+	return values, nil
+}

--- a/internal/common/notification_list_test.go
+++ b/internal/common/notification_list_test.go
@@ -1,0 +1,59 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/signalfx/signalfx-go/notification"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNotificationList(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		items  []any
+		expect []*notification.Notification
+		errVal string
+	}{
+		{
+			name:   "no values provided",
+			items:  nil,
+			expect: nil,
+			errVal: "",
+		},
+		{
+			name:   "invalid notification string",
+			items:  []any{"Provider"},
+			expect: nil,
+			errVal: "invalid notification string \"Provider\", not enough commas",
+		},
+		{
+			name:  "valid notification string",
+			items: []any{"Email,example@localhost"},
+			expect: []*notification.Notification{
+				{
+					Type: "Email",
+					Value: &notification.EmailNotification{
+						Type:  "Email",
+						Email: "example@localhost",
+					},
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := NewNotificationList(tc.items)
+			assert.Equal(t, tc.expect, actual, "Must match the expected notifications")
+			if tc.errVal != "" {
+				require.EqualError(t, err, tc.errVal, "Must much the expected error message")
+			} else {
+				require.NoError(t, err, "Must not error parsing strings")
+			}
+		})
+	}
+}

--- a/internal/common/notification_string.go
+++ b/internal/common/notification_string.go
@@ -1,0 +1,158 @@
+package common
+
+import (
+	"fmt"
+	"net/mail"
+	"net/url"
+	"strings"
+
+	"github.com/signalfx/signalfx-go/notification"
+)
+
+const (
+	AmazonEventBrigeNotificationType string = "AmazonEventBridge"
+	BigPandaNotificationType         string = "BigPanda"
+	EmailNotificationType            string = "Email"
+	JiraNotificationType             string = "Jira"
+	Office365NotificationType        string = "Office365"
+	OpsgenieNotificationType         string = "Opsgenie"
+	PagerDutyNotificationType        string = "PagerDuty"
+	ServiceNowNotificationType       string = "ServiceNow"
+	SlackNotificationType            string = "Slack"
+	TeamNotificationType             string = "Team"
+	TeamEmailNotificationType        string = "TeamEmail"
+	VictorOpsNotificationType        string = "VictorOps"
+	WebhookNotificationType          string = "Webhook"
+	XMattersNotificationType         string = "XMatters"
+)
+
+// NewNotificationFromString converts the notification definition into the API type.
+func NewNotificationFromString(str string) (*notification.Notification, error) {
+	var (
+		values = strings.Split(str, ",")
+		count  = len(values)
+		value  any
+	)
+	if count < 2 {
+		return nil, fmt.Errorf("invalid notification string %q, not enough commas", str)
+	}
+	switch values[0] {
+	case AmazonEventBrigeNotificationType:
+		value = &notification.AmazonEventBrigeNotification{
+			Type:         values[0],
+			CredentialId: values[1],
+		}
+	case BigPandaNotificationType:
+		value = &notification.BigPandaNotification{
+			Type:         values[0],
+			CredentialId: values[1],
+		}
+	case EmailNotificationType:
+		if _, err := mail.ParseAddress(values[1]); err != nil {
+			return nil, err
+		}
+		value = &notification.EmailNotification{
+			Type:  values[0],
+			Email: values[1],
+		}
+	case JiraNotificationType:
+		value = &notification.JiraNotification{
+			Type:         values[0],
+			CredentialId: values[1],
+		}
+	case Office365NotificationType:
+		value = &notification.Office365Notification{
+			Type:         values[0],
+			CredentialId: values[1],
+		}
+	case OpsgenieNotificationType:
+		if count != 5 {
+			return nil, fmt.Errorf("invalid OpsGenie notification string, please consult the documentation (not enough parts)")
+		}
+		value = &notification.OpsgenieNotification{
+			Type:          values[0],
+			CredentialId:  values[1],
+			ResponderName: values[2],
+			ResponderId:   values[3],
+			ResponderType: values[4],
+		}
+	case PagerDutyNotificationType:
+		value = &notification.PagerDutyNotification{
+			Type:         values[0],
+			CredentialId: values[1],
+		}
+	case ServiceNowNotificationType:
+		value = &notification.ServiceNowNotification{
+			Type:         values[0],
+			CredentialId: values[1],
+		}
+	case SlackNotificationType:
+		if count != 3 {
+			return nil, fmt.Errorf("invalid Slack notification string, please consult the documentation (not enough parts)")
+		}
+		if strings.Contains(values[2], "#") {
+			return nil, fmt.Errorf("exclude the # from channel names in %q", values[2])
+		}
+		value = &notification.SlackNotification{
+			Type:         values[0],
+			CredentialId: values[1],
+			Channel:      values[2],
+		}
+	case TeamNotificationType:
+		value = &notification.TeamNotification{
+			Type: values[0],
+			Team: values[1],
+		}
+	case TeamEmailNotificationType:
+		value = &notification.TeamEmailNotification{
+			Type: values[0],
+			Team: values[1],
+		}
+	case VictorOpsNotificationType:
+		if count != 3 {
+			return nil, fmt.Errorf("invalid VictorOps notification string, please consult the documentation (not enough parts)")
+		}
+		value = &notification.VictorOpsNotification{
+			Type:         values[0],
+			CredentialId: values[1],
+			RoutingKey:   values[2],
+		}
+	case WebhookNotificationType:
+		if count != 4 {
+			return nil, fmt.Errorf("invalid Webhook notification string, please consult the documentation (not enough parts)")
+		}
+		if values[1] != "" {
+			// We got a credential ID, so verify we didn't get the other parts
+			if values[2] != "" || values[3] != "" {
+				return nil, fmt.Errorf("invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)")
+			}
+		} else {
+			// We didn't get a credential ID so verify we got the other parts
+			if values[2] == "" || values[3] == "" {
+				return nil, fmt.Errorf("invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)")
+			}
+		}
+		// The URL might be an empty string in the case that the user
+		// only supplied a credential ID
+		if values[3] != "" {
+			if _, err := url.ParseRequestURI(values[3]); err != nil {
+				return nil, fmt.Errorf("invalid Webhook URL %q", values[2])
+			}
+		}
+		value = &notification.WebhookNotification{
+			Type:         values[0],
+			CredentialId: values[1],
+			Secret:       values[2],
+			Url:          values[3],
+		}
+	case XMattersNotificationType:
+		value = &notification.XMattersNotification{
+			Type:         values[0],
+			CredentialId: values[1],
+		}
+	default:
+		return nil, fmt.Errorf("invalid notification type %q", values[0])
+	}
+
+	return &notification.Notification{Type: values[0], Value: value}, nil
+}

--- a/internal/common/notification_string_test.go
+++ b/internal/common/notification_string_test.go
@@ -1,0 +1,286 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/signalfx/signalfx-go/notification"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNotificationFromString(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		str    string
+		expect *notification.Notification
+		errVal string
+	}{
+		{
+			name:   "invalid notification string",
+			str:    "invalid",
+			expect: nil,
+			errVal: "invalid notification string \"invalid\", not enough commas",
+		},
+		{
+			name: "amazon event bridge",
+			str:  "AmazonEventBridge,creds",
+			expect: &notification.Notification{
+				Type: AmazonEventBrigeNotificationType,
+				Value: &notification.AmazonEventBrigeNotification{
+					Type:         AmazonEventBrigeNotificationType,
+					CredentialId: "creds",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "big panda",
+			str:  "BigPanda,creds",
+			expect: &notification.Notification{
+				Type: BigPandaNotificationType,
+				Value: &notification.BigPandaNotification{
+					Type:         BigPandaNotificationType,
+					CredentialId: "creds",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name:   "email invalid",
+			str:    "Email,invalid",
+			expect: nil,
+			errVal: "mail: missing '@' or angle-addr",
+		},
+		{
+			name: "email valid",
+			str:  "Email,example@localhost",
+			expect: &notification.Notification{
+				Type: EmailNotificationType,
+				Value: &notification.EmailNotification{
+					Type:  EmailNotificationType,
+					Email: "example@localhost",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "jira",
+			str:  "Jira,creds",
+			expect: &notification.Notification{
+				Type: JiraNotificationType,
+				Value: &notification.JiraNotification{
+					Type:         JiraNotificationType,
+					CredentialId: "creds",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "office 365",
+			str:  "Office365,creds",
+			expect: &notification.Notification{
+				Type: Office365NotificationType,
+				Value: &notification.Office365Notification{
+					Type:         Office365NotificationType,
+					CredentialId: "creds",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "opsgenie",
+			str:  "Opsgenie,creds,name,id,type",
+			expect: &notification.Notification{
+				Type: OpsgenieNotificationType,
+				Value: &notification.OpsgenieNotification{
+					Type:          OpsgenieNotificationType,
+					CredentialId:  "creds",
+					ResponderName: "name",
+					ResponderId:   "id",
+					ResponderType: "type",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name:   "opsgenie invalid",
+			str:    "Opsgenie,creds,id,type",
+			expect: nil,
+			errVal: "invalid OpsGenie notification string, please consult the documentation (not enough parts)",
+		},
+		{
+			name: "pager duty",
+			str:  "PagerDuty,creds",
+			expect: &notification.Notification{
+				Type: PagerDutyNotificationType,
+				Value: &notification.PagerDutyNotification{
+					Type:         PagerDutyNotificationType,
+					CredentialId: "creds",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "service now",
+			str:  "ServiceNow,creds",
+			expect: &notification.Notification{
+				Type: ServiceNowNotificationType,
+				Value: &notification.ServiceNowNotification{
+					Type:         ServiceNowNotificationType,
+					CredentialId: "creds",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "slack",
+			str:  "Slack,creds,channel",
+			expect: &notification.Notification{
+				Type: SlackNotificationType,
+				Value: &notification.SlackNotification{
+					Type:         SlackNotificationType,
+					CredentialId: "creds",
+					Channel:      "channel",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name:   "slack missing channel",
+			str:    "Slack,creds",
+			expect: nil,
+			errVal: "invalid Slack notification string, please consult the documentation (not enough parts)",
+		},
+		{
+			name:   "slack invalid channel",
+			str:    "Slack,creds,#channel",
+			expect: nil,
+			errVal: "exclude the # from channel names in \"#channel\"",
+		},
+		{
+			name: "team",
+			str:  "Team,team",
+			expect: &notification.Notification{
+				Type: TeamNotificationType,
+				Value: &notification.TeamNotification{
+					Type: TeamNotificationType,
+					Team: "team",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "team email",
+			str:  "TeamEmail,team",
+			expect: &notification.Notification{
+				Type: TeamEmailNotificationType,
+				Value: &notification.TeamEmailNotification{
+					Type: TeamEmailNotificationType,
+					Team: "team",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "victor ops",
+			str:  "VictorOps,creds,route",
+			expect: &notification.Notification{
+				Type: VictorOpsNotificationType,
+				Value: &notification.VictorOpsNotification{
+					Type:         VictorOpsNotificationType,
+					CredentialId: "creds",
+					RoutingKey:   "route",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name:   "invalid victor ops",
+			str:    "VictorOps,creds",
+			expect: nil,
+			errVal: "invalid VictorOps notification string, please consult the documentation (not enough parts)",
+		},
+		{
+			name: "webhook creds only",
+			str:  "Webhook,creds,,",
+			expect: &notification.Notification{
+				Type: WebhookNotificationType,
+				Value: &notification.WebhookNotification{
+					Type:         WebhookNotificationType,
+					CredentialId: "creds",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "webhook secret and url",
+			str:  "Webhook,,secret,http://localhost",
+			expect: &notification.Notification{
+				Type: WebhookNotificationType,
+				Value: &notification.WebhookNotification{
+					Type:   WebhookNotificationType,
+					Secret: "secret",
+					Url:    "http://localhost",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name:   "webhook not enough values",
+			str:    "Webhook,,",
+			expect: nil,
+			errVal: "invalid Webhook notification string, please consult the documentation (not enough parts)",
+		},
+		{
+			name:   "webhook no values set",
+			str:    "Webhook,,,",
+			expect: nil,
+			errVal: "invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)",
+		},
+		{
+			name:   "webhook all values set",
+			str:    "Webhook,creds,secret,http://localhost",
+			expect: nil,
+			errVal: "invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)",
+		},
+		{
+			name:   "webhook invalid url",
+			str:    "Webhook,,secret,zzz",
+			expect: nil,
+			errVal: "invalid Webhook URL \"secret\"",
+		},
+		{
+			name: "xmatters",
+			str:  "XMatters,creds",
+			expect: &notification.Notification{
+				Type: XMattersNotificationType,
+				Value: &notification.XMattersNotification{
+					Type:         XMattersNotificationType,
+					CredentialId: "creds",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name:   "invalid provider",
+			str:    "invalid,creds",
+			expect: nil,
+			errVal: "invalid notification type \"invalid\"",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := NewNotificationFromString(tc.str)
+			assert.Equal(t, tc.expect, actual, "Must match the expected value")
+			if tc.errVal != "" {
+				require.EqualError(t, err, tc.errVal, "Must match the expected error")
+			} else {
+				require.NoError(t, err, "Must not error when parsing string")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

Notification is something that is shared among several resources, to make it easier to manage it is moved out into a common package to avoid package name clashes.

This means it can be imported and used by slo, detector, and team resources as plug and play.

## Changes

- Add new package `internal/common`
  - So far it is only used for translating to and from notification types but I am sure there will be more added as more get ported
- Added `internal/check/notification` to validate notification types locally.