### PR TITLE
Feature: Adding feature package

### DIFF
--- a/internal/feature/global.go
+++ b/internal/feature/global.go
@@ -1,0 +1,25 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package feature
+
+import "sync"
+
+var (
+	once   sync.Once
+	global *Registry
+)
+
+// GetGlobalRegistry is used to allow for components to guard
+// functionality with a preview.
+// Any component that depends on using registry should allow
+// passing a registry value to make it possible to test functionality
+// without triggering the race detector.
+func GetGlobalRegistry() *Registry {
+	if global == nil {
+		once.Do(func() {
+			global = NewRegistry()
+		})
+	}
+	return global
+}

--- a/internal/feature/global_test.go
+++ b/internal/feature/global_test.go
@@ -1,0 +1,24 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package feature
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetGlobalRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := GetGlobalRegistry()
+	assert.NotNil(t, reg, "Must have a valid registry value")
+	assert.Equal(
+		t,
+		unsafe.Pointer(reg),
+		unsafe.Pointer(GetGlobalRegistry()),
+		"Must have the same pointer reference",
+	)
+}

--- a/internal/feature/preview.go
+++ b/internal/feature/preview.go
@@ -1,0 +1,60 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package feature
+
+import "sync/atomic"
+
+// Preview allows for features to be guarded
+// to allow users to opt in for the new functionality.
+//
+// A preview can be modified regardless of its global available state,
+// however, a warning will be displayed on the console saying the
+// preview will be removed in a feature release and no longer requires a user to opt in
+// and if there is any issues, to contact support.
+//
+// By default, the preview is disabled by default and
+// requires for the preview to marked as Global Available for it to default to true.
+// Once marked as GA, this should be added into the change log for that release.
+type Preview struct {
+	_ struct{} // Enforce explicy key assignment
+
+	enabled     *atomic.Bool
+	available   bool
+	description string
+	introduced  string
+}
+
+func NewPreview(opts ...PreviewOption) (*Preview, error) {
+	p := &Preview{
+		enabled: new(atomic.Bool),
+	}
+
+	for _, opt := range opts {
+		if err := opt.apply(p); err != nil {
+			return nil, err
+		}
+	}
+
+	return p, nil
+}
+
+func (p Preview) Enabled() bool {
+	return p.enabled.Load()
+}
+
+func (p Preview) SetEnabled(enabled bool) {
+	p.enabled.Store(enabled)
+}
+
+func (p Preview) GlobalAvailable() bool {
+	return p.available
+}
+
+func (p Preview) Description() string {
+	return p.description
+}
+
+func (p Preview) Introduced() string {
+	return p.introduced
+}

--- a/internal/feature/preview_option.go
+++ b/internal/feature/preview_option.go
@@ -18,13 +18,6 @@ func (fn PreviewOption) apply(g *Preview) error {
 	return fn(g)
 }
 
