### PR TITLE
Fix JSON Syntax Error in IAM Policy

### DIFF
--- a/website/docs/r/aws_external_integration.html.markdown
+++ b/website/docs/r/aws_external_integration.html.markdown
@@ -57,7 +57,7 @@ resource "aws_iam_policy" "aws_splunk_policy" {
       "Effect": "Allow",
       "Action": [
         "airflow:GetEnvironment",
-        "airflow:ListEnvironments
+        "airflow:ListEnvironments",
         "apigateway:GET",
         "autoscaling:DescribeAutoScalingGroups",
         "cloudformation:ListResources",


### PR DESCRIPTION
This PR fixes a syntax error in the IAM policy JSON. Specifically, a missing closing quote was found in the `airflow:ListEnvironments` action.