### PR TITLE
Feature: Adding in support for encoding messages for AWS

### DIFF
--- a/internal/convert/convert_any.go
+++ b/internal/convert/convert_any.go
@@ -1,0 +1,9 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package convert
+
+// ToAny provides a way to convert back to the generic terraform values
+func ToAny[T any](in T) any {
+	return in
+}

--- a/internal/convert/convert_any_test.go
+++ b/internal/convert/convert_any_test.go
@@ -1,0 +1,17 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToAny(t *testing.T) {
+	t.Parallel()
+
+	const v int = 0
+	assert.IsType(t, (any)(int(0)), ToAny(v))
+}

--- a/internal/definition/awsintegration/schema_integration.go
+++ b/internal/definition/awsintegration/schema_integration.go
@@ -321,8 +321,8 @@ func decodeTerraform(rd *schema.ResourceData) (*integration.AwsCloudWatchIntegra
 	return cwi, nil
 }
 
-func encodeTerraform(aws *integration.AwsCloudWatchIntegration, d *schema.ResourceData) (errs error) {
-	err := multierr.Combine(
+func encodeTerraform(aws *integration.AwsCloudWatchIntegration, d *schema.ResourceData) error {
+	errs := multierr.Combine(
 		d.Set("integration_id", aws.Id),
 		d.Set("name", aws.Name),
 		d.Set("enabled", aws.Enabled),
@@ -337,7 +337,6 @@ func encodeTerraform(aws *integration.AwsCloudWatchIntegration, d *schema.Resour
 		d.Set("collect_only_recommended_stats", aws.CollectOnlyRecommendedStats),
 		d.Set("metric_streams_managed_externally", aws.MetricStreamsManagedExternally),
 	)
-	errs = multierr.Append(errs, err)
 
 	if aws.Token != "" {
 		errs = multierr.Append(errs, d.Set("token", aws.Token))

--- a/internal/definition/awsintegration/schema_integration.go
+++ b/internal/definition/awsintegration/schema_integration.go
@@ -342,6 +342,10 @@ func encodeTerraform(aws *integration.AwsCloudWatchIntegration, d *schema.Resour
 		errs = multierr.Append(errs, d.Set("token", aws.Token))
 	}
 
+	if aws.Key != "" {
+		errs = multierr.Append(errs, d.Set("key", aws.Key))
+	}
+
 	if len(aws.Regions) > 0 {
 		errs = multierr.Append(errs, d.Set("regions", schema.NewSet(
 			schema.HashString,

--- a/internal/definition/awsintegration/schema_integration.go
+++ b/internal/definition/awsintegration/schema_integration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/signalfx/signalfx-go/integration"
+	"go.uber.org/multierr"
 
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
@@ -318,4 +319,92 @@ func decodeTerraform(rd *schema.ResourceData) (*integration.AwsCloudWatchIntegra
 	}
 
 	return cwi, nil
+}
+
+func encodeTerraform(aws *integration.AwsCloudWatchIntegration, d *schema.ResourceData) (errs error) {
+	err := multierr.Combine(
+		d.Set("integration_id", aws.Id),
+		d.Set("name", aws.Name),
+		d.Set("enabled", aws.Enabled),
+		d.Set("enable_aws_usage", aws.EnableAwsUsage),
+		d.Set("import_cloud_watch", aws.ImportCloudWatch),
+		d.Set("poll_rate", aws.PollRate/1000),
+		d.Set("use_metric_streams_sync", aws.MetricStreamsSyncState == "ENABLED"),
+		d.Set("enable_logs_sync", aws.LogsSyncState == "ENABLED"),
+		d.Set("enable_check_large_volume", aws.EnableCheckLargeVolume),
+		d.Set("sync_custom_namespaces_only", aws.SyncCustomNamespacesOnly),
+		d.Set("named_token", aws.NamedToken),
+		d.Set("collect_only_recommended_stats", aws.CollectOnlyRecommendedStats),
+		d.Set("metric_streams_managed_externally", aws.MetricStreamsManagedExternally),
+	)
+	errs = multierr.Append(errs, err)
+
+	if aws.Token != "" {
+		errs = multierr.Append(errs, d.Set("token", aws.Token))
+	}
+
+	if len(aws.Regions) > 0 {
+		errs = multierr.Append(errs, d.Set("regions", schema.NewSet(
+			schema.HashString,
+			convert.SliceAll(aws.Regions, convert.ToAny),
+		)))
+	}
+
+	if len(aws.CustomNamespaceSyncRules) > 0 {
+		errs = multierr.Append(errs, d.Set(
+			"custom_namespace_sync_rule",
+			convert.SliceAll(aws.CustomNamespaceSyncRules, func(ns *integration.AwsCustomNameSpaceSyncRule) map[string]any {
+				rule := map[string]any{
+					"default_action": string(ns.DefaultAction),
+					"namespace":      ns.Namespace,
+				}
+				if ns.Filter != nil {
+					rule["filter_action"] = ns.Filter.Action
+					rule["filter_source"] = ns.Filter.Source
+				}
+				return rule
+			})))
+	} else if aws.CustomCloudWatchNamespaces != "" {
+		errs = multierr.Append(errs, d.Set("custom_cloudwatch_namespaces", schema.NewSet(schema.HashString, convert.SliceAll(
+			strings.Split(aws.CustomCloudWatchNamespaces, ","),
+			convert.ToAny,
+		))))
+	}
+
+	if _, ok := d.GetOk("services"); ok {
+		errs = multierr.Append(errs, d.Set("services", convert.SliceAll(
+			aws.Services,
+			func(in integration.AwsService) any {
+				return string(in)
+			},
+		)))
+	} else if len(aws.NamespaceSyncRules) > 0 {
+		errs = multierr.Append(errs, d.Set("namespace_sync_rule", convert.SliceAll(aws.NamespaceSyncRules, func(in *integration.AwsNameSpaceSyncRule) map[string]any {
+			rule := map[string]any{
+				"default_action": string(in.DefaultAction),
+				"namespace":      in.Namespace,
+			}
+			if in.Filter != nil {
+				rule["filter_action"] = in.Filter.Action
+				rule["filter_source"] = in.Filter.Source
+			}
+			return rule
+		})))
+	}
+
+	if len(aws.MetricStatsToSync) > 0 {
+		sync := []map[string]any{}
+		for namespace, v := range aws.MetricStatsToSync {
+			for metric, stats := range v {
+				sync = append(sync, map[string]any{
+					"namespace": namespace,
+					"metric":    metric,
+					"stats":     stats,
+				})
+			}
+		}
+		errs = multierr.Append(errs, d.Set("metric_stats_to_sync", sync))
+	}
+
+	return errs
 }

--- a/internal/definition/awsintegration/schema_integration_test.go
+++ b/internal/definition/awsintegration/schema_integration_test.go
@@ -176,3 +176,105 @@ func TestIntegrationDecode(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodeTerraformIntegration(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		input  *integration.AwsCloudWatchIntegration
+		errVal string
+	}{
+		{
+			name:   "empty integration",
+			input:  &integration.AwsCloudWatchIntegration{},
+			errVal: "",
+		},
+		{
+			name: "token set",
+			input: &integration.AwsCloudWatchIntegration{
+				Token: "my-token",
+			},
+			errVal: "",
+		},
+		{
+			name: "regions set",
+			input: &integration.AwsCloudWatchIntegration{
+				Regions: []string{
+					"us-east-1",
+					"us-east-2",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "custom namespace sync rules",
+			input: &integration.AwsCloudWatchIntegration{
+				CustomNamespaceSyncRules: []*integration.AwsCustomNameSpaceSyncRule{
+					{
+						DefaultAction: integration.INCLUDE,
+						Namespace:     "AWS/Kinesis",
+						Filter: &integration.AwsSyncRuleFilter{
+							Source: "hope",
+							Action: integration.INCLUDE,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "custom namespaces",
+			input: &integration.AwsCloudWatchIntegration{
+				CustomCloudWatchNamespaces: "namespace-1,namespace-2,namespace-3",
+			},
+			errVal: "",
+		},
+		{
+			name: "services",
+			input: &integration.AwsCloudWatchIntegration{
+				Services: []integration.AwsService{
+					"my-service-01",
+					"my-service-02",
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "namespace rules",
+			input: &integration.AwsCloudWatchIntegration{
+				NamespaceSyncRules: []*integration.AwsNameSpaceSyncRule{
+					{
+						DefaultAction: integration.INCLUDE,
+						Namespace:     "AWS/Kinesis",
+						Filter: &integration.AwsSyncRuleFilter{
+							Action: integration.INCLUDE,
+							Source: "hope",
+						},
+					},
+				},
+			},
+			errVal: "",
+		},
+		{
+			name: "metric stats",
+			input: &integration.AwsCloudWatchIntegration{
+				MetricStatsToSync: map[string]map[string][]string{
+					"AWS/SQS": {
+						"ApproximateAgeOfOldestMessage": {"mean"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := encodeTerraform(tc.input, schema.TestResourceDataRaw(t, newIntegrationSchema(), map[string]any{}))
+			if tc.errVal != "" {
+				assert.EqualError(t, err, tc.errVal, "Must match the expected value")
+			} else {
+				assert.NoError(t, err, "Must not return an error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

I am adding the encode functionality for the aws integration to get read for the resource implementation.
Since the integration is has significant number of fields, I have split this up for simpler review

## Changes

- Adding encoding for aws integration.