### PR TITLE
Adding as pointer functionality

### DIFF
--- a/internal/common/pointer.go
+++ b/internal/common/pointer.go
@@ -1,0 +1,8 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+func AsPointer[T any](t T) *T {
+	return &t
+}

--- a/internal/common/pointer_test.go
+++ b/internal/common/pointer_test.go
@@ -1,0 +1,18 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAsPointer(t *testing.T) {
+	t.Parallel()
+
+	val := 6
+	assert.IsType(t, (*int)(nil), AsPointer(val), "Must match the expected type")
+	assert.Equal(t, &val, AsPointer(val), "Must match the expected value")
+}


### PR DESCRIPTION
## Context

Giving the ability to quickly refer to types as their pointer reference for API types.

## Changes

- Added `AsPointer` to common functions.