### PR TITLE
Chore: Adding checks for license headers

### DIFF
--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,0 +1,35 @@
+name: build-and-test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  GO_VERSION: "1.23"
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Caching dependency
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Checking license files
+        run: make checklicense

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ terraform-provider-signalfx
 dist
 .idea
 
+# Generated files/directories as a result of CI/tooling actions
 /coverage
+/.tools

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,6 +11,8 @@ TOOLS_MOD_REGEX := "\s+_\s+\".*\""
 TOOLS_PKG_NAMES := $(shell grep -E $(TOOLS_MOD_REGEX) < $(TOOLS_MOD_DIR)/tools.go | tr -d " _\"" | grep -vE '/v[0-9]+$$')
 TOOLS_BIN_NAMES := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(shell echo $(TOOLS_PKG_NAMES))))
 
+ADDLICENCESE := $(TOOLS_BIN_DIR)/addlicense
+
 default: build
 
 .PHONY: install-tools
@@ -23,8 +25,27 @@ $(TOOLS_BIN_NAMES): $(TOOLS_BIN_DIR) $(TOOLS_MOD_DIR)/go.mod
 	go -C $(TOOLS_MOD_DIR) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))
 
 .PHONY: addlicense
-addlicense: $(TOOLS_BIN_DIR)/addlicense
-	$^ -s=only -y "" -c "Splunk, Inc." -l mpl $(SRC_GO_FILES)
+addlicense: $(ADDLICENCESE)
+	@ADDLICENCESEOUT=`$(ADDLICENCESE) -y "" -c 'Splunk, Inc.' -l mpl -s=only $(SRC_GO_FILES) 2>&1`; \
+		if [ "$$ADDLICENCESEOUT" ]; then \
+			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
+			echo "$$ADDLICENCESEOUT\n"; \
+			exit 1; \
+		else \
+			echo "Add License finished successfully"; \
+		fi
+
+.PHONY: checklicense
+checklicense:
+	@ADDLICENCESEOUT=`$(ADDLICENCESE) -check $(SRC_GO_FILES) 2>&1`; \
+		if [ "$$ADDLICENCESEOUT" ]; then \
+			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
+			echo "$$ADDLICENCESEOUT\n"; \
+			echo "Use 'make addlicense' to fix this."; \
+			exit 1; \
+		else \
+			echo "Check License finished successfully"; \
+		fi
 
 build: fmtcheck
 	go install

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,7 +24,7 @@ $(TOOLS_BIN_NAMES): $(TOOLS_BIN_DIR) $(TOOLS_MOD_DIR)/go.mod
 
 .PHONY: addlicense
 addlicense: $(TOOLS_BIN_DIR)/addlicense
-	$^ -s=only -y "" -c "Splunk, Inc." $(SRC_GO_FILES)
+	$^ -s=only -y "" -c "Splunk, Inc." -l mpl $(SRC_GO_FILES)
 
 build: fmtcheck
 	go install

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,7 +36,7 @@ addlicense: $(ADDLICENCESE)
 		fi
 
 .PHONY: checklicense
-checklicense:
+checklicense: $(ADDLICENCESE)
 	@ADDLICENCESEOUT=`$(ADDLICENCESE) -check $(SRC_GO_FILES) 2>&1`; \
 		if [ "$$ADDLICENCESEOUT" ]; then \
 			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \

--- a/internal/check/doc.go
+++ b/internal/check/doc.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 // Package check is used to provide more specific validations
 // across the different packages and named as such to avoid package
 // collisions with the terraform provided helpers

