### PR TITLE
chore: Updating signalfx-go library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.40.1
+	github.com/signalfx/signalfx-go v1.41.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/multierr v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/rogpeppe/go-internal v1.6.2 h1:aIihoIOHCiLZHxyoNQ+ABL4NKhFTgKLBdMLyEA
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/signalfx/signalfx-go v1.40.1 h1:KxUyPdKBASw2kC4xSRxIq4tVKvPxC44OH0Am40zffoI=
-github.com/signalfx/signalfx-go v1.40.1/go.mod h1:aVrA69k02raBhDtIL1l+KBu+H5eEmS5b0IFbqgKh7eg=
+github.com/signalfx/signalfx-go v1.41.0 h1:+lWPBe/FNEWiDdYtgu7t4xf7h3ogPQmjDlb0se2WoB8=
+github.com/signalfx/signalfx-go v1.41.0/go.mod h1:I30umyhRTu8mPpEtMzEbG0z9wOYjkUKTp9U0gFxFsmk=
 github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L3A=
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/definition/detector/resource_test.go
+++ b/internal/definition/detector/resource_test.go
@@ -57,7 +57,7 @@ func TestResourceCreate(t *testing.T) {
 			}),
 			Input: &detector.Detector{},
 			Issues: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "Bad status 500: Failed create detector\n"},
+				{Severity: diag.Error, Summary: "route \"/v2/detector\" had issues with status code 500"},
 			},
 		},
 		{
@@ -177,7 +177,7 @@ func TestResourceRead(t *testing.T) {
 				Id: "id-01",
 			},
 			Issues: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "Bad status 400: failed to read body\n"},
+				{Severity: diag.Error, Summary: "route \"/v2/detector/id-01\" had issues with status code 400"},
 			},
 		},
 		{
@@ -338,7 +338,7 @@ func TestResourceUpdate(t *testing.T) {
 			Resource: NewResource(),
 			Input:    &detector.Detector{Id: "id-01"},
 			Issues: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "Bad status 500: failed update\n"},
+				{Severity: diag.Error, Summary: "route \"/v2/detector/id-01\" had issues with status code 500"},
 			},
 		},
 		{
@@ -429,7 +429,7 @@ func TestResourceDelete(t *testing.T) {
 			},
 			Expect: nil,
 			Issues: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "Unexpected status code: 400: invalid detector\n"},
+				{Severity: diag.Error, Summary: "route \"/v2/detector/detector-01\" had issues with status code 400"},
 			},
 		},
 	} {

--- a/internal/definition/dimension/datasource_test.go
+++ b/internal/definition/dimension/datasource_test.go
@@ -48,7 +48,7 @@ func TestDataSource(t *testing.T) {
 			}),
 			values: []any{},
 			diags: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "Bad status 400: unable to read dimensions\n"},
+				{Severity: diag.Error, Summary: "route \"/v2/dimension\" had issues with status code 400"},
 			},
 		},
 		{
@@ -63,7 +63,7 @@ func TestDataSource(t *testing.T) {
 			}),
 			values: []any{},
 			diags: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "Bad status 400: unable to read dimensions\n"},
+				{Severity: diag.Error, Summary: "route \"/v2/dimension\" had issues with status code 400"},
 			},
 		},
 		{

--- a/internal/definition/team/resource_test.go
+++ b/internal/definition/team/resource_test.go
@@ -55,7 +55,7 @@ func TestResourceCreate(t *testing.T) {
 			Issues: diag.Diagnostics{
 				{
 					Severity: diag.Error,
-					Summary:  "Unexpected status code: 400: Failed to create\n",
+					Summary:  "route \"/v2/team\" had issues with status code 400",
 				},
 			},
 		},
@@ -186,7 +186,7 @@ func TestResourceRead(t *testing.T) {
 			Issues: diag.Diagnostics{
 				{
 					Severity: diag.Error,
-					Summary:  "Unexpected status code: 400: Failed to read\n",
+					Summary:  "route \"/v2/team/0001\" had issues with status code 400",
 				},
 			},
 		},
@@ -303,7 +303,7 @@ func TestResourceUpdate(t *testing.T) {
 			Issues: diag.Diagnostics{
 				{
 					Severity: diag.Error,
-					Summary:  "Unexpected status code: 400: Failed to update\n",
+					Summary:  "route \"/v2/team/0001\" had issues with status code 400",
 				},
 			},
 		},
@@ -387,7 +387,7 @@ func TestResourceDelete(t *testing.T) {
 			Issues: diag.Diagnostics{
 				{
 					Severity: diag.Error,
-					Summary:  "Unexpected status code: 400 Bad Request",
+					Summary:  "route \"/v2/team/0001\" had issues with status code 400",
 				},
 			},
 		},


### PR DESCRIPTION
## Context

Upgrading the library changed how the error messages were handled so updating the tests that reflect on that.

## Changes

- Bumped `signalfx-go` to version `v1.41.0`