### PR TITLE
Feature: Acceptance test framework with example

### DIFF
--- a/internal/definition/provider/provider.go
+++ b/internal/definition/provider/provider.go
@@ -70,7 +70,7 @@ func New() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"signalfx_team": team.NewResource(),
+			team.ResourceName: team.NewResource(),
 		},
 		DataSourcesMap:       map[string]*schema.Resource{},
 		ConfigureContextFunc: configureProvider,

--- a/internal/definition/provider/provider_test.go
+++ b/internal/definition/provider/provider_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/tftest"
 )
 
 func TestProviderValidation(t *testing.T) {
@@ -37,7 +39,6 @@ func TestProviderHasResource(t *testing.T) {
 }
 
 func TestProviderConfiguration(t *testing.T) {
-	t.Parallel()
 
 	for _, tc := range []struct {
 		name    string
@@ -61,7 +62,7 @@ func TestProviderConfiguration(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			tftest.CleanEnvVars(t)
 
 			actual := New().Configure(
 				context.Background(),

--- a/internal/definition/team/resource_acceptance_test.go
+++ b/internal/definition/team/resource_acceptance_test.go
@@ -1,0 +1,58 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package team
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/tftest"
+)
+
+func TestAcceptance(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		opts  []tftest.AcceptanceHandlerOption
+		steps []resource.TestStep
+	}{
+		{
+			name: "simple lifecylce",
+			steps: []resource.TestStep{
+				{
+					Config: tftest.LoadConfig("testdata/resource_team.tf"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("signalfx_team.example_test", "name", "my team"),
+						resource.TestCheckResourceAttr("signalfx_team.example_test", "description", "An example of team"),
+					),
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+				{
+					Config: tftest.LoadConfig("testdata/resource_team.tf"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("signalfx_team.example_test", "name", "my team"),
+						resource.TestCheckResourceAttr("signalfx_team.example_test", "description", "An example of team"),
+					),
+				},
+				{
+					Config:  tftest.LoadConfig("testdata/resource_team.tf"),
+					Destroy: true,
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := []tftest.AcceptanceHandlerOption{
+				tftest.WithAcceptanceResources(map[string]*schema.Resource{
+					ResourceName: NewResource(),
+				}),
+			}
+
+			tftest.NewAcceptanceHandler(append(base, tc.opts...)).
+				Test(t, tc.steps)
+		})
+	}
+}

--- a/internal/definition/team/testdata/resource_team.tf
+++ b/internal/definition/team/testdata/resource_team.tf
@@ -1,0 +1,8 @@
+provider "signalfx" {}
+
+resource "signalfx_team" "example_test" {
+  provider = signalfx
+
+  name        = "my team"
+  description = "An example of team"
+}

--- a/internal/tftest/acceptance.go
+++ b/internal/tftest/acceptance.go
@@ -16,7 +16,7 @@ import (
 )
 
 // AcceptanceHandler is used to abstract some of the more raw
-// terraform test functionality and standardise how acceptance tests are invoked.
+// terraform test functionality and standardize how acceptance tests are invoked.
 type AcceptanceHandler struct {
 	beforeAll func()
 	provider  *schema.Provider

--- a/internal/tftest/acceptance.go
+++ b/internal/tftest/acceptance.go
@@ -94,7 +94,7 @@ func (ah *AcceptanceHandler) Test(t *testing.T, steps []resource.TestStep) {
 	tc := resource.TestCase{
 		IsUnitTest: false,
 		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"signalfx": func() (*schema.Provider, error) {
+			"signalfx": func() (*schema.Provider, error) { //nolint:unparam // Required signature
 				return ah.provider, nil
 			},
 		},

--- a/internal/tftest/acceptance.go
+++ b/internal/tftest/acceptance.go
@@ -1,0 +1,106 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tftest
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"go.uber.org/multierr"
+)
+
+// AcceptanceHandler is used to abstract some of the more raw
+// terraform test functionality and standardise how acceptance tests are invoked.
+type AcceptanceHandler struct {
+	beforeAll func()
+	provider  *schema.Provider
+}
+
+// AcceptanceHandlerOption is used to supply additional values to a test case.
+type AcceptanceHandlerOption func(*AcceptanceHandler)
+
+func WithAcceptanceResources(resources map[string]*schema.Resource) AcceptanceHandlerOption {
+	return func(ah *AcceptanceHandler) {
+		ah.provider.ResourcesMap = resources
+	}
+}
+
+func WithAcceptanceDataSources(data map[string]*schema.Resource) AcceptanceHandlerOption {
+	return func(ah *AcceptanceHandler) {
+		ah.provider.DataSourcesMap = data
+	}
+}
+
+func WithAcceptanceBeforeAll(before func()) AcceptanceHandlerOption {
+	return func(ah *AcceptanceHandler) {
+		ah.beforeAll = before
+	}
+}
+
+func NewAcceptanceHandler(opts []AcceptanceHandlerOption) *AcceptanceHandler {
+	ah := &AcceptanceHandler{
+		provider: &schema.Provider{
+			Schema:               make(map[string]*schema.Schema),
+			ConfigureContextFunc: newAcceptanceConfigure,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(ah)
+	}
+
+	return ah
+}
+
+func (ah *AcceptanceHandler) Validate() (errs error) {
+	if len(ah.provider.DataSourcesMap) == 0 && len(ah.provider.ResourcesMap) == 0 {
+		errs = multierr.Append(errs, errors.New("missing resource and datasource defintions"))
+	}
+
+	return multierr.Append(errs, ah.provider.InternalValidate())
+}
+
+func (ah *AcceptanceHandler) Test(t *testing.T, steps []resource.TestStep) {
+	var msgs []string
+	if _, set := os.LookupEnv("SFX_AUTH_TOKEN"); !set {
+		msgs = append(msgs, fmt.Sprintf("missing environment variable %q", "SFX_AUTH_TOKEN"))
+	}
+	if _, set := os.LookupEnv("SFX_API_URL"); !set {
+		msgs = append(msgs, fmt.Sprintf("missing environment variable %q", "SFX_API_URL"))
+	}
+	if len(msgs) != 0 {
+		t.Skip(
+			"Missing required environment variables to run tests, Please set the listed variables below:\n",
+			strings.Join(msgs, "\n"),
+		)
+		return
+	}
+
+	// Due to how the terraform library works,
+	// if this is globally set for each test case,
+	// it will cause some functions to panic instead of returning an error.
+	// Therefore, this will set the environment variable for the test and will
+	// be unset once the test is completed.
+	//
+	// See https://github.com/hashicorp/terraform-plugin-sdk/issues/1384 for more details.
+	t.Setenv("TF_ACC", "1")
+
+	tc := resource.TestCase{
+		IsUnitTest: false,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"signalfx": func() (*schema.Provider, error) {
+				return ah.provider, nil
+			},
+		},
+		PreCheck: ah.beforeAll,
+		Steps:    steps,
+	}
+
+	resource.Test(t, tc)
+}

--- a/internal/tftest/acceptance_test.go
+++ b/internal/tftest/acceptance_test.go
@@ -1,0 +1,128 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tftest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAcceptanceHandlerOptions(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		opts   []AcceptanceHandlerOption
+		errVal string
+	}{
+		{
+			name:   "no options",
+			opts:   []AcceptanceHandlerOption{},
+			errVal: "missing resource and datasource defintions",
+		},
+		{
+			name: "defines data sources",
+			opts: []AcceptanceHandlerOption{
+				WithAcceptanceDataSources(map[string]*schema.Resource{
+					"blank": {},
+				}),
+			},
+		},
+		{
+			name: "defines resources",
+			opts: []AcceptanceHandlerOption{
+				WithAcceptanceResources(map[string]*schema.Resource{
+					"blank": {},
+				}),
+			},
+		},
+		{
+			name: "all options",
+			opts: []AcceptanceHandlerOption{
+				WithAcceptanceResources(map[string]*schema.Resource{
+					"blank": {},
+				}),
+				WithAcceptanceDataSources(map[string]*schema.Resource{
+					"blank": {},
+				}),
+				WithAcceptanceBeforeAll(func() {
+					// Do nothing
+				}),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := NewAcceptanceHandler(tc.opts).Validate()
+			if tc.errVal != "" {
+				assert.EqualError(t, err, tc.errVal, "Must match the expected value")
+			} else {
+				assert.NoError(t, err, "Must not error")
+			}
+		})
+	}
+}
+
+func TestAcceptanceHandlerTest(t *testing.T) {
+
+	for _, tc := range []struct {
+		name    string
+		env     map[string]string
+		skipped bool
+	}{
+		{
+			name:    "No environment variables set",
+			env:     map[string]string{},
+			skipped: true,
+		},
+		{
+			name: "environment vars set",
+			env: map[string]string{
+				"SFX_AUTH_TOKEN": "aaaa",
+				"SFX_API_URL":    "https://localhost",
+			},
+			skipped: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Ensure that any values that might already be set
+			// are excluded for these test cases
+			globals := make(map[string]string)
+			t.Cleanup(func() {
+				// Restore the original values if any where defined
+				for k, v := range globals {
+					_ = os.Setenv(k, v)
+				}
+			})
+			for k, v := range tc.env {
+				if val, ok := os.LookupEnv(k); ok {
+					globals[k] = val
+				}
+				t.Setenv(k, v)
+			}
+
+			handler := NewAcceptanceHandler([]AcceptanceHandlerOption{
+				WithAcceptanceResources(map[string]*schema.Resource{
+					"nop": {},
+				}),
+			})
+
+			t.Cleanup(func() {
+				assert.Equal(t, tc.skipped, t.Skipped(), "Must have been skipped")
+			})
+
+			handler.Test(t, []resource.TestStep{
+				{
+					Config:   "{}",
+					SkipFunc: func() (bool, error) { return true, nil },
+				},
+			})
+		})
+	}
+}

--- a/internal/tftest/acceptance_test.go
+++ b/internal/tftest/acceptance_test.go
@@ -4,7 +4,6 @@
 package tftest
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -70,7 +69,6 @@ func TestAcceptanceHandlerOptions(t *testing.T) {
 }
 
 func TestAcceptanceHandlerTest(t *testing.T) {
-
 	for _, tc := range []struct {
 		name    string
 		env     map[string]string
@@ -91,19 +89,9 @@ func TestAcceptanceHandlerTest(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// Ensure that any values that might already be set
-			// are excluded for these test cases
-			globals := make(map[string]string)
-			t.Cleanup(func() {
-				// Restore the original values if any where defined
-				for k, v := range globals {
-					_ = os.Setenv(k, v)
-				}
-			})
+			CleanEnvVars(t)
+
 			for k, v := range tc.env {
-				if val, ok := os.LookupEnv(k); ok {
-					globals[k] = val
-				}
 				t.Setenv(k, v)
 			}
 

--- a/internal/tftest/acceptance_test.go
+++ b/internal/tftest/acceptance_test.go
@@ -107,8 +107,7 @@ func TestAcceptanceHandlerTest(t *testing.T) {
 
 			handler.Test(t, []resource.TestStep{
 				{
-					Config:   "{}",
-					SkipFunc: func() (bool, error) { return true, nil },
+					Config: "{}", // Empty configuration
 				},
 			})
 		})

--- a/internal/tftest/config.go
+++ b/internal/tftest/config.go
@@ -1,0 +1,17 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tftest
+
+import "os"
+
+// LoadConfig is used to read a configuration file from
+// disk and used within acceptance tests.
+// If there is any issue trying to read the file, this function will panic.
+func LoadConfig(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}

--- a/internal/tftest/config_test.go
+++ b/internal/tftest/config_test.go
@@ -1,0 +1,45 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tftest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		path   string
+		panics bool
+	}{
+		{
+			name:   "not existing file",
+			path:   "does-not-exist",
+			panics: true,
+		},
+		{
+			name:   "file exists",
+			path:   "config_test.go",
+			panics: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.panics {
+				assert.Panics(t, func() {
+					_ = LoadConfig(tc.path)
+				})
+			} else {
+				assert.NotPanics(t, func() {
+					_ = LoadConfig(tc.path)
+				})
+			}
+		})
+	}
+}

--- a/internal/tftest/environment.go
+++ b/internal/tftest/environment.go
@@ -1,0 +1,29 @@
+package tftest
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// CleanEnvVars removes any of the globally set env vars
+// that are used by the library and restores them once the tests is done.
+// Note this has be called before `t.Setenv` to ensure the original values are restored.
+func CleanEnvVars(t *testing.T) {
+	orig := os.Environ()
+	for _, k := range []string{
+		"SFX_AUTH_TOKEN",
+		"SFX_API_URL",
+	} {
+		assert.NoError(t, os.Unsetenv(k), "Unable to unset environment var %q", k)
+	}
+
+	t.Cleanup(func() {
+		for _, kv := range orig {
+			values := strings.SplitN(kv, "=", 2)
+			assert.NoError(t, os.Setenv(values[0], values[1]), "Unable to restore environment var %q", kv)
+		}
+	})
+}

--- a/internal/tftest/environment.go
+++ b/internal/tftest/environment.go
@@ -5,7 +5,6 @@ package tftest
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,18 +14,20 @@ import (
 // that are used by the library and restores them once the tests is done.
 // Note this has be called before `t.Setenv` to ensure the original values are restored.
 func CleanEnvVars(t *testing.T) {
-	orig := os.Environ()
+	orig := make(map[string]string)
 	for _, k := range []string{
 		"SFX_AUTH_TOKEN",
 		"SFX_API_URL",
 	} {
-		assert.NoError(t, os.Unsetenv(k), "Unable to unset environment var %q", k)
+		if v, ok := os.LookupEnv(k); ok {
+			orig[k] = v
+			assert.NoError(t, os.Unsetenv(k), "Unable to unset environment var %q", k)
+		}
 	}
 
 	t.Cleanup(func() {
-		for _, kv := range orig {
-			values := strings.SplitN(kv, "=", 2)
-			assert.NoError(t, os.Setenv(values[0], values[1]), "Unable to restore environment var %q", kv)
+		for k, v := range orig {
+			assert.NoError(t, os.Setenv(k, v), "Unable to restore environment var %s=%s", k, v)
 		}
 	})
 }

--- a/internal/tftest/environment.go
+++ b/internal/tftest/environment.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftest
 
 import (

--- a/internal/tftest/environment_test.go
+++ b/internal/tftest/environment_test.go
@@ -1,3 +1,6 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftest
 
 import "testing"

--- a/internal/tftest/environment_test.go
+++ b/internal/tftest/environment_test.go
@@ -1,0 +1,9 @@
+package tftest
+
+import "testing"
+
+func TestCleanEnvVars(t *testing.T) {
+	// Just testing the functionality is correct
+	// and included in the test coverage report.
+	CleanEnvVars(t)
+}

--- a/internal/tftest/meta.go
+++ b/internal/tftest/meta.go
@@ -4,13 +4,18 @@
 package tftest
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/signalfx/signalfx-go"
 
 	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
 )
 
 // NewTestHTTPMockMeta allows for a `providermeta.Meta` to be configured as if it would be set by the provider.
@@ -45,4 +50,23 @@ func NewTestHTTPMockMeta(routes map[string]http.HandlerFunc) func(testing.TB) an
 			Client:       sfx,
 		}
 	}
+}
+
+// newAcceptanceConfigure is used for acceptance testing purposes and not be used within unit tests.
+func newAcceptanceConfigure(context.Context, *schema.ResourceData) (any, diag.Diagnostics) {
+	meta := &pmeta.Meta{
+		APIURL:       os.Getenv("SFX_API_URL"),
+		AuthToken:    os.Getenv("SFX_AUTH_TOKEN"),
+		CustomAppURL: "https://app.signalfx.com",
+	}
+
+	meta.Client, _ = signalfx.NewClient(
+		meta.AuthToken,
+		signalfx.APIUrl(meta.APIURL),
+	)
+
+	if err := meta.Validate(); err != nil {
+		return nil, tfext.AsErrorDiagnostics(err)
+	}
+	return meta, nil
 }

--- a/internal/tftest/meta_test.go
+++ b/internal/tftest/meta_test.go
@@ -9,6 +9,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
@@ -33,4 +36,47 @@ func TestNewHTTPMockStat(t *testing.T) {
 
 	require.NoError(t, client.DeleteTeam(context.Background(), "001"), "Must not error removing team")
 	require.Error(t, client.DeleteTeam(context.Background(), "002"), "Must error trying to make request to endpoint not defined in mock")
+}
+
+func TestNewAcceptanceConfigure(t *testing.T) {
+
+	for _, tc := range []struct {
+		name   string
+		envs   map[string]string
+		issues diag.Diagnostics
+	}{
+		{
+			name: "no values set",
+			envs: map[string]string{},
+			issues: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "auth token not set"},
+				{Severity: diag.Error, Summary: "api url is not set"},
+			},
+		},
+		{
+			name: "configured environment vars",
+			envs: map[string]string{
+				"SFX_AUTH_TOKEN": "mytoken",
+				"SFX_API_URL":    "https://localhost",
+			},
+			issues: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			CleanEnvVars(t)
+
+			for k, v := range tc.envs {
+				t.Setenv(k, v)
+			}
+
+			actual, issues := newAcceptanceConfigure(context.Background(), &schema.ResourceData{})
+			if len(tc.issues) == 0 {
+				assert.NotNil(t, actual, "Must have a valid meta object returned")
+				assert.Empty(t, issues)
+			} else {
+				assert.Nil(t, actual, "Must have a valid meta object returned")
+				assert.Equal(t, tc.issues, issues, "Must match the expected value")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Context

To help make it easier setting up provider to work with the configured resources, and not depend on too much external state or files. This looks to bring in a standard way that acceptance tests can be run and also ensure the project 

While also setting up the acceptance test for the team resource, I also noticed a fun little side affect that the helper library changes its behaviour to _return on error_ to _panic on error_, so the type `AcceptanceHandler` was introduced to address those issues and make it possible to continue on without needing changes to existing code test frameworks.

## Changes

- Adding acceptance tests to `team` resource
- Added acceptance test framework
