### PR TITLE
Feature: Add support for data link type APPD_LINK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.43.0
+	github.com/signalfx/signalfx-go v1.44.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/multierr v1.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/signalfx/signalfx-go v1.41.0 h1:+lWPBe/FNEWiDdYtgu7t4xf7h3ogPQmjDlb0s
 github.com/signalfx/signalfx-go v1.41.0/go.mod h1:I30umyhRTu8mPpEtMzEbG0z9wOYjkUKTp9U0gFxFsmk=
 github.com/signalfx/signalfx-go v1.43.0 h1:Wp/XkyETzRyFvtuCGTN039hYwVgwIPfkBciqs19hqv4=
 github.com/signalfx/signalfx-go v1.43.0/go.mod h1:I30umyhRTu8mPpEtMzEbG0z9wOYjkUKTp9U0gFxFsmk=
+github.com/signalfx/signalfx-go v1.44.0 h1:BkLtohTJkq3mr1Yl1OzCWK+e2DZRqZ0M0zD9Gs+c41Q=
+github.com/signalfx/signalfx-go v1.44.0/go.mod h1:I30umyhRTu8mPpEtMzEbG0z9wOYjkUKTp9U0gFxFsmk=
 github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L3A=
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/signalfx/resource_signalfx_data_link.go
+++ b/signalfx/resource_signalfx_data_link.go
@@ -227,17 +227,12 @@ func getPayloadDataLink(d *schema.ResourceData) (*datalink.CreateUpdateDataLinkR
 		}
 	}
 
