### PR TITLE
Feature: Adding support for provider level tags

### DIFF
--- a/internal/common/ordered_set.go
+++ b/internal/common/ordered_set.go
@@ -4,8 +4,8 @@
 package common
 
 import (
-	"container/list"
 	"iter"
+	"slices"
 )
 
 // OrderedSet preserves the order of when elements
@@ -15,30 +15,23 @@ import (
 // can not assume that items should be sorted based on value.
 type OrderedSet[E comparable] struct {
 	seen  map[E]struct{}
-	items *list.List
+	items []E
 }
 
 func NewOrderedSet[E comparable]() *OrderedSet[E] {
 	return &OrderedSet[E]{
-		seen:  make(map[E]struct{}),
-		items: list.New(),
+		seen: make(map[E]struct{}),
 	}
 }
 
 func (s *OrderedSet[E]) All() iter.Seq[E] {
-	return func(yield func(E) bool) {
-		for node := s.items.Front(); node != nil; node = node.Next() {
-			if !yield(node.Value.(E)) {
-				return
-			}
-		}
-	}
+	return slices.Values(s.items)
 }
 
 func (s *OrderedSet[E]) Add(e E) {
 	if _, exist := s.seen[e]; !exist {
 		s.seen[e] = struct{}{}
-		s.items.PushBack(e)
+		s.items = append(s.items, e)
 	}
 }
 

--- a/internal/common/ordered_set.go
+++ b/internal/common/ordered_set.go
@@ -1,0 +1,49 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"container/list"
+	"iter"
+)
+
+// OrderedSet preserves the order of when elements
+// where added into the set so that iterating through
+// the values is deterministic since a default map does
+// not ensure order when iterating through items, and
+// can not assume that items should be sorted based on value.
+type OrderedSet[E comparable] struct {
+	seen  map[E]struct{}
+	items *list.List
+}
+
+func NewOrderedSet[E comparable]() *OrderedSet[E] {
+	return &OrderedSet[E]{
+		seen:  make(map[E]struct{}),
+		items: list.New(),
+	}
+}
+
+func (s *OrderedSet[E]) All() iter.Seq[E] {
+	return func(yield func(E) bool) {
+		for node := s.items.Front(); node != nil; node = node.Next() {
+			if !yield(node.Value.(E)) {
+				return
+			}
+		}
+	}
+}
+
+func (s *OrderedSet[E]) Add(e E) {
+	if _, exist := s.seen[e]; !exist {
+		s.seen[e] = struct{}{}
+		s.items.PushBack(e)
+	}
+}
+
+func (s *OrderedSet[E]) Append(items ...E) {
+	for _, e := range items {
+		s.Add(e)
+	}
+}

--- a/internal/common/ordered_set_test.go
+++ b/internal/common/ordered_set_test.go
@@ -1,0 +1,56 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewOrderedSet(t *testing.T) {
+	t.Parallel()
+
+	assert.NotNil(t, NewOrderedSet[int](), "Must have a valid set returned")
+}
+
+func TestOrderedSetAll(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		in     []int
+		expect []int
+	}{
+		{
+			name:   "No values",
+			in:     []int{},
+			expect: nil,
+		},
+		{
+			name:   "unique values",
+			in:     []int{0, 1, 2, 3, 4, 5},
+			expect: []int{0, 1, 2, 3, 4, 5},
+		},
+		{
+			name:   "duplicate values",
+			in:     []int{0, 0, 0, 1},
+			expect: []int{0, 1},
+		},
+		{
+			name:   "unordered values",
+			in:     []int{3, 3, 1, 1, 2, 2, 1, 0, 5, 5, 5, 1, 4},
+			expect: []int{3, 1, 2, 0, 5, 4},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			os := NewOrderedSet[int]()
+			os.Append(tc.in...)
+			assert.Equal(t, tc.expect, slices.Collect(os.All()), "Must match the expected values")
+		})
+	}
+}

