### PR TITLE
Chore: Don't fail on codecov targets

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,7 @@ coverage:
   status:
     project:
       default:
-        enabled: no
+        enabled: yes
         target: 80%
     patch:
       default:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,3 +61,4 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false


### PR DESCRIPTION
## Context

There is a lot of work needed to reach the targets, so I don't want to block commits into the project.

## Changes

- Don't fail CI on code cov report