### PR TITLE
Bug Fix: Update color definitions.

### DIFF
--- a/internal/check/color.go
+++ b/internal/check/color.go
@@ -1,0 +1,35 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package check
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/visual"
+)
+
+func ColorName() schema.SchemaValidateDiagFunc {
+	return func(i any, p cty.Path) diag.Diagnostics {
+		s, ok := i.(string)
+		if !ok {
+			return tfext.AsErrorDiagnostics(
+				fmt.Errorf("expected %v to be of type string", i),
+				p,
+			)
+		}
+		cp := visual.NewColorPalette()
+		if _, exist := cp.GetColorIndex(s); exist {
+			return nil
+		}
+		return tfext.AsErrorDiagnostics(
+			fmt.Errorf("value %q is not allowed; must be one of %v", s, cp.Names()),
+			p,
+		)
+	}
+}

--- a/internal/check/color_test.go
+++ b/internal/check/color_test.go
@@ -1,0 +1,56 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package check
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColorName(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		val   any
+		diags diag.Diagnostics
+	}{
+		{
+			name: "no values provided",
+			val:  nil,
+			diags: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "expected <nil> to be of type string"},
+			},
+		},
+		{
+			name: "not a valid color",
+			val:  "nop",
+			diags: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary: "value \"nop\" is not allowed; must be one of " +
+						"[dark_red red crayola peridot greenyellow lime_green sage " +
+						"gray azure blue light_blue azue brown dark_orange orange dark_yellow " +
+						"gold yellow grape magenta cerise pink violet purple indigo lilac " +
+						"dark_green emerald jade chartreuse green aquamarine grey_blue iris navy]",
+				},
+			},
+		},
+		{
+			name:  "valid color",
+			val:   "red",
+			diags: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := ColorName()(tc.val, cty.Path{})
+			assert.Equal(t, tc.diags, diags, "Must match the expected values")
+		})
+	}
+}

--- a/internal/visual/color_palette.go
+++ b/internal/visual/color_palette.go
@@ -1,0 +1,115 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package visual
+
+import "slices"
+
+type ColorPalette struct {
+	// Named is the convience lookup table that allows
+	// a user to type the color they want to use and
+	// not need to be aware of the palette.
+	//
+	// Note:
+	// - the names used for the colors are best guesses since they are not named within the documentation.
+	// - Values can be referenced more than once to improve UX.
+	named map[string]int
+	// Index are the values table that is defined in
+	// https://dev.splunk.com/observability/docs/chartsdashboards/charts_overview/#Chart-color-palettes
+	index []string
+}
+
+func NewColorPalette() ColorPalette {
+	return ColorPalette{
+		named: map[string]int{
+			"red":         0,
+			"orange":      10,
+			"yellow":      11,
+			"green":       19,
+			"blue":        6,
+			"indigo":      17,
+			"violet":      15,
+			"brown":       9,
+			"dark_red":    0,
+			"crayola":     1,
+			"dark_orange": 9,
+			"peridot":     2,
+			"dark_yellow": 11,
+			"gold":        11,
+			"lime_green":  3,
+			"sage":        4,
+			"dark_green":  18,
+			"emerald":     18,
+			"chartreuse":  19,
+			"aquamarine":  20,
+			"light_blue":  7,
+			"navy":        21,
+			"azue":        8,
+			"iris":        21,
+			"purple":      16,
+			"magenta":     12,
+			"grape":       12,
+			"lilac":       17,
+			"cerise":      13,
+			"pink":        14,
+			"gray":        5,
+			"grey_blue":   21,
+			"azure":       6,
+			"greenyellow": 3,
+			"jade":        18,
+		},
+		// These values should be exactly matching to:
+		// https://dev.splunk.com/observability/docs/chartsdashboards/charts_overview/#Chart-color-palettes
+		index: []string{
+			0:  "#ea1849",
+			1:  "#eac24b",
+			2:  "#e5e517",
+			3:  "#6bd37e",
+			4:  "#aecf7f",
+			5:  "#999999",
+			6:  "#0077c2",
+			7:  "#00b9ff",
+			8:  "#6ca2b7",
+			9:  "#b04600",
+			10: "#f47e00",
+			11: "#e5b312",
+			12: "#bd468d",
+			13: "#e9008a",
+			14: "#ff8dd1",
+			15: "#876ff3",
+			16: "#a747ff",
+			17: "#ab99bc",
+			18: "#007c1d",
+			19: "#05ce00",
+			20: "#0dba8f",
+			21: "#98abbe",
+		},
+	}
+}
+
+func (cp ColorPalette) GetColorIndex(name string) (int32, bool) {
+	index, exist := cp.named[name]
+	return int32(index), exist
+}
+
+func (cp ColorPalette) GetHexCodebyIndex(index int32) (string, bool) {
+	hex := ""
+	if int(index) < len(cp.index) {
+		hex = cp.index[index]
+	}
+	return hex, hex != ""
+}
+
+func (cp ColorPalette) Names() []string {
+	words := make(map[int][]string, len(cp.named))
+	for name, index := range cp.named {
+		words[index] = append(words[index], name)
+	}
+	names := make([]string, 0, len(cp.named))
+	for i := 0; i < len(cp.index); i++ {
+		colors := words[i]
+		slices.Sort(colors)
+		names = append(names, colors...)
+	}
+	return names
+}