--- a/internal/check/notification.go
+++ b/internal/check/notification.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package check
 
 import (

--- a/internal/check/notification_test.go
+++ b/internal/check/notification_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package check
 
 import (

--- a/internal/check/severity.go
+++ b/internal/check/severity.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package check
 
 import (

--- a/internal/check/severity_test.go
+++ b/internal/check/severity_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package check
 
 import (

--- a/internal/check/timezone.go
+++ b/internal/check/timezone.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package check
 
 import (

--- a/internal/check/timezone_test.go
+++ b/internal/check/timezone_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package check
 
 import (

--- a/internal/check/unit.go
+++ b/internal/check/unit.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package check
 
 import (

--- a/internal/check/unit_test.go
+++ b/internal/check/unit_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package check
 
 import (

--- a/internal/common/notification_api.go
+++ b/internal/common/notification_api.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package common
 
 import (

--- a/internal/common/notification_api_test.go
+++ b/internal/common/notification_api_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package common
 
 import (

--- a/internal/common/notification_list.go
+++ b/internal/common/notification_list.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package common
 
 import (

--- a/internal/common/notification_list_test.go
+++ b/internal/common/notification_list_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package common
 
 import (

--- a/internal/common/notification_string.go
+++ b/internal/common/notification_string.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package common
 
 import (

--- a/internal/common/notification_string_test.go
+++ b/internal/common/notification_string_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package common
 
 import (

--- a/internal/definition/team/resource.go
+++ b/internal/definition/team/resource.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package team
 
 import (

--- a/internal/definition/team/resource_test.go
+++ b/internal/definition/team/resource_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package team
 
 import (

--- a/internal/definition/team/schema.go
+++ b/internal/definition/team/schema.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package team
 
 import (

--- a/internal/definition/team/schema_test.go
+++ b/internal/definition/team/schema_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package team
 
 import (

--- a/internal/providermeta/meta.go
+++ b/internal/providermeta/meta.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package pmeta
 
 import (

--- a/internal/providermeta/meta_lookup.go
+++ b/internal/providermeta/meta_lookup.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package pmeta
 
 import (

--- a/internal/providermeta/meta_lookup_other.go
+++ b/internal/providermeta/meta_lookup_other.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 //go:build !windows
 
 package pmeta

--- a/internal/providermeta/meta_lookup_test.go
+++ b/internal/providermeta/meta_lookup_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package pmeta
 
 import (

--- a/internal/providermeta/meta_lookup_windows.go
+++ b/internal/providermeta/meta_lookup_windows.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package pmeta
 
 const NetrcFile = "_netrc"

--- a/internal/providermeta/meta_test.go
+++ b/internal/providermeta/meta_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package pmeta
 
 import (

--- a/internal/tfextension/diag.go
+++ b/internal/tfextension/diag.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tfext
 
 import (

--- a/internal/tfextension/diag_test.go
+++ b/internal/tfextension/diag_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tfext
 
 import (

--- a/internal/tfextension/encoding.go
+++ b/internal/tfextension/encoding.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tfext
 
 import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/tfextension/encoding_test.go
+++ b/internal/tfextension/encoding_test.go
@@ -1,1 +1,4 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tfext

--- a/internal/tftest/meta.go
+++ b/internal/tftest/meta.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftest
 
 import (

--- a/internal/tftest/meta_test.go
+++ b/internal/tftest/meta_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftest
 
 import (

--- a/internal/tftest/resource.go
+++ b/internal/tftest/resource.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftest
 
 import (

--- a/internal/tftest/resource_test.go
+++ b/internal/tftest/resource_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftest
 
 import (

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,0 +1,10 @@
+module github.com/splunk-terraform/terraform-provider-signalfx/internal/tools
+
+go 1.23.2
+
+require github.com/google/addlicense v1.1.1
+
+require (
+	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+)

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -1,0 +1,6 @@
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/google/addlicense v1.1.1 h1:jpVf9qPbU8rz5MxKo7d+RMcNHkqxi4YJi/laauX4aAE=
+github.com/google/addlicense v1.1.1/go.mod h1:Sm/DHu7Jk+T5miFHHehdIjbi4M5+dJDRS3Cq0rncIxA=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1,0 +1,11 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build tools
+
+package tools
+
+import (
+	_ "github.com/google/addlicense"
+)
+go

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1,5 +1,5 @@
 // Copyright Splunk, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MPL-2.0
 
 //go:build tools
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1,4 +1,4 @@
 // Copyright Splunk, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MPL-2.0
 
 package tools

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1,0 +1,4 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tools

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package main
 
 import (

--- a/signalfx/data_source_dimension_values.go
+++ b/signalfx/data_source_dimension_values.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/data_source_pagerduty_integration.go
+++ b/signalfx/data_source_pagerduty_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/integration.go
+++ b/signalfx/integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/integration_test.go
+++ b/signalfx/integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/notifications.go
+++ b/signalfx/notifications.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/notifications_test.go
+++ b/signalfx/notifications_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/provider_test.go
+++ b/signalfx/provider_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_alert_muting_rule.go
+++ b/signalfx/resource_signalfx_alert_muting_rule.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_alert_muting_rule_test.go
+++ b/signalfx/resource_signalfx_alert_muting_rule_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_aws_external_integration.go
+++ b/signalfx/resource_signalfx_aws_external_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_aws_integration_ops.go
+++ b/signalfx/resource_signalfx_aws_integration_ops.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_aws_integration_test.go
+++ b/signalfx/resource_signalfx_aws_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_aws_token_integration.go
+++ b/signalfx/resource_signalfx_aws_token_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_azure_integration.go
+++ b/signalfx/resource_signalfx_azure_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_azure_integration_test.go
+++ b/signalfx/resource_signalfx_azure_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_dashboard_and_friends_test.go
+++ b/signalfx/resource_signalfx_dashboard_and_friends_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_dashboard_group_dashboard_configs_test.go
+++ b/signalfx/resource_signalfx_dashboard_group_dashboard_configs_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_dashboard_group_test.go
+++ b/signalfx/resource_signalfx_dashboard_group_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_dashboard_layouts_test.go
+++ b/signalfx/resource_signalfx_dashboard_layouts_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_dashboard_test.go
+++ b/signalfx/resource_signalfx_dashboard_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_data_link.go
+++ b/signalfx/resource_signalfx_data_link.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_data_link_test.go
+++ b/signalfx/resource_signalfx_data_link_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_event_feed_chart.go
+++ b/signalfx/resource_signalfx_event_feed_chart.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_event_feed_chart_test.go
+++ b/signalfx/resource_signalfx_event_feed_chart_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_gcp_integration.go
+++ b/signalfx/resource_signalfx_gcp_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_gcp_integration_test.go
+++ b/signalfx/resource_signalfx_gcp_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_heatmap_chart_test.go
+++ b/signalfx/resource_signalfx_heatmap_chart_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_jira_integration.go
+++ b/signalfx/resource_signalfx_jira_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_jira_integration_test.go
+++ b/signalfx/resource_signalfx_jira_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_list_chart_test.go
+++ b/signalfx/resource_signalfx_list_chart_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_log_timeline.go
+++ b/signalfx/resource_signalfx_log_timeline.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_log_timeline_test.go
+++ b/signalfx/resource_signalfx_log_timeline_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_log_view.go
+++ b/signalfx/resource_signalfx_log_view.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_log_view_test.go
+++ b/signalfx/resource_signalfx_log_view_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_metric_ruleset.go
+++ b/signalfx/resource_signalfx_metric_ruleset.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_metric_ruleset_test.go
+++ b/signalfx/resource_signalfx_metric_ruleset_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_opsgenie_integration.go
+++ b/signalfx/resource_signalfx_opsgenie_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_opsgenie_integration_test.go
+++ b/signalfx/resource_signalfx_opsgenie_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_org_token.go
+++ b/signalfx/resource_signalfx_org_token.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_org_token_test.go
+++ b/signalfx/resource_signalfx_org_token_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_pagerduty_integration.go
+++ b/signalfx/resource_signalfx_pagerduty_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_pagerduty_integration_test.go
+++ b/signalfx/resource_signalfx_pagerduty_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_service_now_integration.go
+++ b/signalfx/resource_signalfx_service_now_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 /*
  * Resource for ServiceNow integration
  *

--- a/signalfx/resource_signalfx_service_now_integration_test.go
+++ b/signalfx/resource_signalfx_service_now_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_single_value_chart_test.go
+++ b/signalfx/resource_signalfx_single_value_chart_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_slack_integration.go
+++ b/signalfx/resource_signalfx_slack_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_slack_integration_test.go
+++ b/signalfx/resource_signalfx_slack_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_slo.go
+++ b/signalfx/resource_signalfx_slo.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_slo_test.go
+++ b/signalfx/resource_signalfx_slo_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_table_chart.go
+++ b/signalfx/resource_signalfx_table_chart.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_table_chart_test.go
+++ b/signalfx/resource_signalfx_table_chart_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_team.go
+++ b/signalfx/resource_signalfx_team.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_team_test.go
+++ b/signalfx/resource_signalfx_team_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_text_chart.go
+++ b/signalfx/resource_signalfx_text_chart.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_text_chart_test.go
+++ b/signalfx/resource_signalfx_text_chart_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_time_chart_test.go
+++ b/signalfx/resource_signalfx_time_chart_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_victor_ops_integration.go
+++ b/signalfx/resource_signalfx_victor_ops_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_victor_ops_integration_test.go
+++ b/signalfx/resource_signalfx_victor_ops_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_webhook_integration.go
+++ b/signalfx/resource_signalfx_webhook_integration.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/resource_signalfx_webhook_integration_test.go
+++ b/signalfx/resource_signalfx_webhook_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package signalfx
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package version
 
 var (


### PR DESCRIPTION
## Context

This is to ensure that all files within the project have the correct license heading on all source code

## Changes

- Added `make addlicense` and `make checklicense` into Makefile
- Added Github workflow to validate license headers are being added.