### PR TITLE
Chore: Removing deadcode from the current codebase

### DIFF
--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -649,16 +649,6 @@ func getMirroredDashboardConfigs(config *signalfxConfig, d *schema.ResourceData)
 	return out, nil
 }
 
-func getDashboardIDs(dashboardList interface{}) map[string]bool {
-	dashes := dashboardList.([]interface{})
-	dashIDs := map[string]bool{}
-	for _, d := range dashes {
-		dash := d.(map[string]interface{})
-		dashIDs[dash["dashboard_id"].(string)] = true
-	}
-	return dashIDs
-}
-
 func dashboardgroupDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -916,14 +916,3 @@ func HashCodeString(s string) int {
 	// v == MinInt
 	return 0
 }
-
-// Strings hashes a list of strings to a unique hashcode.
-func HashCodeStrings(strings []string) string {
-	var buf bytes.Buffer
-
-	for _, s := range strings {
-		buf.WriteString(fmt.Sprintf("%s-", s))
-	}
-
-	return fmt.Sprintf("%d", HashCodeString(buf.String()))
-}

--- a/signalfx/resource_signalfx_table_chart.go
+++ b/signalfx/resource_signalfx_table_chart.go
@@ -6,9 +6,7 @@ package signalfx
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -383,24 +381,4 @@ func tablechartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
 	return config.Client.DeleteChart(context.TODO(), d.Id())
-}
-
-/*
-Validates the color_range field against a list of allowed words.
-*/
-func validateTableChartColor(v interface{}, k string) (we []string, errors []error) {
-	value := v.(string)
-	keys := make([]string, 0, len(ChartColorsSlice))
-	found := false
-	for _, item := range ChartColorsSlice {
-		if value == item.name {
-			found = true
-		}
-		keys = append(keys, item.name)
-	}
-	if !found {
-		joinedColors := strings.Join(keys, ",")
-		errors = append(errors, fmt.Errorf("%s not allowed; must be either %s", value, joinedColors))
-	}
-	return
 }

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -4,13 +4,9 @@
 package signalfx
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"math"
-	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -56,25 +52,6 @@ var ChartColorsSlice = []chartColor{
 	{"lime_green", "#6bd37e"},
 }
 
-func buildURL(apiURL string, path string, params map[string]string) (string, error) {
-	u, err := url.Parse(apiURL)
-	if err != nil {
-		return "", err
-	}
-
-	u.Path = path
-
-	if len(params) > 0 {
-		q := u.Query()
-		for k, v := range params {
-			q.Set(k, v)
-		}
-		u.RawQuery = q.Encode()
-	}
-
-	return u.String(), nil
-}
-
 func buildAppURL(appURL string, fragment string) (string, error) {
 	// Include a trailing slash, as without this Go doesn't add one for the fragment and that seems to be a required part of the url
 	u, err := url.Parse(appURL + "/")
@@ -96,31 +73,6 @@ func chartExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 		return false, err
 	}
 	return true, nil
-}
-
-/*
-Utility function that wraps http calls to SignalFx
-*/
-func sendRequest(method string, url string, token string, payload []byte) (int, []byte, error) {
-	client := &http.Client{}
-
-	req, err := http.NewRequest(method, url, bytes.NewReader(payload))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-SF-Token", token)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return -1, nil, fmt.Errorf("Failed sending %s request to Signalfx: %s", method, err.Error())
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	defer resp.Body.Close()
-
-	if err != nil {
-		return resp.StatusCode, nil, fmt.Errorf("Failed reading response body from %s request: %s", method, err.Error())
-	}
-
-	return resp.StatusCode, body, nil
 }
 
 func expandStringSetToSlice(set *schema.Set) []string {
@@ -225,94 +177,6 @@ func getColorScaleOptionsFromSlice(colorScale []interface{}) []*chart.SecondaryV
 		item[i] = options
 	}
 	return item