--- a/internal/visual/color_palette.go
+++ b/internal/visual/color_palette.go
@@ -13,7 +13,7 @@ type ColorPalette struct {
 	// Note:
 	// - the names used for the colors are best guesses since they are not named within the documentation.
 	// - Values can be referenced more than once to improve UX.
-	named map[string]int
+	named map[string]int32
 	// Index are the values table that is defined in
 	// https://dev.splunk.com/observability/docs/chartsdashboards/charts_overview/#Chart-color-palettes
 	index []string
@@ -21,7 +21,7 @@ type ColorPalette struct {
 
 func NewColorPalette() ColorPalette {
 	return ColorPalette{
-		named: map[string]int{
+		named: map[string]int32{
 			"red":         0,
 			"orange":      10,
 			"yellow":      11,
@@ -89,7 +89,7 @@ func NewColorPalette() ColorPalette {
 
 func (cp ColorPalette) GetColorIndex(name string) (int32, bool) {
 	index, exist := cp.named[name]
-	return int32(index), exist
+	return index, exist
 }
 
 func (cp ColorPalette) GetHexCodebyIndex(index int32) (string, bool) {
@@ -101,12 +101,12 @@ func (cp ColorPalette) GetHexCodebyIndex(index int32) (string, bool) {
 }
 
 func (cp ColorPalette) Names() []string {
-	words := make(map[int][]string, len(cp.named))
+	words := make(map[int32][]string, len(cp.named))
 	for name, index := range cp.named {
 		words[index] = append(words[index], name)
 	}
 	names := make([]string, 0, len(cp.named))
-	for i := 0; i < len(cp.index); i++ {
+	for i := int32(0); int(i) < len(cp.index); i++ {
 		colors := words[i]
 		slices.Sort(colors)
 		names = append(names, colors...)

--- a/internal/visual/color_palette_test.go
+++ b/internal/visual/color_palette_test.go
@@ -1,0 +1,64 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package visual
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestColorPalette(t *testing.T) {
+	t.Parallel()
+
+	var (
+		cp   = NewColorPalette()
+		seen = make([]int, 22)
+	)
+
+	for _, name := range cp.Names() {
+		idx, exist := cp.GetColorIndex(name)
+		require.True(t, exist, "Must return a valid result reading index")
+		seen[int(idx)]++
+		hex, exist := cp.GetHexCodebyIndex(idx)
+		assert.NotEmpty(t, hex, "Must have returned the expected hex code")
+		assert.True(t, exist, "Must have found the hex code value")
+	}
+
+	for idx := range seen {
+		assert.GreaterOrEqual(t, seen[idx], 1, "Must have seen each value at least once")
+	}
+}
+
+func TestHistoricalNames(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"gray",
+		"blue",
+		"azure",
+		"navy",
+		"brown",
+		"orange",
+		"yellow",
+		"magenta",
+		"purple",
+		"pink",
+		"violet",
+		"lilac",
+		"iris",
+		"emerald",
+		"green",
+		"aquamarine",
+		"red",
+		"gold",
+		"greenyellow",
+		"chartreuse",
+		"jade",
+	} {
+		_, ok := NewColorPalette().GetColorIndex(name)
+		assert.True(t, ok, "Must have the %q set as an option", name)
+	}
+}


### PR DESCRIPTION
## Context
This was an interesting one that had little documentation around it, so this is done on best effort and make sure the existing 
values are corrected while also provided standard color names.

This also includes validation checks for schema definitions.

I've opted to use `visual` as the package name since `color` package already exists in the standard library, and I am sure there is more to go into this package.

## Changes

- New corrected color palette type with additional names to address them
- Added validation function.