--- a/internal/common/unique.go
+++ b/internal/common/unique.go
@@ -1,0 +1,18 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import "slices"
+
+// Unique processes various different lists of data
+// and returns a unique list of all the values.
+// The values are returned in order they are processed
+// to provide a deterministic order.
+func Unique[S ~[]E, E comparable](lists ...S) S {
+	s := NewOrderedSet[E]()
+	for _, l := range lists {
+		s.Append(l...)
+	}
+	return slices.Collect(s.All())
+}

--- a/internal/common/unique_test.go
+++ b/internal/common/unique_test.go
@@ -1,0 +1,53 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnique(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		lists  [][]string
+		expect []string
+	}{
+		{
+			name:   "no values",
+			lists:  [][]string{},
+			expect: nil,
+		},
+		{
+			name: "single value",
+			lists: [][]string{
+				{"The", "Quick", "Brown", "Horse"},
+			},
+			expect: []string{"The", "Quick", "Brown", "Horse"},
+		},
+		{
+			name: "mixed values",
+			lists: [][]string{
+				{"The", "Quick", "Brown", "Horse"},
+				{"Jumps", "Over", "Brown", "Fence"},
+				{"Brown", "Horse", "Quick", "Battery", "Stable"},
+			},
+			expect: []string{"The", "Quick", "Brown", "Horse", "Jumps", "Over", "Fence", "Battery", "Stable"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				tc.expect,
+				Unique(tc.lists...),
+				"Must match the expected values",
+			)
+		})
+	}
+}

--- a/internal/definition/detector/schema.go
+++ b/internal/definition/detector/schema.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
-	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/definition/rule"
 	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/visual"
@@ -214,7 +213,6 @@ func decodeTerraform(rd *schema.ResourceData) (*detector.Detector, error) {
 			ShowDataMarkers: rd.Get("show_data_markers").(bool),
 			ShowEventLines:  rd.Get("show_event_lines").(bool),
 		},
-		Tags: convert.SchemaListAll(rd.Get("tags"), convert.ToString),
 	}
 
 	if tr, ok := rd.GetOk("time_range"); ok {

--- a/internal/definition/detector/schema.go
+++ b/internal/definition/detector/schema.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/definition/rule"
 	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/visual"
@@ -213,6 +214,7 @@ func decodeTerraform(rd *schema.ResourceData) (*detector.Detector, error) {
 			ShowDataMarkers: rd.Get("show_data_markers").(bool),
 			ShowEventLines:  rd.Get("show_event_lines").(bool),
 		},
+		Tags: convert.SchemaListAll(rd.Get("tags"), convert.ToString),
 	}
 
 	if tr, ok := rd.GetOk("time_range"); ok {

--- a/internal/definition/provider/provider.go
+++ b/internal/definition/provider/provider.go
@@ -15,8 +15,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/signalfx/signalfx-go"
 
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/definition/detector"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/definition/dimension"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/definition/team"
@@ -97,6 +99,15 @@ func New() *schema.Provider {
 				Optional:    true,
 				Description: "Allows for users to opt-in to new features that are considered experimental or not ready for general availability yet.",
 			},
+			"tags": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				Optional:    true,
+				Description: "Allows for Tags to be added by default to resources that allow for tags to be included. If there is already tags configured, the global tags are added in prefix.",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			team.ResourceName:     team.NewResource(),
@@ -114,6 +125,7 @@ func configureProvider(ctx context.Context, data *schema.ResourceData) (any, dia
 		Email:          data.Get("email").(string),
 		Password:       data.Get("password").(string),
 		OrganizationID: data.Get("organization_id").(string),
+		Tags:           convert.SliceAll(data.Get("tags").([]any), convert.ToString),
 	}
 
 	for _, lookup := range pmeta.NewDefaultProviderLookups() {
@@ -190,5 +202,5 @@ func configureProvider(ctx context.Context, data *schema.ResourceData) (any, dia
 		}
 	}
 
-	return &meta, nil
+	return meta, nil
 }