-func WithPreviewEnabled() PreviewOption {
-	return func(p *Preview) error {
-		p.enabled.Store(true)
-		return nil
-	}
-}
-
 func WithPreviewGlobalAvailable() PreviewOption {
 	return func(g *Preview) error {
 		g.available = true

--- a/internal/feature/preview_option.go
+++ b/internal/feature/preview_option.go
@@ -1,0 +1,58 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package feature
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+type PreviewOption func(g *Preview) error
+
+func (fn PreviewOption) apply(g *Preview) error {
+	if fn == nil {
+		return errors.New("function is nil")
+	}
+	return fn(g)
+}
+
+func WithPreviewEnabled() PreviewOption {
+	return func(p *Preview) error {
+		p.enabled.Store(true)
+		return nil
+	}
+}
+
+func WithPreviewGlobalAvailable() PreviewOption {
+	return func(g *Preview) error {
+		g.available = true
+		g.enabled.Store(true)
+		return nil
+	}
+}
+
+func WithPreviewAddInVersion(version string) PreviewOption {
+	return func(g *Preview) error {
+		matched, err := regexp.MatchString(`^v[1-9]+\.[0-9]+`, version)
+		if err != nil {
+			return err
+		}
+		if !matched {
+			return fmt.Errorf("version string %q needs to be in format vX.Y[.+]", version)
+		}
+		g.introduced = version
+		return nil
+	}
+}
+
+func WithPreviewDescription(description string) PreviewOption {
+	return func(g *Preview) error {
+		if description == "" {
+			return errors.New("adding empty description")
+		}
+		g.description = description
+		return nil
+	}
+}

--- a/internal/feature/preview_option_test.go
+++ b/internal/feature/preview_option_test.go
@@ -24,11 +24,6 @@ func TestPreviewOption(t *testing.T) {
 			errVal: "function is nil",
 		},
 		{
-			name:   "enable preview",
-			fn:     WithPreviewEnabled(),
-			errVal: "",
-		},
-		{
 			name:   "Global Available",
 			fn:     WithPreviewGlobalAvailable(),
 			errVal: "",

--- a/internal/feature/preview_option_test.go
+++ b/internal/feature/preview_option_test.go
@@ -1,0 +1,68 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package feature
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreviewOption(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		fn     PreviewOption
+		errVal string
+	}{
+		{
+			name:   "unset preview option",
+			fn:     nil,
+			errVal: "function is nil",
+		},
+		{
+			name:   "enable preview",
+			fn:     WithPreviewEnabled(),
+			errVal: "",
+		},
+		{
+			name:   "Global Available",
+			fn:     WithPreviewGlobalAvailable(),
+			errVal: "",
+		},
+		{
+			name:   "Bad AddedInVersion",
+			fn:     WithPreviewAddInVersion("v2"),
+			errVal: "version string \"v2\" needs to be in format vX.Y[.+]",
+		},
+		{
+			name:   "Valid AddedInVerison",
+			fn:     WithPreviewAddInVersion("v2.1.0"),
+			errVal: "",
+		},
+		{
+			name:   "Invalid Description",
+			fn:     WithPreviewDescription(""),
+			errVal: "adding empty description",
+		},
+		{
+			name:   "Valid Description",
+			fn:     WithPreviewDescription("Allows for new fancy thing"),
+			errVal: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.fn.apply(&Preview{enabled: new(atomic.Bool)})
+			if tc.errVal != "" {
+				assert.EqualError(t, err, tc.errVal, "Must match the expected value")
+			} else {
+				assert.NoError(t, err, "Must not error")
+			}
+		})
+	}
+}

--- a/internal/feature/preview_test.go
+++ b/internal/feature/preview_test.go
@@ -1,0 +1,26 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package feature
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDefaultPreview(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewPreview()
+	require.NoError(t, err, "Must not error when creating a default preview")
+
+	assert.False(t, p.Enabled(), "Must be disabled by default")
+	assert.False(t, p.GlobalAvailable(), "Must be disabled by default")
+	assert.Equal(t, "", p.Description(), "Must have no description by default")
+	assert.Equal(t, "", p.Introduced(), "Must have no value set for introduced")
+
+	p.SetEnabled(true)
+	assert.True(t, p.Enabled(), "Must be enabled once set")
+}

--- a/internal/feature/registry.go
+++ b/internal/feature/registry.go
@@ -1,0 +1,103 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package feature
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"regexp"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+type Registry struct {
+	features sync.Map
+}
+
+func NewRegistry() *Registry {
+	return &Registry{}
+}
+
+func (r *Registry) All() iter.Seq2[string, *Preview] {
+	return func(yield func(string, *Preview) bool) {
+		r.features.Range(func(key, value any) bool {
+			return yield(key.(string), value.(*Preview))
+		})
+	}
+}
+
+func (reg *Registry) Configure(ctx context.Context, feature string, enabled bool) error {
+	p, ok := reg.Get(feature)
+	if !ok {
+		return fmt.Errorf("no preview with id %q found", feature)
+	}
+
+	if p.GlobalAvailable() {
+		tflog.Warn(
+			ctx,
+			"Preview has been marked as Global Available,"+
+				" it is no longer required to be configured. "+
+				"If you're experiencing issues with a new feature, "+
+				"please reach out to customer support so the issue can be addressed",
+			tfext.NewLogFields().
+				Field("feature", feature).
+				Field("enabled", p.Enabled()),
+		)
+	}
+
+	p.SetEnabled(enabled)
+
+	tflog.Debug(ctx, "Configured feature preview", tfext.NewLogFields().
+		Field("feature", feature).
+		Field("enabled", p.Enabled()).
+		Field("added_in", p.Introduced()).
+		Field("description", p.Description()),
+	)
+
+	return nil
+}
+
+func (reg *Registry) Get(id string) (*Preview, bool) {
+	if v, ok := reg.features.Load(id); ok {
+		return v.(*Preview), true
+	}
+	return nil, false
+}
+
+func (reg *Registry) Register(feature string, opts ...PreviewOption) (*Preview, error) {
+	matched, err := regexp.MatchString(`^[a-z0-9\._\-]+$`, feature)
+	if err != nil {
+		// Error here should technically never happen.
+		return nil, err
+	}
+
+	if !matched {
+		return nil, fmt.Errorf("feature %q does not match expected naming format", feature)
+	}
+
+	g, err := NewPreview(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := reg.Get(feature); ok {
+		return nil, fmt.Errorf("feature %q already exists", feature)
+	}
+
+	reg.features.Store(feature, g)
+
+	return g, nil
+}
+
+func (reg *Registry) MustRegister(feature string, opts ...PreviewOption) *Preview {
+	g, err := reg.Register(feature, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return g
+}

--- a/internal/feature/registry_test.go
+++ b/internal/feature/registry_test.go
@@ -1,0 +1,180 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package feature
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRegistry(t *testing.T) {
+	t.Parallel()
+
+	assert.NotNil(t, NewRegistry(), "Must have a valid type when called")
+}
+
+func TestRegistryAll(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		entries map[string][]PreviewOption
+	}{
+		{
+			name:    "no values",
+			entries: map[string][]PreviewOption{},
+		},
+		{
+			name: "one feature",
+			entries: map[string][]PreviewOption{
+				"chart_validation": {},
+			},
+		},
+		{
+			name: "multiple entries",
+			entries: map[string][]PreviewOption{
+				"chart_validation": {},
+				"new_ui_elements":  {},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := NewRegistry()
+			for feature, opts := range tc.entries {
+				p, err := r.Register(feature, opts...)
+				assert.NoError(t, err, "Must not error creating preview")
+				assert.NotNil(t, p, "Must have a valid preview value")
+			}
+
+			features := maps.Collect(r.All())
+			assert.Len(t, features, len(tc.entries), "Must match the expected length of entries")
+			for feature := range tc.entries {
+				assert.Contains(t, features, feature, "Must contain the expected feature")
+			}
+		})
+	}
+}
+
+func TestRegistryRegister(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		feature string
+		opts    []PreviewOption
+		errVal  string
+	}{
+		{
+			name:    "empty feature name",
+			feature: "",
+			opts:    []PreviewOption{},
+			errVal:  "feature \"\" does not match expected naming format",
+		},
+		{
+			name:    "use of hyphen",
+			feature: "my-feature-01",
+			opts:    []PreviewOption{},
+			errVal:  "",
+		},
+		{
+			name:    "use of dot notation",
+			feature: "my.feature-01",
+			opts:    []PreviewOption{},
+			errVal:  "",
+		},
+		{
+			name:    "bad preview options",
+			feature: "my.feature",
+			opts: []PreviewOption{
+				WithPreviewDescription(""),
+			},
+			errVal: "adding empty description",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p, err := NewRegistry().Register(tc.feature, tc.opts...)
+			if tc.errVal != "" {
+				assert.Nil(t, p, "Must have a returned a nil value")
+				assert.EqualError(t, err, tc.errVal, "Must match the expected error value")
+			} else {
+				assert.NotNil(t, p, "Must have a valid preview")
+				assert.NoError(t, err, "Must not returned an error")
+			}
+		})
+	}
+}
+
+func TestRegistryMustRegister(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		_ = NewRegistry().MustRegister("my_feature_1")
+	})
+
+	assert.Panics(t, func() {
+		_ = NewRegistry().MustRegister("")
+	})
+
+	assert.Panics(t, func() {
+		r := NewRegistry()
+		_ = r.MustRegister("my-feature-01")
+		_ = r.MustRegister("my-feature-01")
+	})
+}
+
+func TestRegistryConfigure(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		opts    []PreviewOption
+		feature string
+		errVal  string
+	}{
+		{
+			name:    "default preview",
+			opts:    []PreviewOption{},
+			feature: "feature-01",
+			errVal:  "",
+		},
+		{
+			name:    "unset preview",
+			opts:    []PreviewOption{},
+			feature: "feature-02",
+			errVal:  "no preview with id \"feature-02\" found",
+		},
+		{
+			name: "globally available",
+			opts: []PreviewOption{
+				WithPreviewEnabled(),
+				WithPreviewGlobalAvailable(),
+			},
+			feature: "feature-01",
+			errVal:  "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			reg := NewRegistry()
+			_, err := reg.Register("feature-01", tc.opts...)
+			require.NoError(t, err, "Must not error when register a feature preview")
+
+			err = reg.Configure(context.Background(), tc.feature, true)
+			if tc.errVal != "" {
+				assert.EqualError(t, err, tc.errVal, "Must match the expected value")
+			} else {
+				assert.NoError(t, err, "Must not ")
+			}
+		})
+	}
+}

