### PR TITLE
Chore: Adding target project coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,7 @@ coverage:
   status:
     project:
       default:
-        enabled: no
+        enabled: yes
         target: 80%
     patch:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,6 +3,9 @@ codecov:
   # only use the latest copy on main branch
   strict_yaml_branch: main
 
+ignore:
+- "signalfx"
+
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
## Context

Due to the CI restriction to only use main's workflows, this will now enable project overall coverage tracking without breaking the build.

## Changes

- Adding project target