### PR TITLE
Feature: Adding helper functions around errors and logging 

### DIFF
--- a/internal/tfextension/diag.go
+++ b/internal/tfextension/diag.go
@@ -35,7 +35,7 @@ func newUnwrapErrors(sev diag.Severity, err error, path ...cty.Path) (issues dia
 	}
 
 	// Checking to see if there is any joined errors
-	// so it can be unpacked into seperate reported issues.
+	// so it can be unpacked into separate reported issues.
 	// This useses the unpublished errors' [interface{ Unwrap() []error }]
 	// and if that is unset it then checks the uber's implementation.
 	var errs []error

--- a/internal/tfextension/diag.go
+++ b/internal/tfextension/diag.go
@@ -39,8 +39,8 @@ func newUnwrapErrors(sev diag.Severity, err error, path ...cty.Path) (issues dia
 	// This useses the unpublished errors' [interface{ Unwrap() []error }]
 	// and if that is unset it then checks the uber's implementation.
 	var errs []error
-	if v, ok := err.(interface{ Unwarp() []error }); ok {
-		errs = v.Unwarp()
+	if v, ok := err.(interface{ Unwrap() []error }); ok {
+		errs = v.Unwrap()
 	}
 
 	if len(errs) == 0 {

--- a/internal/tfextension/diag_test.go
+++ b/internal/tfextension/diag_test.go
@@ -101,6 +101,16 @@ func TestAsErrorDiagnostics(t *testing.T) {
 				{Severity: diag.Error, Summary: "bad entry", AttributePath: cty.IndexStringPath("attr")},
 			},
 		},
+		{
+			name: "multiple errors reported",
+			value: AsErrorDiagnostics(
+				errors.Join(errors.New("failed to validate entry #1"), errors.New("failed to validate entry #2")),
+			),
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "failed to validate entry #1"},
+				{Severity: diag.Error, Summary: "failed to validate entry #2"},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expect, tc.value)
@@ -133,6 +143,16 @@ func TestAsWarnDiagnostics(t *testing.T) {
 			value: AsWarnDiagnostics(errors.New("bad entry"), cty.IndexStringPath("attr")),
 			expect: diag.Diagnostics{
 				{Severity: diag.Warning, Summary: "bad entry", AttributePath: cty.IndexStringPath("attr")},
+			},
+		},
+		{
+			name: "multiple errors reported",
+			value: AsWarnDiagnostics(
+				errors.Join(errors.New("failed to validate entry #1"), errors.New("failed to validate entry #2")),
+			),
+			expect: diag.Diagnostics{
+				{Severity: diag.Warning, Summary: "failed to validate entry #1"},
+				{Severity: diag.Warning, Summary: "failed to validate entry #2"},
 			},
 		},
 	} {

--- a/internal/tfextension/logging.go
+++ b/internal/tfextension/logging.go
@@ -1,0 +1,42 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfext
+
+import "time"
+
+// LogFields is an extention to logging fields parameter
+// to help as a convience and provides some level of standards.
+type LogFields map[string]any
+
+// NewLogFields creates an empty [LogFields] that be used
+// as part of the `tflog` fields parameter.
+func NewLogFields() LogFields {
+	return make(LogFields)
+}
+
+// ErrorLogFields is a convience function that allows
+// for a [LogFields] to be created with the error entry set.
+func ErrorLogFields(err error) LogFields {
+	return NewLogFields().Error(err)
+}
+
+// Error appends the field name `error` if the error value is not nil
+func (lf LogFields) Error(err error) LogFields {
+	if err != nil {
+		lf["error"] = err.Error()
+	}
+	return lf
+}
+
+// Duration is a convience function to ensure the key is correctly set.
+func (lf LogFields) Duration(key string, val time.Duration) LogFields {
+	return lf.Field(key, val.String())
+}
+
+// Field appends any type to be set as the key's value.
+// if the field already exists, it is overwritten.
+func (lf LogFields) Field(key string, val any) LogFields {
+	lf[key] = val
+	return lf
+}

--- a/internal/tfextension/logging.go
+++ b/internal/tfextension/logging.go
@@ -5,7 +5,7 @@ package tfext
 
 import "time"
 
-// LogFields is an extention to logging fields parameter
+// LogFields is an extension to logging fields parameter
 // to help as a convience and provides some level of standards.
 type LogFields map[string]any
 

--- a/internal/tfextension/logging_test.go
+++ b/internal/tfextension/logging_test.go
@@ -1,0 +1,54 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfext
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		lf     LogFields
+		expect map[string]any
+	}{
+		{
+			name:   "empty",
+			lf:     NewLogFields(),
+			expect: map[string]any{},
+		},
+		{
+			name:   "contains error message",
+			lf:     ErrorLogFields(errors.New("failed operation")),
+			expect: map[string]any{"error": "failed operation"},
+		},
+		{
+			name:   "no error message",
+			lf:     ErrorLogFields(nil),
+			expect: map[string]any{},
+		},
+		{
+			name:   "duration set",
+			lf:     NewLogFields().Duration("min-delay", 1*time.Minute+30*time.Second),
+			expect: map[string]any{"min-delay": "1m30s"},
+		},
+		{
+			name:   "custom field",
+			lf:     NewLogFields().Field("example", 1),
+			expect: map[string]any{"example": 1},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.EqualValues(t, tc.expect, tc.lf, "Must match the expected field")
+		})
+	}
+}


### PR DESCRIPTION
## Context

As a means to help support functionality from packages like `muliterr` and `errors` that can return multiple errors as one type, this looks at introspection of those types and providing an improved functionality and reporting them as seperate issues if they are made up of many errors.

The logging portion from `tflog` makes it hard to standardise fields, and the most common one being `error`. So this extension is added to provide that functionality and is similar to something observed in something like `slog` or `zap`.

## Changes

- `tfextention.AsErrorDiagnostics` and `tfextension.AsWarnDiagnostics` perform introspection on errors and split multiple errors
- Added new helpers with regards to `tflog`