### PR TITLE
Removing error on build URL

### DIFF
--- a/internal/definition/team/resource.go
+++ b/internal/definition/team/resource.go
@@ -57,12 +57,7 @@ func newResourceCreate() schema.CreateContextFunc {
 			"id": tm.Id,
 		})
 
-		u, err := pmeta.LoadApplicationURL(ctx, meta, AppPath, tm.Id)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		if err := rd.Set("url", u); err != nil {
+		if err := rd.Set("url", pmeta.LoadApplicationURL(ctx, meta, AppPath, tm.Id)); err != nil {
 			return diag.FromErr(err)
 		}
 
@@ -83,12 +78,7 @@ func newResourceRead() schema.ReadContextFunc {
 		}
 		tflog.Debug(ctx, "Successfully fetched team data")
 
-		u, err := pmeta.LoadApplicationURL(ctx, meta, AppPath, tm.Id)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		if err := rd.Set("url", u); err != nil {
+		if err := rd.Set("url", pmeta.LoadApplicationURL(ctx, meta, AppPath, tm.Id)); err != nil {
 			return diag.FromErr(err)
 		}
 
@@ -118,12 +108,7 @@ func newResourceUpdate() schema.UpdateContextFunc {
 			return diag.FromErr(err)
 		}
 
-		u, err := pmeta.LoadApplicationURL(ctx, meta, AppPath, tm.Id)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		if err := rd.Set("url", u); err != nil {
+		if err := rd.Set("url", pmeta.LoadApplicationURL(ctx, meta, AppPath, tm.Id)); err != nil {
 			return diag.FromErr(err)
 		}
 

--- a/internal/providermeta/meta_test.go
+++ b/internal/providermeta/meta_test.go
@@ -46,14 +46,12 @@ func TestLoadApplicationURL(t *testing.T) {
 		meta      any
 		fragments []string
 		url       string
-		errVal    string
 	}{
 		{
 			name:      "no meta set",
 			meta:      nil,
 			fragments: []string{},
 			url:       "",
-			errVal:    "expected to implement type Meta",
 		},
 		{
 			name: "custom domain set",
@@ -62,7 +60,6 @@ func TestLoadApplicationURL(t *testing.T) {
 			},
 			fragments: []string{},
 			url:       "http://custom.signalfx.com/",
-			errVal:    "",
 		},
 		{
 			name: "custom domain with fragments",
@@ -74,8 +71,7 @@ func TestLoadApplicationURL(t *testing.T) {
 				"aaaa",
 				"edit",
 			},
-			url:    "http://custom.signalfx.com/#detector/aaaa/edit",
-			errVal: "",
+			url: "http://custom.signalfx.com/#detector/aaaa/edit",
 		},
 		{
 			name: "invalid domain set",
@@ -84,19 +80,13 @@ func TestLoadApplicationURL(t *testing.T) {
 			},
 			fragments: []string{},
 			url:       "",
-			errVal:    "parse \"domain\": invalid URI for request",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			u, err := LoadApplicationURL(context.Background(), tc.meta, tc.fragments...)
+			u := LoadApplicationURL(context.Background(), tc.meta, tc.fragments...)
 			require.Equal(t, tc.url, u, "Must match the expected url")
-			if tc.errVal != "" {
-				require.EqualError(t, err, tc.errVal, "Must match expected error message")
-			} else {
-				require.NoError(t, err, "Must not error when loading url")
-			}
 		})
 	}
 }


### PR DESCRIPTION
## Context

Building a URL will always happen after a call to the client has been done. This means that if we are generating a URL, the URL has already been validated.

## Changes

- Updated method signature for `LoadApplicationURL`