--- a/internal/feature/registry_test.go
+++ b/internal/feature/registry_test.go
@@ -155,7 +155,6 @@ func TestRegistryConfigure(t *testing.T) {
 		{
 			name: "globally available",
 			opts: []PreviewOption{
-				WithPreviewEnabled(),
 				WithPreviewGlobalAvailable(),
 			},
 			feature: "feature-01",

--- a/internal/feature/registry_test.go
+++ b/internal/feature/registry_test.go
@@ -173,7 +173,7 @@ func TestRegistryConfigure(t *testing.T) {
 			if tc.errVal != "" {
 				assert.EqualError(t, err, tc.errVal, "Must match the expected value")
 			} else {
-				assert.NoError(t, err, "Must not ")
+				assert.NoError(t, err, "Must not return an error")
 			}
 		})
 	}


### PR DESCRIPTION
## Context

In order to allow for changes that could have potential impact on users, this would allow the new feature to behind a feature preview and require users to opt in.

By default, each feature starts off as disabled and requires the feature to be configured (during provider start up) for the feature to be enabled. Once a feature has been marked as Global Available, it means that the feature is ready for global adoption but allows users to rollback the change in their provider and reach out to support if they are experiencing any issues.

## vNext addition

To allow the user to opt into the new features, the following will be added into the provider definition:

 ```hcl
provider "signalfx" {
  # ... Other required fields
  feature_preview {
    new_feature_01: true
    new_feature_02: true
  }
}
```