### PR TITLE
Enhancement: standardise error handling

### DIFF
--- a/internal/common/error.go
+++ b/internal/common/error.go
@@ -14,11 +14,11 @@ import (
 	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
 )
 
-// OnError handles the general case when the signalfx api returns
+// HandleError handles the general case when the signalfx api returns
 // an error, and it uses that information to determine what needs to happen.
 // This will ensure that the state is cleaned up given the error condition.
 // To help simplify error handling, it will always return the error provided.
-func OnError(ctx context.Context, err error, data *schema.ResourceData) error {
+func HandleError(ctx context.Context, err error, data *schema.ResourceData) error {
 	re, ok := signalfx.AsResponseError(err)
 	if !ok {
 		// Not a response error, pass it back

--- a/internal/common/error.go
+++ b/internal/common/error.go
@@ -1,0 +1,48 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/signalfx/signalfx-go"
+
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+// OnError handles the general case when the signalfx api returns
+// an error, and it uses that information to determine what needs to happen.
+// This will ensure that the state is cleaned up given the error condition.
+// To help simplify error handling, it will always return the error provided.
+func OnError(ctx context.Context, err error, data *schema.ResourceData) error {
+	re, ok := signalfx.AsResponseError(err)
+	if !ok {
+		// Not a repsonse error, pass it back
+		return err
+	}
+	switch re.Code() {
+	case http.StatusNotFound:
+		tflog.Info(ctx, "Resource has been removed externally, removing from state", tfext.NewLogFields().
+			Field("route", re.Route()),
+		)
+		// Clear the id from the state when 404 is returned.
+		data.SetId("")
+	case http.StatusUnauthorized:
+		tflog.Error(ctx, "Token is not authorised", tfext.NewLogFields().
+			Field("route", re.Route()).
+			Field("code", re.Code()).
+			Field("details", re.Details()),
+		)
+	default:
+		tflog.Debug(ctx, "Issue trying to work with the API", tfext.NewLogFields().
+			Field("route", re.Route()).
+			Field("code", re.Code()).
+			Field("details", re.Details()),
+		)
+	}
+	return err
+}

--- a/internal/common/error.go
+++ b/internal/common/error.go
@@ -21,7 +21,7 @@ import (
 func OnError(ctx context.Context, err error, data *schema.ResourceData) error {
 	re, ok := signalfx.AsResponseError(err)
 	if !ok {
-		// Not a repsonse error, pass it back
+		// Not a response error, pass it back
 		return err
 	}
 	switch re.Code() {
@@ -32,7 +32,7 @@ func OnError(ctx context.Context, err error, data *schema.ResourceData) error {
 		// Clear the id from the state when 404 is returned.
 		data.SetId("")
 	case http.StatusUnauthorized:
-		tflog.Error(ctx, "Token is not authorised", tfext.NewLogFields().
+		tflog.Error(ctx, "Token is not authorized", tfext.NewLogFields().
 			Field("route", re.Route()).
 			Field("code", re.Code()).
 			Field("details", re.Details()),

--- a/internal/common/error_test.go
+++ b/internal/common/error_test.go
@@ -1,0 +1,54 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/signalfx/signalfx-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOnError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		err    error
+		expect string
+	}{
+		{
+			name:   "no error provided",
+			err:    nil,
+			expect: "id",
+		},
+		{
+			name:   "not a response rror",
+			err:    errors.New("derp"),
+			expect: "id",
+		},
+		{
+			name:   "uncatalogue response error",
+			err:    &signalfx.ResponseError{},
+			expect: "id",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := schema.TestResourceDataRaw(
+				t,
+				map[string]*schema.Schema{},
+				map[string]any{},
+			)
+			data.SetId("id")
+
+			assert.ErrorIs(t, tc.err, OnError(context.Background(), tc.err, data), "Must return the same error")
+			assert.Equal(t, tc.expect, data.Id(), "Must have the expected id")
+		})
+	}
+}

--- a/internal/common/error_test.go
+++ b/internal/common/error_test.go
@@ -47,7 +47,7 @@ func TestOnError(t *testing.T) {
 			)
 			data.SetId("id")
 
-			assert.ErrorIs(t, tc.err, OnError(context.Background(), tc.err, data), "Must return the same error")
+			assert.ErrorIs(t, tc.err, HandleError(context.Background(), tc.err, data), "Must return the same error")
 			assert.Equal(t, tc.expect, data.Id(), "Must have the expected id")
 		})
 	}

--- a/internal/definition/detector/resource.go
+++ b/internal/definition/detector/resource.go
@@ -64,7 +64,7 @@ func resourceCreate(ctx context.Context, data *schema.ResourceData, meta any) (i
 		ParentDetectorId:     dt.ParentDetectorId,
 		DetectorOrigin:       dt.DetectorOrigin,
 	})
-	if common.OnError(ctx, err, data) != nil {
+	if common.HandleError(ctx, err, data) != nil {
 		return tfext.AsErrorDiagnostics(err)
 	}
 
@@ -89,7 +89,7 @@ func resourceRead(ctx context.Context, data *schema.ResourceData, meta any) (iss
 	}
 
 	dt, err := client.GetDetector(ctx, data.Id())
-	if common.OnError(ctx, err, data) != nil {
+	if common.HandleError(ctx, err, data) != nil {
 		return tfext.AsErrorDiagnostics(err)
 	}
 
@@ -134,7 +134,7 @@ func resourceUpdate(ctx context.Context, data *schema.ResourceData, meta any) (i
 		ParentDetectorId:     dt.ParentDetectorId,
 		DetectorOrigin:       dt.DetectorOrigin,
 	})
-	if common.OnError(ctx, err, data) != nil {
+	if common.HandleError(ctx, err, data) != nil {
 		return tfext.AsErrorDiagnostics(err)
 	}
 
@@ -155,6 +155,6 @@ func resourceDelete(ctx context.Context, data *schema.ResourceData, meta any) di
 	if err != nil {
 		return tfext.AsErrorDiagnostics(err)
 	}
-	err = common.OnError(ctx, client.DeleteDetector(ctx, data.Id()), data)
+	err = common.HandleError(ctx, client.DeleteDetector(ctx, data.Id()), data)
 	return tfext.AsErrorDiagnostics(err)
 }

--- a/internal/definition/detector/resource.go
+++ b/internal/definition/detector/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/signalfx/signalfx-go/detector"
 
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
 	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
 	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
 )
@@ -63,7 +64,7 @@ func resourceCreate(ctx context.Context, data *schema.ResourceData, meta any) (i
 		ParentDetectorId:     dt.ParentDetectorId,
 		DetectorOrigin:       dt.DetectorOrigin,
 	})
-	if err != nil {
+	if err != common.OnError(ctx, err, data) {
 		return tfext.AsErrorDiagnostics(err)
 	}
 
@@ -88,7 +89,7 @@ func resourceRead(ctx context.Context, data *schema.ResourceData, meta any) (iss
 	}
 
 	dt, err := client.GetDetector(ctx, data.Id())
-	if err != nil {
+	if err != common.OnError(ctx, err, data) {
 		return tfext.AsErrorDiagnostics(err)
 	}
 
@@ -133,7 +134,7 @@ func resourceUpdate(ctx context.Context, data *schema.ResourceData, meta any) (i
 		ParentDetectorId:     dt.ParentDetectorId,
 		DetectorOrigin:       dt.DetectorOrigin,
 	})
-	if err != nil {
+	if err != common.OnError(ctx, err, data) {
 		return tfext.AsErrorDiagnostics(err)
 	}
 
@@ -154,5 +155,6 @@ func resourceDelete(ctx context.Context, data *schema.ResourceData, meta any) di
 	if err != nil {
 		return tfext.AsErrorDiagnostics(err)
 	}
-	return tfext.AsErrorDiagnostics(client.DeleteDetector(ctx, data.Id()))
+	err = common.OnError(ctx, client.DeleteDetector(ctx, data.Id()), data)
+	return tfext.AsErrorDiagnostics(err)
 }

--- a/internal/definition/detector/resource.go
+++ b/internal/definition/detector/resource.go
@@ -64,7 +64,7 @@ func resourceCreate(ctx context.Context, data *schema.ResourceData, meta any) (i
 		ParentDetectorId:     dt.ParentDetectorId,
 		DetectorOrigin:       dt.DetectorOrigin,
 	})
-	if err != common.OnError(ctx, err, data) {
+	if common.OnError(ctx, err, data) != nil {
 		return tfext.AsErrorDiagnostics(err)
 	}
 
@@ -89,7 +89,7 @@ func resourceRead(ctx context.Context, data *schema.ResourceData, meta any) (iss
 	}
 
 	dt, err := client.GetDetector(ctx, data.Id())
-	if err != common.OnError(ctx, err, data) {
+	if common.OnError(ctx, err, data) != nil {
 		return tfext.AsErrorDiagnostics(err)
 	}
 
@@ -134,7 +134,7 @@ func resourceUpdate(ctx context.Context, data *schema.ResourceData, meta any) (i
 		ParentDetectorId:     dt.ParentDetectorId,
 		DetectorOrigin:       dt.DetectorOrigin,
 	})
-	if err != common.OnError(ctx, err, data) {
+	if common.OnError(ctx, err, data) != nil {
 		return tfext.AsErrorDiagnostics(err)
 	}
 

--- a/internal/definition/team/resource.go
+++ b/internal/definition/team/resource.go
@@ -50,7 +50,7 @@ func newResourceCreate() schema.CreateContextFunc {
 			Members:           payload.Members,
 			NotificationLists: payload.NotificationLists,
 		})
-		if err != common.OnError(ctx, err, rd) {
+		if common.OnError(ctx, err, rd) != nil {
 			return diag.FromErr(err)
 		}
 
@@ -74,7 +74,7 @@ func newResourceRead() schema.ReadContextFunc {
 		}
 
 		tm, err := client.GetTeam(ctx, rd.Id())
-		if err != common.OnError(ctx, err, rd) {
+		if common.OnError(ctx, err, rd) != nil {
 			return diag.FromErr(err)
 		}
 
@@ -96,7 +96,7 @@ func newResourceUpdate() schema.UpdateContextFunc {
 		}
 
 		client, err := pmeta.LoadClient(ctx, meta)
-		if err != common.OnError(ctx, err, rd) {
+		if err != nil {
 			return diag.FromErr(err)
 		}
 
@@ -106,7 +106,7 @@ func newResourceUpdate() schema.UpdateContextFunc {
 			Members:           payload.Members,
 			NotificationLists: payload.NotificationLists,
 		})
-		if err != nil {
+		if common.OnError(ctx, err, rd) != nil {
 			return diag.FromErr(err)
 		}
 

--- a/internal/definition/team/resource.go
+++ b/internal/definition/team/resource.go
@@ -50,7 +50,7 @@ func newResourceCreate() schema.CreateContextFunc {
 			Members:           payload.Members,
 			NotificationLists: payload.NotificationLists,
 		})
-		if common.OnError(ctx, err, rd) != nil {
+		if common.HandleError(ctx, err, rd) != nil {
 			return diag.FromErr(err)
 		}
 
@@ -74,7 +74,7 @@ func newResourceRead() schema.ReadContextFunc {
 		}
 
 		tm, err := client.GetTeam(ctx, rd.Id())
-		if common.OnError(ctx, err, rd) != nil {
+		if common.HandleError(ctx, err, rd) != nil {
 			return diag.FromErr(err)
 		}
 
@@ -106,7 +106,7 @@ func newResourceUpdate() schema.UpdateContextFunc {
 			Members:           payload.Members,
 			NotificationLists: payload.NotificationLists,
 		})
-		if common.OnError(ctx, err, rd) != nil {
+		if common.HandleError(ctx, err, rd) != nil {
 			return diag.FromErr(err)
 		}
 
@@ -130,7 +130,7 @@ func newResourceDelete() schema.DeleteContextFunc {
 			"team-id": rd.Id(),
 		})
 
-		err = common.OnError(ctx, client.DeleteTeam(ctx, rd.Id()), rd)
+		err = common.HandleError(ctx, client.DeleteTeam(ctx, rd.Id()), rd)
 
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
## Context

To make the experience consistent across each the components, this will provide a standard approach as to how errors are handled from the API.

This means that if resources are removed external from terraform, it will be automatically removed from the state to avoid dealing with fractured state.

## Changes

- Adding `common.OnError` method to improve error responses
- Updating existing resources to adopt method. 