--- a/internal/providermeta/meta_test.go
+++ b/internal/providermeta/meta_test.go
@@ -261,3 +261,67 @@ func TestMetaToken(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadProviderTags(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		meta   any
+		expect []string
+	}{
+		{
+			name:   "no provider set",
+			meta:   nil,
+			expect: nil,
+		},
+		{
+			name:   "incorrect provider type set",
+			meta:   "provider",
+			expect: nil,
+		},
+		{
+			name: "disabled provider",
+			meta: &Meta{
+				reg: func() *feature.Registry {
+					r := feature.NewRegistry()
+					r.MustRegister(previewGlobalTagsKey)
+					return r
+				}(),
+				Tags: []string{
+					"example",
+					"test",
+				},
+			},
+			expect: nil,
+		},
+		{
+			name: "disabled provider",
+			meta: &Meta{
+				reg: func() *feature.Registry {
+					r := feature.NewRegistry()
+					r.MustRegister(previewGlobalTagsKey, feature.WithPreviewGlobalAvailable())
+					return r
+				}(),
+				Tags: []string{
+					"example",
+					"test",
+				},
+			},
+			expect: []string{
+				"example",
+				"test",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				tc.expect,
+				LoadProviderTags(t.Context(), tc.meta),
+			)
+		})
+	}
+}

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -16,6 +16,8 @@ import (
 	"github.com/signalfx/signalfx-go/dashboard"
 	"github.com/signalfx/signalfx-go/util"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
 )
 
 const (
@@ -819,6 +821,11 @@ func dashboardCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
+	payload.Tags = common.Unique(
+		pmeta.LoadProviderTags(context.Background(), meta),
+		payload.Tags,
+	)
+
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Dashboard Create Payload: %s", debugOutput)
 
@@ -1117,6 +1124,11 @@ func dashboardUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
+
+	payload.Tags = common.Unique(
+		pmeta.LoadProviderTags(context.Background(), meta),
+		payload.Tags,
+	)
 
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Dashboard Payload: %s", string(debugOutput))

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -19,6 +19,7 @@ import (
 	"github.com/signalfx/signalfx-go/detector"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
 )
 
 const (
@@ -497,6 +498,11 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
+	payload.Tags = common.Unique(
+		pmeta.LoadProviderTags(context.Background(), meta),
+		payload.Tags,
+	)
+
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Detector Payload: %s", string(debugOutput))
 
@@ -706,6 +712,11 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
+
+	payload.Tags = common.Unique(
+		pmeta.LoadProviderTags(context.Background(), meta),
+		payload.Tags,
+	)
 
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Update Detector Payload: %s", string(debugOutput))

--- a/signalfx/resource_signalfx_event_feed_chart.go
+++ b/signalfx/resource_signalfx_event_feed_chart.go
@@ -55,6 +55,14 @@ func eventFeedChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "URL of the chart",
 			},
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Tags associated with the resource",
+			},
 		},
 
 		Create: eventFeedChartCreate,

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
 
 	chart "github.com/signalfx/signalfx-go/chart"
 )
@@ -786,6 +788,11 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	payload := getPayloadTimeChart(d)
 
+	payload.Tags = common.Unique(
+		pmeta.LoadProviderTags(context.Background(), meta),
+		payload.Tags,
+	)
+
 	debugOutput, _ := json.Marshal(payload)
 	log.Printf("[DEBUG] SignalFx: Create Time Chart Payload: %s", string(debugOutput))
 
@@ -1112,6 +1119,11 @@ func publishLabelOptionsToMap(options *chart.PublishLabelOptions) (map[string]in
 func timechartUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	payload := getPayloadTimeChart(d)
+
+	payload.Tags = common.Unique(
+		pmeta.LoadProviderTags(context.Background(), meta),
+		payload.Tags,
+	)
 
 	c, err := config.Client.UpdateChart(context.TODO(), d.Id(), payload)
 	if err != nil {


### PR DESCRIPTION
## Context

To allow for a simplification of tags being applied to all resources managed by terraform, this looks to expose a `tags` field at a provider level that will merge will be prefixed with tags at a resource level. 

Note: This will require the preview to be enabled to start using this. 

## Changes


- Adding new internal type for OrderedSet 
  - This is due to iterating over a map is not deterministic
- Adding into provider vnext
  - Updated tests in vnext provider and caught some issues
- Updated vnext detectors
- Updated current provider
- Added `tags` field into chart resources

Resolves issue #404 