-}
-
-/*
-Send a GET to get the current state of the resource. It just checks if the lastUpdated timestamp is
-later than the timestamp saved in the resource. If so, the resource has been modified in some way
-in the UI, and should be recreated. This is signaled by setting synced to false, meaning if synced is set to
-true in the tf configuration, it will update the resource to achieve the desired state.
-*/
-func resourceRead(url string, sfxToken string, d *schema.ResourceData) error {
-	status_code, resp_body, err := sendRequest("GET", url, sfxToken, nil)
-	if status_code == 200 {
-		mapped_resp := map[string]interface{}{}
-		err = json.Unmarshal(resp_body, &mapped_resp)
-		if err != nil {
-			return fmt.Errorf("Failed unmarshaling for the resource %s during read: %s", d.Get("name"), err.Error())
-		}
-		// This implies the resource was modified in the Splunk Observability Cloud UI and therefore it is not synced.
-		last_updated := mapped_resp["lastUpdated"].(float64)
-		if last_updated > (d.Get("last_updated").(float64) + OFFSET) {
-			d.Set("synced", false)
-			d.Set("last_updated", last_updated)
-		}
-	} else {
-		if status_code == 404 && strings.Contains(string(resp_body), " not found") {
-			// This implies that the resouce was deleted in the Splunk Observability Cloud UI and therefore we need to recreate it
-			d.SetId("")
-		} else {
-			return fmt.Errorf("For the resource '%s' Splunk Observability Cloud returned status %d: \n%s", d.Get("name"), status_code, resp_body)
-		}
-	}
-
-	return nil
-}
-
-/*
-Fetches payload specified in terraform configuration and creates a resource
-*/
-func resourceCreate(url string, sfxToken string, payload []byte, d *schema.ResourceData) error {
-	status_code, resp_body, err := sendRequest("POST", url, sfxToken, payload)
-	if status_code == 200 {
-		mapped_resp := map[string]interface{}{}
-		err = json.Unmarshal(resp_body, &mapped_resp)
-		if err != nil {
-			return fmt.Errorf("Failed unmarshaling for the resource %s during creation: %s", d.Get("name"), err.Error())
-		}
-		d.SetId(fmt.Sprintf("%s", mapped_resp["id"].(string)))
-		d.Set("last_updated", mapped_resp["lastUpdated"].(float64))
-		d.Set("synced", true)
-	} else {
-		return fmt.Errorf("For the resource %s Splunk Observability Cloud returned status %d: \n%s", d.Get("name"), status_code, resp_body)
-	}
-	return nil
-}
-
-/*
-Fetches payload specified in terraform configuration and creates chart
-*/
-func resourceUpdate(url string, sfxToken string, payload []byte, d *schema.ResourceData) error {
-	status_code, resp_body, err := sendRequest("PUT", url, sfxToken, payload)
-	if status_code == 200 {
-		mapped_resp := map[string]interface{}{}
-		err = json.Unmarshal(resp_body, &mapped_resp)
-		if err != nil {
-			return fmt.Errorf("Failed unmarshaling for the resource %s during creation: %s", d.Get("name"), err.Error())
-		}
-		// If the resource was updated successfully with configs, it is now synced with Signalfx
-		d.Set("synced", true)
-		d.Set("last_updated", mapped_resp["lastUpdated"].(float64))
-	} else {
-		return fmt.Errorf("For the resource '%s' Splunk Observability Cloud returned status %d: \n%s", d.Get("name"), status_code, resp_body)
-	}
-	return nil
-}
-
-/*
-Deletes a resource.  If the resource does not exist, it will receive a 404, and carry on as usual.
-*/
-func resourceDelete(url string, sfxToken string, d *schema.ResourceData) error {
-	status_code, resp_body, err := sendRequest("DELETE", url, sfxToken, nil)
-	if err != nil {
-		return fmt.Errorf("Failed deleting resource  %s: %s", d.Get("name"), err.Error())
-	}
-	if status_code < 400 || status_code == 404 {
-		d.SetId("")
-	} else {
-		return fmt.Errorf("For the resource  %s Splunk Observability Cloud returned status %d: \n%s", d.Get("name"), status_code, resp_body)
-	}
-	return nil
 }
 
 /*

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -4,38 +4,10 @@
 package signalfx
 
 import (
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestSendRequestSuccess(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, `Test Response`)
-	}))
-	defer server.Close()
-
-	status_code, body, err := sendRequest("GET", server.URL, "token", nil)
-	assert.Equal(t, 200, status_code)
-	assert.Equal(t, "Test Response\n", string(body))
-	assert.Nil(t, err)
-}
-
-func TestSendRequestResponseNotFound(t *testing.T) {
-	// Handler returns 404 page not found
-	server := httptest.NewServer(http.NotFoundHandler())
-	defer server.Close()
-
-	status_code, body, err := sendRequest("POST", server.URL, "token", nil)
-	assert.Equal(t, 404, status_code)
-	assert.Contains(t, string(body), "page not found")
-	assert.Nil(t, err)
-}
 
 func TestGetNameFromChartColorsByIndex(t *testing.T) {
 	name, err := getNameFromChartColorsByIndex(4)
@@ -65,14 +37,6 @@ func TestGetNameFromFullPaletteColorsByIndex(t *testing.T) {
 	name, err = getNameFromPaletteColorsByIndex(44)
 	assert.Equal(t, "", name, "Expected empty string for missing index")
 	assert.Error(t, err, "Expected error for missing color index")
-}
-
-func TestSendRequestFail(t *testing.T) {
-	// Client will fail to send due to invalid URL
-	status_code, body, err := sendRequest("GET", "", "token", nil)
-	assert.Equal(t, -1, status_code)
-	assert.Nil(t, body)
-	assert.Contains(t, err.Error(), "Failed sending GET request")
 }
 
 func TestValidateSignalfxRelativeTimeMinutes(t *testing.T) {
@@ -129,18 +93,6 @@ func TestValidateFullPaletteColorsFail(t *testing.T) {
 func TestValidateSortByNoDirection(t *testing.T) {
 	_, errors := validateSortBy("foo", "sort_by")
 	assert.Equal(t, 1, len(errors))
-}
-
-func TestBuildURL(t *testing.T) {
-	u, error := buildURL("https://www.example.com", "/v2/chart", map[string]string{})
-	assert.NoError(t, error)
-	assert.Equal(t, "https://www.example.com/v2/chart", u)
-}
-
-func TestBuildURLWithParams(t *testing.T) {
-	u, error := buildURL("https://www.example.com", "/v2/chart", map[string]string{"foo": "bar"})
-	assert.NoError(t, error)
-	assert.Equal(t, "https://www.example.com/v2/chart?foo=bar", u)
 }
 
 func TestBuildAppURL(t *testing.T) {


### PR DESCRIPTION
## Context

To help with addressing what to port and what should be deprecated, I've used go's `deadcode` tool that highlighted these functions are not used, thus not sparking joy.

## Changes

- Removing methods highlighted with `deadcode`