### PR TITLE
Fix: Removing tidy step on release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 version: 2
-before:
-  hooks:
-    - go mod tidy
 builds:
 - env:
     - CGO_ENABLED=0


### PR DESCRIPTION
## Context

We should be sure whatever is contained within the branch is what is deployed, so removing the tidy means the builds are reproducible.

## changes

- Removing tidy on release.