### PR TITLE
Feature: Include support for feature previews

### DIFF
--- a/internal/definition/provider/provider.go
+++ b/internal/definition/provider/provider.go
@@ -89,6 +89,14 @@ func New() *schema.Provider {
 				ConflictsWith: []string{"auth_token"},
 				Description:   "Required if the user is configured to be part of multiple organizations",
 			},
+			"feature_preview": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeBool,
+				},
+				Optional:    true,
+				Description: "Allows for users to opt-in to new features that are considered experimental or not ready for general availability yet.",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			team.ResourceName:     team.NewResource(),
@@ -175,6 +183,12 @@ func configureProvider(ctx context.Context, data *schema.ResourceData) (any, dia
 		Duration("wait_min", waitmin).
 		Duration("wait_max", waitmax),
 	)
+
+	for feat, val := range data.Get("feature_preview").(map[string]any) {
+		if err := pmeta.LoadPreviewRegistry(ctx, meta).Configure(ctx, feat, val.(bool)); err != nil {
+			return nil, tfext.AsWarnDiagnostics(err)
+		}
+	}
 
 	return &meta, nil
 }

--- a/internal/definition/provider/provider_test.go
+++ b/internal/definition/provider/provider_test.go
@@ -61,6 +61,19 @@ func TestProviderConfiguration(t *testing.T) {
 			},
 			expect: nil,
 		},
+		{
+			name: "Adding feature previews",
+			details: map[string]any{
+				"auth_token": "hunter2",
+				"api_url":    "api.us.signalfx.com",
+				"feature_preview": map[string]any{
+					"feature-01": true,
+				},
+			},
+			expect: diag.Diagnostics{
+				{Severity: diag.Warning, Summary: "no preview with id \"feature-01\" found"},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tftest.CleanEnvVars(t)

--- a/internal/providermeta/meta_test.go
+++ b/internal/providermeta/meta_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/signalfx/signalfx-go/sessiontoken"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/feature"
 )
 
 func TestLoadClient(t *testing.T) {
@@ -93,6 +95,41 @@ func TestLoadApplicationURL(t *testing.T) {
 
 			u := LoadApplicationURL(context.Background(), tc.meta, tc.fragments...)
 			require.Equal(t, tc.url, u, "Must match the expected url")
+		})
+	}
+}
+
+func TestLoadPreviewRegistry(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		meta   any
+		expect *feature.Registry
+	}{
+		{
+			name:   "no meta set",
+			meta:   nil,
+			expect: feature.GetGlobalRegistry(),
+		},
+		{
+			name:   "no local registry set",
+			meta:   &Meta{},
+			expect: feature.GetGlobalRegistry(),
+		},
+		{
+			name: "empty local registry",
+			meta: &Meta{
+				reg: &feature.Registry{},
+			},
+			expect: &feature.Registry{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := LoadPreviewRegistry(context.Background(), tc.meta)
+			assert.Equal(t, tc.expect, r, "Must match the expected registry")
 		})
 	}
 }

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -95,6 +95,14 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: "Required if the user is configured to be part of multiple organizations",
 			},
+			"feature_preview": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeBool,
+				},
+				Optional:    true,
+				Description: "Allows for users to opt-in to new features that are considered experimental or not ready for general availabilty yet.",
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"signalfx_dimension_values":      dataSourceDimensionValues(),
@@ -238,6 +246,17 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 	}
 
 	config.Client = client
+
+	for feat, val := range data.Get("feature_preview").(map[string]any) {
+		err = pmeta.LoadPreviewRegistry(
+			context.TODO(),
+			config,
+		).Configure(context.TODO(), feat, val.(bool))
+
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	return &config, nil
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -82,7 +82,7 @@ To allow for more experimental features to be added into the provider,
 a feature can be added behind a preview gate that defaults to being off and requires a user to opt into the change.
 Once a feature has been added into the provider, in can be set to globally available which will default to the feature being on by default.
 
-There is an oppotunity for the user to opt out of a globally available feature if an issue is experienced.
+There is an opportunity for the user to opt out of a globally available feature if an issue is experienced.
 If that is the case, please raise a support case with the provider configuration and any error messages.
 
 The feature preview can be enabled by the following example:
@@ -90,7 +90,7 @@ The feature preview can be enabled by the following example:
 ```hcl
 provider "signalfx" {
   # Other configured values
-  feature_values = {
+  feature_preview = {
     "feature-01": true,  // True means that the feature is enabled
     "feature-02": false, // False means that the feature is explicitly disabled
   }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -76,6 +76,27 @@ provider "signalfx" {
 }
 ```
 
+# Feature Previews
+
+To allow for more experimental features to be added into the provider, 
+a feature can be added behind a preview gate that defaults to being off and requires a user to opt into the change.
+Once a feature has been added into the provider, in can be set to globally available which will default to the feature being on by default.
+
+There is an oppotunity for the user to opt out of a globally available feature if an issue is experienced.
+If that is the case, please raise a support case with the provider configuration and any error messages.
+
+The feature preview can be enabled by the following example:
+
+```hcl
+provider "signalfx" {
+  # Other configured values
+  feature_values = {
+    "feature-01": true,  // True means that the feature is enabled
+    "feature-02": false, // False means that the feature is explicitly disabled
+  }
+}
+```
+
 ## Arguments
 
 The provider supports the following arguments:
@@ -90,3 +111,4 @@ The provider supports the following arguments:
 * `email` - (Optional) The provided email address is used to generate a _Session Token_ that is then used for all API interactions. Requires email address to be configured with a password, and not via SSO.
 * `password` - (Optional) The password is used to authenticate the email provided to generate a _Session Token_. Requires email address to be configured with a password, and not via SSO.
 * `organization_id` - (Optional) The organisation id is used to select which organization if the user provided belongs to multiple.
+* `feature_preview` - (Optional) A map structure that allows users to enable experimental features before they are ready to be globally available.


### PR DESCRIPTION
## Context

In order to help transition some of the behaviour, the feature previews will allow users to opt into the changes before they are throughly tested and be globally available.

## Changes

- Added new provider schema field `feature_preview`
- Added documentation to prepare users for changes