### PR TITLE
Chore: Moving time range functionality

### DIFF
--- a/internal/check/time_range.go
+++ b/internal/check/time_range.go
@@ -1,0 +1,29 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package check
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+func TimeRange() schema.SchemaValidateDiagFunc {
+	return func(i any, p cty.Path) diag.Diagnostics {
+		s, ok := i.(string)
+		if !ok {
+			return tfext.AsErrorDiagnostics(
+				fmt.Errorf("expected %v to be type string", i),
+				p,
+			)
+		}
+		_, err := common.FromTimeRangeToMilliseconds(s)
+		return tfext.AsErrorDiagnostics(err, p)
+	}
+}

--- a/internal/check/time_range_test.go
+++ b/internal/check/time_range_test.go
@@ -1,0 +1,50 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package check
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeRange(t *testing.T) {
+	t.Parallel()
+
+	// More thorough testing is done within common
+	for _, tc := range []struct {
+		name   string
+		value  any
+		expect diag.Diagnostics
+	}{
+		{
+			name:  "no values provided",
+			value: nil,
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "expected <nil> to be type string"},
+			},
+		},
+		{
+			name:  "invalid timestamp",
+			value: "last week",
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "invalid timerange \"last week\": no negative prefix"},
+			},
+		},
+		{
+			name:   "valid timestamp",
+			value:  "-1w",
+			expect: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := TimeRange()(tc.value, cty.Path{})
+			assert.Equal(t, tc.expect, actual, "Must match the expected values")
+		})
+	}
+}

--- a/internal/common/time_range.go
+++ b/internal/common/time_range.go
@@ -1,0 +1,72 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+var millistamps = map[rune]int{
+	'm': 60 * 1000,               // Minute in Milliseconds
+	'h': 60 * 60 * 1000,          // Hour in Milliseconds
+	'd': 24 * 60 * 60 * 1000,     // Day in Milliseconds
+	'w': 7 * 24 * 60 * 60 * 1000, // Week in Milliseconds
+}
+
+func isUnit(r rune) bool {
+	_, ok := millistamps[r]
+	return ok
+}
+
+// FromTimeRange converts a timerange value into a millisecond value.
+// There is two supported syntax to the timerange:
+// - No unit values: implies the value is defined in milliseconds
+// - Unit values used: converts the sections into milliseconds based on unit
+// These syntax styles can no be mixed
+func FromTimeRangeToMilliseconds(tr string) (int, error) {
+	if tr == "" {
+		return 0, fmt.Errorf("invalid timerange: no value")
+	}
+	if !strings.HasPrefix(tr, "-") {
+		return 0, fmt.Errorf("invalid timerange %q: no negative prefix", tr)
+	}
+
+	var (
+		orig   = tr
+		window = 0
+		val    []rune
+	)
+	for _, r := range strings.TrimPrefix(tr, "-") {
+		switch {
+		case unicode.IsDigit(r):
+			val = append(val, r)
+		case isUnit(r):
+			if len(val) == 0 {
+				return 0, fmt.Errorf("invalid timerange %q: missing digits", orig)
+			}
+			v, err := strconv.Atoi(string(val))
+			if err != nil {
+				return 0, err
+			}
+			window += v * millistamps[r]
+			val = val[:0]
+		default:
+			return 0, fmt.Errorf("invalid timerange %q: unknown value", orig)
+		}
+	}
+
+	if len(val) != 0 {
+		if window != 0 {
+			return 0, fmt.Errorf("invalid timerange %q: mixed syntax used", orig)
+		}
+		// It is assumed that without a unit suffix,
+		// the value is provided in milliseconds
+		return strconv.Atoi(string(val))
+	}
+
+	return window, nil
+}