-	// New AppD datalink check
-	// REQ: url validation
-	// REQ: url follows appd pattern
-	// REQ: appd applicatin id and content id are of type integer
 	if val, ok := d.GetOk("target_appd_url"); ok {
 		appdURLs := val.(*schema.Set).List()
 
 		for _, tfLink := range appdURLs {
 			tfLink := tfLink.(map[string]interface{})
 
-			// AppD URL validation
 			appdUrl, err := url.ParseRequestURI(tfLink["url"].(string))
 			if err != nil {
 				return dataLink, fmt.Errorf("Invalid URL")
@@ -255,14 +250,12 @@ func getPayloadDataLink(d *schema.ResourceData) (*datalink.CreateUpdateDataLinkR
 			_, componentIdErr := strconv.Atoi(componentId[0])
 			_, applicationIdErr := strconv.Atoi(applicationId[0])
 			if componentIdErr != nil || applicationIdErr != nil {
-				return dataLink, fmt.Errorf("URL must include a valid component and application ID")
+				return dataLink, fmt.Errorf("URL must include a valid component and application IDs")
 			}
 
 			dl := &datalink.Target{
 				Name: tfLink["name"].(string),
 				URL:  tfLink["url"].(string),
-				// Need to add APPD_LINK type to signalfx-go library
-				// Type: datalink.APPD_LINK,
 				Type: datalink.APPD_LINK,
 			}
 

--- a/signalfx/resource_signalfx_data_link.go
+++ b/signalfx/resource_signalfx_data_link.go
@@ -263,7 +263,7 @@ func getPayloadDataLink(d *schema.ResourceData) (*datalink.CreateUpdateDataLinkR
 				URL:  tfLink["url"].(string),
 				// Need to add APPD_LINK type to signalfx-go library
 				// Type: datalink.APPD_LINK,
-				Type: datalink.EXTERNAL_LINK,
+				Type: datalink.APPD_LINK,
 			}
 
 			dataLink.Targets = append(dataLink.Targets, dl)

--- a/signalfx/resource_signalfx_data_link_test.go
+++ b/signalfx/resource_signalfx_data_link_test.go
@@ -72,6 +72,30 @@ resource "signalfx_data_link" "big_test_data_link" {
 }
 `
 
+const newDataLinkAppdConfig = `
+  resource "signalfx_data_link" "big_test_data_link" {
+    property_name = "pname"
+    property_value = "pvalue"
+
+    target_appd_url {
+      name = "appd_url"
+      url = "https://example.saas.appdynamics.com/controller/#/application=3039831&component=3677819"
+    }
+  }
+`
+
+const newDataLinkAppdConfigBadUrlErr = `
+  resource "signalfx_data_link" "big_test_data_link" {
+    property_name = "pname"
+    property_value = "pvalue"
+
+    target_appd_url {
+      name = "appd_url"
+      url = "https://example.saas.appdynamics.com/controller/#/application=3039831"
+    }
+  }
+`
+
 func TestAccCreateDashboardDataLinkFails(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
@@ -134,6 +158,38 @@ func TestAccCreateUpdateDataLinkWithoutPropertyValue(t *testing.T) {
 					testAccCheckDataLinkResourceExists,
 					resource.TestCheckResourceAttr("signalfx_data_link.big_test_data_link", "property_name", "pname"),
 					resource.TestCheckResourceAttr("signalfx_data_link.big_test_data_link", "property_value", ""),
+				),
+			},
+		},
+	})
+}
+
+// AppD DataLink acceptance tests
+func testAccCreateAppdDataLinkFails(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDataLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      newDataLinkAppdConfigBadUrlErr,
+				ExpectError: regexp.MustCompile("URL must include a valid component and application ID"),
+			},
+		},
+	})
+}
+func testAccCreateAppdDataLink(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDataLinkDestroy,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: newDataLinkAppdConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataLinkResourceExists,
+					resource.TestCheckResourceAttr("signalfx_data_link.big_test_data_link", "property_name", "pname"),
+					resource.TestCheckResourceAttr("signalfx_data_link.big_test_data_link", "property_value", "pvalue"),
 				),
 			},
 		},

--- a/signalfx/resource_signalfx_data_link_test.go
+++ b/signalfx/resource_signalfx_data_link_test.go
@@ -164,26 +164,24 @@ func TestAccCreateUpdateDataLinkWithoutPropertyValue(t *testing.T) {
 	})
 }
 
-// AppD DataLink acceptance tests
-func testAccCreateAppdDataLinkFails(t *testing.T) {
+func TestAccCreateAppdDataLinkFails(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
 		CheckDestroy: testAccDataLinkDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      newDataLinkAppdConfigBadUrlErr,
-				ExpectError: regexp.MustCompile("URL must include a valid component and application ID"),
+				ExpectError: regexp.MustCompile("URL must include component and application IDs"),
 			},
 		},
 	})
 }
-func testAccCreateAppdDataLink(t *testing.T) {
+func TestAccCreateAppdDataLink(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccDataLinkDestroy,
 		Steps: []resource.TestStep{
-			// Create
 			{
 				Config: newDataLinkAppdConfig,
 				Check: resource.ComposeTestCheckFunc(

--- a/signalfx/resource_signalfx_data_link_test.go
+++ b/signalfx/resource_signalfx_data_link_test.go
@@ -171,7 +171,7 @@ func TestAccCreateAppdDataLinkFails(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      newDataLinkAppdConfigBadUrlErr,
-				ExpectError: regexp.MustCompile("URL must include component and application IDs"),
+				ExpectError: regexp.MustCompile("Enter a valid AppD Link. The link needs to include the contoller URL, application ID, and Application component."),
 			},
 		},
 	})


### PR DESCRIPTION
## Feature
- In order to further integrate AppDynamics with Splunk o11y, we are adding data links that deep link to AppDynamics CSaaS.
- Add `target_appd_url` to data link resource
- Bump `signalfx-go` version

## Usage
- Run a Terraform file using the new `target_appd_url` field on a data link resource.

## Implementation
- Conditional check on data link type. Followed style for existing data link types (`target_external_url`, `target_splunk`, etc.).
- URL validation checks for `target_appd_url`
- Error handling for URL validation. Returns an error if input URL does not match AppDynamics regex pattern.

## Testing
- Manually tested by generating local binary and running Terraform module with `development_overrides` flag. 
- Acceptance tests:
  - Valid `target_appd_url` url that should create and destroy a data link without errors
  - A `target_appd_url` with a missing query parameter `component`. This should throw an error in the URL validation logic.