### PR TITLE
Enchament: Adding json field output

### DIFF
--- a/internal/tfextension/logging.go
+++ b/internal/tfextension/logging.go
@@ -3,7 +3,10 @@
 
 package tfext
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // LogFields is an extension to logging fields parameter
 // to help as a convience and provides some level of standards.
@@ -38,5 +41,12 @@ func (lf LogFields) Duration(key string, val time.Duration) LogFields {
 // if the field already exists, it is overwritten.
 func (lf LogFields) Field(key string, val any) LogFields {
 	lf[key] = val
+	return lf
+}
+
+func (lf LogFields) JSON(key string, val any) LogFields {
+	if buf, err := json.Marshal(val); err == nil {
+		lf[key] = string(buf)
+	}
 	return lf
 }

--- a/internal/tfextension/logging_test.go
+++ b/internal/tfextension/logging_test.go
@@ -44,6 +44,13 @@ func TestLogFields(t *testing.T) {
 			lf:     NewLogFields().Field("example", 1),
 			expect: map[string]any{"example": 1},
 		},
+		{
+			name: "json field",
+			lf:   NewLogFields().JSON("data", map[string]any{"hello": "world"}),
+			expect: map[string]any{
+				"data": `{"hello":"world"}`,
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Context

There is a few places where the API type is rather complex, so having the json data printed allows for a quick means of investigating the issue and moving on from there.

## Changes

- Added json field 
- Added test.