### PR TITLE
Bug Fix: Correcting usage of palette

### DIFF
--- a/internal/check/color.go
+++ b/internal/check/color.go
@@ -24,7 +24,7 @@ func ColorName() schema.SchemaValidateDiagFunc {
 			)
 		}
 		cp := visual.NewColorPalette()
-		if _, exist := cp.GetColorIndex(s); exist {
+		if _, exist := cp.ColorIndex(s); exist {
 			return nil
 		}
 		return tfext.AsErrorDiagnostics(

--- a/internal/check/color_test.go
+++ b/internal/check/color_test.go
@@ -33,10 +33,8 @@ func TestColorName(t *testing.T) {
 				{
 					Severity: diag.Error,
 					Summary: "value \"nop\" is not allowed; must be one of " +
-						"[dark_red red crayola peridot greenyellow lime_green sage " +
-						"gray azure blue light_blue azue brown dark_orange orange dark_yellow " +
-						"gold yellow grape magenta cerise pink violet purple indigo lilac " +
-						"dark_green emerald jade chartreuse green aquamarine grey_blue iris navy]",
+						"[red gold iris green jade gray blue azure navy brown orange yellow " +
+						"magenta cerise pink violet purple lilac emerald chartreuse yellowgreen aquamarine]",
 				},
 			},
 		},

--- a/internal/visual/color_palette.go
+++ b/internal/visual/color_palette.go
@@ -12,7 +12,6 @@ type ColorPalette struct {
 	//
 	// Note:
 	// - the names used for the colors are best guesses since they are not named within the documentation.
-	// - Values can be referenced more than once to improve UX.
 	named map[string]int32
 	// Index are the values table that is defined in
 	// https://dev.splunk.com/observability/docs/chartsdashboards/charts_overview/#Chart-color-palettes
@@ -23,40 +22,27 @@ func NewColorPalette() ColorPalette {
 	return ColorPalette{
 		named: map[string]int32{
 			"red":         0,
+			"gold":        1,
+			"iris":        2,
+			"green":       3,
+			"jade":        4,
+			"gray":        5,
+			"blue":        6,
+			"azure":       7,
+			"navy":        8,
+			"brown":       9,
 			"orange":      10,
 			"yellow":      11,
-			"green":       19,
-			"blue":        6,
-			"indigo":      17,
-			"violet":      15,
-			"brown":       9,
-			"dark_red":    0,
-			"crayola":     1,
-			"dark_orange": 9,
-			"peridot":     2,
-			"dark_yellow": 11,
-			"gold":        11,
-			"lime_green":  3,
-			"sage":        4,
-			"dark_green":  18,
-			"emerald":     18,
-			"chartreuse":  19,
-			"aquamarine":  20,
-			"light_blue":  7,
-			"navy":        21,
-			"azue":        8,
-			"iris":        21,
-			"purple":      16,
 			"magenta":     12,
-			"grape":       12,
-			"lilac":       17,
 			"cerise":      13,
 			"pink":        14,
-			"gray":        5,
-			"grey_blue":   21,
-			"azure":       6,
-			"greenyellow": 3,
-			"jade":        18,
+			"violet":      15,
+			"purple":      16,
+			"lilac":       17,
+			"emerald":     18,
+			"chartreuse":  19,
+			"yellowgreen": 20,
+			"aquamarine":  21,
 		},
 		// These values should be exactly matching to:
 		// https://dev.splunk.com/observability/docs/chartsdashboards/charts_overview/#Chart-color-palettes
@@ -87,12 +73,22 @@ func NewColorPalette() ColorPalette {
 	}
 }
 
-func (cp ColorPalette) GetColorIndex(name string) (int32, bool) {
+func (cp ColorPalette) ColorIndex(name string) (int32, bool) {
 	index, exist := cp.named[name]
 	return index, exist
 }
 
-func (cp ColorPalette) GetHexCodebyIndex(index int32) (string, bool) {
+func (cp ColorPalette) IndexColorName(index int32) (string, bool) {
+	color := ""
+	for name, idx := range cp.named {
+		if index == idx {
+			color = name
+		}
+	}
+	return color, color != ""
+}
+
+func (cp ColorPalette) HexCodebyIndex(index int32) (string, bool) {
 	hex := ""
 	if int(index) < len(cp.index) {
 		hex = cp.index[index]

--- a/internal/visual/color_palette.go
+++ b/internal/visual/color_palette.go
@@ -3,8 +3,6 @@
 
 package visual
 
-import "slices"
-
 type ColorPalette struct {
 	// Named is the convience lookup table that allows
 	// a user to type the color they want to use and
@@ -97,15 +95,9 @@ func (cp ColorPalette) HexCodebyIndex(index int32) (string, bool) {
 }
 
 func (cp ColorPalette) Names() []string {
-	words := make(map[int32][]string, len(cp.named))
-	for name, index := range cp.named {
-		words[index] = append(words[index], name)
-	}
-	names := make([]string, 0, len(cp.named))
-	for i := int32(0); int(i) < len(cp.index); i++ {
-		colors := words[i]
-		slices.Sort(colors)
-		names = append(names, colors...)
+	names := make([]string, len(cp.named))
+	for name, idx := range cp.named {
+		names[idx] = name
 	}
 	return names
 }

--- a/internal/visual/color_palette_test.go
+++ b/internal/visual/color_palette_test.go
@@ -37,6 +37,7 @@ func TestColorPaletteIndexColorName(t *testing.T) {
 
 	cp := NewColorPalette()
 	for idx, expect := range cp.Names() {
+		//nolint:gosec // Ignore warning for int overflow
 		actual, exist := cp.IndexColorName(int32(idx))
 		assert.True(t, exist, "Color must exist")
 		assert.Equal(t, expect, actual, "Must match the expect index %d", idx)

--- a/internal/visual/color_palette_test.go
+++ b/internal/visual/color_palette_test.go
@@ -19,16 +19,16 @@ func TestColorPalette(t *testing.T) {
 	)
 
 	for _, name := range cp.Names() {
-		idx, exist := cp.GetColorIndex(name)
+		idx, exist := cp.ColorIndex(name)
 		require.True(t, exist, "Must return a valid result reading index")
 		seen[int(idx)]++
-		hex, exist := cp.GetHexCodebyIndex(idx)
+		hex, exist := cp.HexCodebyIndex(idx)
 		assert.NotEmpty(t, hex, "Must have returned the expected hex code")
 		assert.True(t, exist, "Must have found the hex code value")
 	}
 
 	for idx := range seen {
-		assert.GreaterOrEqual(t, seen[idx], 1, "Must have seen each value at least once")
+		assert.Equal(t, 1, seen[idx], "Must have seen index %d once", idx)
 	}
 }
 
@@ -36,9 +36,13 @@ func TestHistoricalNames(t *testing.T) {
 	t.Parallel()
 
 	for _, name := range []string{
+		"red",
+		"gold",
+		"iris",
+		"jade",
 		"gray",
-		"blue",
 		"azure",
+		"blue",
 		"navy",
 		"brown",
 		"orange",
@@ -48,17 +52,13 @@ func TestHistoricalNames(t *testing.T) {
 		"pink",
 		"violet",
 		"lilac",
-		"iris",
 		"emerald",
 		"green",
 		"aquamarine",
-		"red",
-		"gold",
-		"greenyellow",
+		"yellowgreen",
 		"chartreuse",
-		"jade",
 	} {
-		_, ok := NewColorPalette().GetColorIndex(name)
+		_, ok := NewColorPalette().ColorIndex(name)
 		assert.True(t, ok, "Must have the %q set as an option", name)
 	}
 }

--- a/internal/visual/color_palette_test.go
+++ b/internal/visual/color_palette_test.go
@@ -36,10 +36,10 @@ func TestColorPaletteIndexColorName(t *testing.T) {
 	t.Parallel()
 
 	cp := NewColorPalette()
-	for idx, name := range cp.Names() {
-		index, exist := cp.ColorIndex(name)
+	for idx, expect := range cp.Names() {
+		actual, exist := cp.IndexColorName(int32(idx))
 		assert.True(t, exist, "Color must exist")
-		assert.EqualValues(t, idx, index, "Must match the expect index for %s", name)
+		assert.Equal(t, expect, actual, "Must match the expect index %d", idx)
 	}
 }
 

--- a/internal/visual/color_palette_test.go
+++ b/internal/visual/color_palette_test.go
@@ -32,6 +32,17 @@ func TestColorPalette(t *testing.T) {
 	}
 }
 
+func TestColorPaletteIndexColorName(t *testing.T) {
+	t.Parallel()
+
+	cp := NewColorPalette()
+	for idx, name := range cp.Names() {
+		index, exist := cp.ColorIndex(name)
+		assert.True(t, exist, "Color must exist")
+		assert.EqualValues(t, idx, index, "Must match the expect index for %s", name)
+	}
+}
+
 func TestHistoricalNames(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Context

I overlooked that color palette is used as a reverse lookup and requires a one to one value otherwise, it will change the state file.

## Changes

- Fixed up color definitions
- Changed names to be more go idiomatic 