--- a/internal/common/time_range_test.go
+++ b/internal/common/time_range_test.go
@@ -1,0 +1,82 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromTimeRange(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		window string
+		expect int
+		errVal string
+	}{
+		{
+			name:   "no value provided",
+			window: "",
+			expect: 0,
+			errVal: "invalid timerange: no value",
+		},
+		{
+			name:   "no negative range provided",
+			window: "10h",
+			expect: 0,
+			errVal: "invalid timerange \"10h\": no negative prefix",
+		},
+		{
+			name:   "mixed syntax",
+			window: "-10h100",
+			expect: 0,
+			errVal: "invalid timerange \"-10h100\": mixed syntax used",
+		},
+		{
+			name:   "invalid string",
+			window: "-10l",
+			expect: 0,
+			errVal: "invalid timerange \"-10l\": unknown value",
+		},
+		{
+			name:   "no digits",
+			window: "-h",
+			expect: 0,
+			errVal: "invalid timerange \"-h\": missing digits",
+		},
+		{
+			name:   "simple timerange",
+			window: "-1w",
+			expect: 604800000,
+			errVal: "",
+		},
+		{
+			name:   "multiple units",
+			window: "-4w10d",
+			expect: 3283200000,
+			errVal: "",
+		},
+		{
+			name:   "milliseconds used",
+			window: "-10",
+			expect: 10,
+			errVal: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := FromTimeRangeToMilliseconds(tc.window)
+			assert.Equal(t, tc.expect, actual, "Must match the expected value")
+			if tc.errVal != "" {
+				assert.EqualError(t, err, tc.errVal, "Must match the expected error message")
+			} else {
+				assert.NoError(t, err, "Must not error")
+			}
+		})
+	}
+}

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/signalfx/signalfx-go/dashboard"
 	"github.com/signalfx/signalfx-go/util"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 )
 
 const (
@@ -53,11 +54,11 @@ func dashboardResource() *schema.Resource {
 				ValidateFunc: validateChartsResolution,
 			},
 			"time_range": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  validateSignalfxRelativeTime,
-				Description:   "From when to display data. Splunk Observability Cloud time syntax (e.g. -5m, -1h)",
-				ConflictsWith: []string{"start_time", "end_time"},
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: check.TimeRange(),
+				Description:      "From when to display data. Splunk Observability Cloud time syntax (e.g. -5m, -1h)",
+				ConflictsWith:    []string{"start_time", "end_time"},
 			},
 			"start_time": &schema.Schema{
 				Type:          schema.TypeInt,

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -295,7 +295,7 @@ func timeRangeStateUpgradeV0(ctx context.Context, rawState map[string]interface{
 
 	log.Printf("[DEBUG] SignalFx: Upgrading Detector State %v", rawState["time_range"])
 	if tr, ok := rawState["time_range"].(string); ok {
-		millis, err := fromRangeToMilliSeconds(tr)
+		millis, err := common.FromTimeRangeToMilliseconds(tr)
 		if err != nil {
 			return rawState, err
 		}

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"math"
 	"net/url"
-	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -231,45 +229,6 @@ func getLegendFieldOptions(d *schema.ResourceData) *chart.DataTableOptions {
 		}
 	}
 	return nil
-}
-
-/*
-Util method to validate Splunk Observability Cloud specific string format.
-*/
-func validateSignalfxRelativeTime(v interface{}, k string) (we []string, errors []error) {
-	ts := v.(string)
-
-	r, _ := regexp.Compile("-([0-9]+)[mhdw]")
-	if !r.MatchString(ts) {
-		errors = append(errors, fmt.Errorf("%s not allowed. Please use milliseconds from epoch or Splunk Observability Cloud time syntax (e.g. -5m, -1h)", ts))
-	}
-	return
-}
-
-/*
-*  Util method to convert from Splunk Observability Cloud string format to milliseconds
- */
-func fromRangeToMilliSeconds(timeRange string) (int, error) {
-	r := regexp.MustCompile("-([0-9]+)([mhdw])")
-	ss := r.FindStringSubmatch(timeRange)
-	var c int
-	switch ss[2] {
-	case "m":
-		c = 60 * 1000
-	case "h":
-		c = 60 * 60 * 1000
-	case "d":
-		c = 24 * 60 * 60 * 1000
-	case "w":
-		c = 7 * 24 * 60 * 60 * 1000
-	default:
-		c = 1
-	}
-	val, err := strconv.Atoi(ss[1])
-	if err != nil {
-		return -1, err
-	}
-	return val * c, nil
 }
 
 /*

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -39,37 +39,6 @@ func TestGetNameFromFullPaletteColorsByIndex(t *testing.T) {
 	assert.Error(t, err, "Expected error for missing color index")
 }
 
-func TestValidateSignalfxRelativeTimeMinutes(t *testing.T) {
-	_, errors := validateSignalfxRelativeTime("-5m", "time_range")
-	assert.Equal(t, 0, len(errors))
-}
-
-func TestValidateSignalfxRelativeTimeHours(t *testing.T) {
-	_, errors := validateSignalfxRelativeTime("-5h", "time_range")
-	assert.Equal(t, 0, len(errors))
-}
-
-func TestValidateSignalfxRelativeTimeDays(t *testing.T) {
-	_, errors := validateSignalfxRelativeTime("-5d", "time_range")
-	assert.Equal(t, 0, len(errors))
-}
-
-func TestValidateSignalfxRelativeTimeWeeks(t *testing.T) {
-	_, errors := validateSignalfxRelativeTime("-5w", "time_range")
-	assert.Equal(t, 0, len(errors))
-}
-
-func TestValidateSignalfxRelativeTimeNotAllowed(t *testing.T) {
-	_, errors := validateSignalfxRelativeTime("-5M", "time_range")
-	assert.Equal(t, 1, len(errors))
-}
-
-func TestConversionSignalfxRelativeTimeIntoMs(t *testing.T) {
-	ms, err := fromRangeToMilliSeconds("-15m")
-	assert.Equal(t, 900000, ms)
-	assert.Nil(t, err)
-}
-
 func TestValidateSortByAscending(t *testing.T) {
 	_, errors := validateSortBy("+foo", "sort_by")
 	assert.Equal(t, 0, len(errors))


### PR DESCRIPTION
## Context

Taking smaller pieces and moving them out into a expected structure.

## Changes

- Moved `fromRangeToMilliSeconds` to `common.FromTimeRangeToMilliseconds`