### PR TITLE
Feature: Add support for "Service Accounts"

### DIFF
--- a/internal/definition/provider/provider.go
+++ b/internal/definition/provider/provider.go
@@ -87,7 +87,7 @@ func New() *schema.Provider {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"auth_token"},
-				Description:   "Required if the user is configured to be part of multiple organisations",
+				Description:   "Required if the user is configured to be part of multiple organizations",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/internal/definition/provider/provider_test.go
+++ b/internal/definition/provider/provider_test.go
@@ -50,7 +50,7 @@ func TestProviderConfiguration(t *testing.T) {
 			name:    "no details provided",
 			details: make(map[string]any),
 			expect: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "auth token not set"},
+				{Severity: diag.Error, Summary: "missing auth token or email and password"},
 			},
 		},
 		{

--- a/internal/providermeta/meta.go
+++ b/internal/providermeta/meta.go
@@ -99,11 +99,11 @@ func (m *Meta) LoadSessionToken(ctx context.Context) (string, error) {
 	return resp.AccessToken, nil
 }
 
-func (s *Meta) Validate() (errs error) {
-	if s.AuthToken == "" && (s.Email == "" && s.Password == "") {
+func (m *Meta) Validate() (errs error) {
+	if m.AuthToken == "" && (m.Email == "" && m.Password == "") {
 		errs = multierr.Append(errs, errors.New("missing auth token or email and password"))
 	}
-	if s.APIURL == "" {
+	if m.APIURL == "" {
 		errs = multierr.Append(errs, errors.New("api url is not set"))
 	}
 	return errs

--- a/internal/providermeta/meta.go
+++ b/internal/providermeta/meta.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/signalfx/signalfx-go"
+	"github.com/signalfx/signalfx-go/sessiontoken"
 	"go.uber.org/multierr"
 
 	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
@@ -27,10 +28,13 @@ var (
 // It is abstracted out from the provider definition to make it easier
 // to test CRUD operations within unit tests.
 type Meta struct {
-	AuthToken    string           `json:"auth_token"`
-	APIURL       string           `json:"api_url"`
-	CustomAppURL string           `json:"custom_app_url"`
-	Client       *signalfx.Client `json:"-"`
+	AuthToken      string           `json:"auth_token"`
+	APIURL         string           `json:"api_url"`
+	CustomAppURL   string           `json:"custom_app_url"`
+	Client         *signalfx.Client `json:"-"`
+	Email          string           `json:"email"`
+	Password       string           `json:"password"`
+	OrganizationID string           `json:"org_id"`
 }
 
 // LoadClient returns the configured [signalfx.Client] ready to use.
@@ -68,9 +72,36 @@ func LoadApplicationURL(ctx context.Context, meta any, fragments ...string) stri
 	return u.String()
 }
 
+// LoadSessionToken will use the provider username and password
+// so that it can be used as the token through the interaction.
+func (m *Meta) LoadSessionToken(ctx context.Context) (string, error) {
+	if m.AuthToken != "" {
+		return m.AuthToken, nil
+	}
+
+	client, err := signalfx.NewClient("", signalfx.APIUrl(m.APIURL))
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.CreateSessionToken(ctx, &sessiontoken.CreateTokenRequest{
+		Email:          m.Email,
+		Password:       m.Password,
+		OrganizationId: m.OrganizationID,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// TODO: determine if any additional fields would be useful for debugging.
+	tflog.Info(ctx, "Created new session token")
+
+	return resp.AccessToken, nil
+}
+
 func (s *Meta) Validate() (errs error) {
-	if s.AuthToken == "" {
-		errs = multierr.Append(errs, errors.New("auth token not set"))
+	if s.AuthToken == "" && (s.Email == "" && s.Password == "") {
+		errs = multierr.Append(errs, errors.New("missing auth token or email and password"))
 	}
 	if s.APIURL == "" {
 		errs = multierr.Append(errs, errors.New("api url is not set"))

--- a/internal/providermeta/meta.go
+++ b/internal/providermeta/meta.go
@@ -100,7 +100,7 @@ func (m *Meta) LoadSessionToken(ctx context.Context) (string, error) {
 }
 
 func (m *Meta) Validate() (errs error) {
-	if m.AuthToken == "" && (m.Email == "" && m.Password == "") {
+	if m.AuthToken == "" && (m.Email == "" || m.Password == "") {
 		errs = multierr.Append(errs, errors.New("missing auth token or email and password"))
 	}
 	if m.APIURL == "" {

--- a/internal/providermeta/meta_test.go
+++ b/internal/providermeta/meta_test.go
@@ -5,8 +5,14 @@ package pmeta
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/signalfx/signalfx-go/sessiontoken"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -102,7 +108,7 @@ func TestMetaValidation(t *testing.T) {
 		{
 			name:   "meta not set",
 			meta:   Meta{},
-			errVal: "auth token not set; api url is not set",
+			errVal: "missing auth token or email and password; api url is not set",
 		},
 		{
 			name: "state valid",
@@ -120,6 +126,84 @@ func TestMetaValidation(t *testing.T) {
 				require.EqualError(t, err, tc.errVal, "Must match the expected error")
 			} else {
 				require.NoError(t, err, "Must not error when validation")
+			}
+		})
+	}
+}
+
+func TestMetaToken(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		token    string
+		handler  http.HandlerFunc
+		email    string
+		password string
+		expect   string
+		errVal   string
+	}{
+		{
+			name:  "missing values",
+			token: "",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				_ = r.Body.Close()
+
+				http.Error(w, "failed auth", http.StatusBadRequest)
+			},
+			email:    "",
+			password: "",
+			expect:   "",
+			errVal:   "route \"/v2/session\" had issues with status code 400",
+		},
+		{
+			name:  "token already provided",
+			token: "aaccbbb",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				_ = r.Body.Close()
+
+				http.Error(w, "should not be called", http.StatusBadRequest)
+			},
+			email:    "",
+			password: "",
+			expect:   "aaccbbb",
+			errVal:   "",
+		},
+		{
+			name:  "username password provided",
+			token: "",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				_ = r.Body.Close()
+
+				_ = json.NewEncoder(w).Encode(&sessiontoken.Token{AccessToken: "secret"})
+			},
+			email:    "user@example",
+			password: "notsosecret",
+			expect:   "secret",
+			errVal:   "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := httptest.NewServer(tc.handler)
+			t.Cleanup(s.Close)
+
+			m := &Meta{
+				APIURL:    s.URL,
+				AuthToken: tc.token,
+				Email:     tc.email,
+				Password:  tc.password,
+			}
+
+			if token, err := m.LoadSessionToken(context.Background()); tc.errVal != "" {
+				assert.Equal(t, tc.expect, token, "Must match the expected value")
+				assert.EqualError(t, err, tc.errVal, "Must match the expected value")
+			} else {
+				assert.Equal(t, tc.expect, token, "Must match the expected value")
+				assert.NoError(t, err, "Must not error")
 			}
 		})
 	}

--- a/internal/providermeta/meta_test.go
+++ b/internal/providermeta/meta_test.go
@@ -117,6 +117,22 @@ func TestMetaValidation(t *testing.T) {
 				APIURL:    "http://api.signalfx.com",
 			},
 		},
+		{
+			name: "Email only provided",
+			meta: Meta{
+				Email:  "example@com",
+				APIURL: "http://api.signalfx.com",
+			},
+			errVal: "missing auth token or email and password",
+		},
+		{
+			name: "password only provided",
+			meta: Meta{
+				Password: "derp",
+				APIURL:   "http://api.signalfx.com",
+			},
+			errVal: "missing auth token or email and password",
+		},
 	} {
 
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/tftest/meta_test.go
+++ b/internal/tftest/meta_test.go
@@ -49,7 +49,7 @@ func TestNewAcceptanceConfigure(t *testing.T) {
 			name: "no values set",
 			envs: map[string]string{},
 			issues: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "auth token not set"},
+				{Severity: diag.Error, Summary: "missing auth token or email and password"},
 				{Severity: diag.Error, Summary: "api url is not set"},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+
 	"github.com/splunk-terraform/terraform-provider-signalfx/signalfx"
 )
 

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -96,7 +96,7 @@ func Provider() *schema.Provider {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"auth_token"},
-				Description:   "Required if the user is configured to be part of multiple organisations",
+				Description:   "Required if the user is configured to be part of multiple organizations",
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -186,7 +186,7 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 		config.CustomAppURL = customAppURL.(string)
 	}
 
-	if err := config.Validate(); err != nil {
+	if err = config.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/signalfx/provider_test.go
+++ b/signalfx/provider_test.go
@@ -86,7 +86,7 @@ func TestProviderConfigureFromNothing(t *testing.T) {
 	rp := Provider()
 	diag := rp.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	assert.NotNil(t, diag)
-	assert.Contains(t, diag[0].Summary, "auth_token: required field is not set")
+	assert.Contains(t, diag[0].Summary, "missing auth token or email and password")
 }
 
 func TestProviderConfigureFromTerraform(t *testing.T) {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -20,10 +20,20 @@ You can use the SignalFlow programming language to create charts and detectors u
 
 # Authentication
 
-When authenticating to the Splunk Observability Cloud API you can use either an Org token or a 
-Session token. See [Authenticate API Requests](https://dev.splunk.com/observability/docs/apibasics/authentication_basics/) in the Splunk developer documentation.
+When authenticating to the Splunk Observability Cloud API you can use:
 
-Session tokens are short-lived and provide administrative permissions to edit integrations. They expire relatively quickly, but let you manipulate some sensitive resources. Resources that require session tokens are flagged in their documentation.
+1. An Org token.
+1. A Session token.
+1. A Service account.
+
+See [Authenticate API Requests](https://dev.splunk.com/observability/docs/apibasics/authentication_basics/) in the Splunk developer documentation.
+
+Session tokens are short-lived and provide administrative permissions to edit integrations. 
+They expire relatively quickly, but let you manipulate some sensitive resources. 
+Resources that require session tokens are flagged in their documentation.
+
+A Service account is term used when a user is created within organization that can login via Username and Password, 
+this allows for a _Session Token_ to be created by the terraform provider and then used throughout the application.
 
 ~> **NOTE** Separate the less sensitive resources, such as dashboards, from the 
 more sensitive ones, such as integrations, to avoid having to change tokens.
@@ -53,6 +63,19 @@ resource "signalfx_dashboard" "default" {
 }
 ```
 
+```hcl
+# An example configuration with a service account.
+provider "signalfx" {
+  email           = "service.account@example"
+  password        = "${var.service_account_password}"
+  organization_id = "${var.service_account_org_id}"
+  # If your organization uses a different realm
+  # api_url = "https://api.<realm>.signalfx.com"
+  # If your organization uses a custom URL
+  # custom_app_url = "https://myorg.signalfx.com"
+}
+```
+
 ## Arguments
 
 The provider supports the following arguments:
@@ -64,3 +87,6 @@ The provider supports the following arguments:
 * `retry_max_attempts` - (Optional) The number of retry attempts when making HTTP API calls to Splunk Observability Cloud. Defaults to `4`.
 * `retry_wait_min_seconds` - (Optional) The minimum wait time between retry attempts when making HTTP API calls to Splunk Observability Cloud, in seconds. Defaults to `1`.
 * `retry_wait_max_seconds` - (Optional) The maximum wait time between retry attempts when making HTTP API calls to Splunk Observability Cloud, in seconds. Defaults to `30`.
+* `email` - (Optional) The provided email address is used to generate a _Session Token_ that is then used for all API interactions. Requires email address to be configured with a password, and not via SSO.
+* `password` - (Optional) The password is used to authenticate the email provided to generate a _Session Token_. Requires email address to be configured with a password, and not via SSO.
+* `organization_id` - (Optional) The organisation id is used to select which organization if the user provided belongs to multiple.


### PR DESCRIPTION
## Context

Since actions that require "admin" are only applied to session tokens, it means that customers need a means of supplying an session token. This can result in a session token that is stored within a vault service or user input for that given CI run.

This is typically fine in most cases considering admins have a lot of power in the account, however, in the scenario that you want to provide a greater level of automation, supplying a session token becomes cumbersome.

Hence, the idea of a "service account" then allows that increased level of autonomy since a session token can be create on behalf of the service account in the provider.

A service account is purely a user that can authenticate via email/password (meaning it has to be manually added into the org, and can't use an SSO user). This removes the 30d restriction that is applied to session tokens, and any external management that would be needed to be done by the user prior.

## Changes

- Provider supports authentication by "service accounts"
- Included documentation on what is meant by "service account"

## Intended Release
v9.3.0

No breaking changes since this currently extends the current configuration and doesn't change the existing behaviour.