### PR TITLE
Chore: Remove deprecated exists functionality 

### DIFF
--- a/signalfx/integration.go
+++ b/signalfx/integration.go
@@ -6,21 +6,12 @@ package signalfx
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"reflect"
 	"strings"
-)
 
-func handleIntegrationExists(err error) (bool, error) {
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
 
 func handleIntegrationRead(err error, d *schema.ResourceData) bool {
 	if err != nil {

--- a/signalfx/resource_signalfx_alert_muting_rule.go
+++ b/signalfx/resource_signalfx_alert_muting_rule.go
@@ -8,10 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/signalfx/signalfx-go/alertmuting"
@@ -106,7 +107,6 @@ func alertMutingRuleResource() *schema.Resource {
 		Read:   alertMutingRuleRead,
 		Update: alertMutingRuleUpdate,
 		Delete: alertMutingRuleDelete,
-		Exists: alertMutingRuleExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -181,18 +181,6 @@ func alertMutingRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(amr.Id)
 
 	return alertMutingRuleAPIToTF(d, amr)
-}
-
-func alertMutingRuleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAlertMutingRule(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func alertMutingRuleRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_aws_external_integration.go
+++ b/signalfx/resource_signalfx_aws_external_integration.go
@@ -36,6 +36,5 @@ func integrationAWSExternalResource() *schema.Resource {
 		},
 		Read:   IntegrationAWSRead,
 		Delete: noop, // delete is handled in the resource_signalfx_aws_integration.go
-		Exists: IntegrationAWSExists,
 	}
 }

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -263,20 +263,7 @@ func integrationAWSResource() *schema.Resource {
 		Read:   integrationAWSRead,
 		Update: integrationAWSUpdate,
 		Delete: integrationAWSDelete,
-		Exists: integrationAWSExists,
 	}
-}
-
-func integrationAWSExists(d *schema.ResourceData, meta any) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Get("integration_id").(string))
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func integrationAWSRead(d *schema.ResourceData, meta any) error {

--- a/signalfx/resource_signalfx_aws_integration_ops.go
+++ b/signalfx/resource_signalfx_aws_integration_ops.go
@@ -7,23 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/signalfx/signalfx-go/integration"
 	"log"
 	"strings"
-)
 
-func IntegrationAWSExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAWSCloudWatchIntegration(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/signalfx/signalfx-go/integration"
+)
 
 func IntegrationAWSRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)

--- a/signalfx/resource_signalfx_aws_token_integration.go
+++ b/signalfx/resource_signalfx_aws_token_integration.go
@@ -36,6 +36,5 @@ func integrationAWSTokenResource() *schema.Resource {
 		},
 		Read:   IntegrationAWSRead,
 		Delete: noop, // delete is handled in the resource_signalfx_aws_integration.go
-		Exists: IntegrationAWSExists,
 	}
 }

--- a/signalfx/resource_signalfx_azure_integration.go
+++ b/signalfx/resource_signalfx_azure_integration.go
@@ -144,23 +144,10 @@ func integrationAzureResource() *schema.Resource {
 		Read:   integrationAzureRead,
 		Update: integrationAzureUpdate,
 		Delete: integrationAzureDelete,
-		Exists: integrationAzureExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 	}
-}
-
-func integrationAzureExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetAzureIntegration(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func integrationAzureRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -461,7 +461,6 @@ func dashboardResource() *schema.Resource {
 		Read:   dashboardRead,
 		Update: dashboardUpdate,
 		Delete: dashboardDelete,
-		Exists: dashboardExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -844,18 +843,6 @@ func dashboardCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(dash.Id)
 
 	return dashboardAPIToTF(d, dash)
-}
-
-func dashboardExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetDashboard(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func dashboardRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_dashboard_group.go
+++ b/signalfx/resource_signalfx_dashboard_group.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -203,23 +202,10 @@ func dashboardGroupResource() *schema.Resource {
 		Read:   dashboardgroupRead,
 		Update: dashboardgroupUpdate,
 		Delete: dashboardgroupDelete,
-		Exists: dashboardgroupExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 	}
-}
-
-func dashboardgroupExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetDashboardGroup(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 /*

--- a/signalfx/resource_signalfx_data_link.go
+++ b/signalfx/resource_signalfx_data_link.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -154,7 +153,6 @@ func dataLinkResource() *schema.Resource {
 		Read:   dataLinkRead,
 		Update: dataLinkUpdate,
 		Delete: dataLinkDelete,
-		Exists: dataLinkExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -431,16 +429,4 @@ func dataLinkDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
 	return config.Client.DeleteDataLink(context.TODO(), d.Id())
-}
-
-func dataLinkExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetDataLink(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -274,7 +274,6 @@ func detectorResource() *schema.Resource {
 		Read:   detectorRead,
 		Update: detectorUpdate,
 		Delete: detectorDelete,
-		Exists: detectorExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -521,18 +520,6 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(det.Id)
 
 	return detectorRead(d, meta)
-}
-
-func detectorExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetDetector(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func detectorRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_event_feed_chart.go
+++ b/signalfx/resource_signalfx_event_feed_chart.go
@@ -69,7 +69,6 @@ func eventFeedChartResource() *schema.Resource {
 		Read:   eventFeedChartRead,
 		Update: eventFeedChartUpdate,
 		Delete: eventFeedChartDelete,
-		Exists: chartExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/signalfx/resource_signalfx_gcp_integration.go
+++ b/signalfx/resource_signalfx_gcp_integration.go
@@ -133,23 +133,10 @@ func integrationGCPResource() *schema.Resource {
 		Read:   integrationGCPRead,
 		Update: integrationGCPUpdate,
 		Delete: integrationGCPDelete,
-		Exists: integrationGCPExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 	}
-}
-
-func integrationGCPExists(d *schema.ResourceData, meta any) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetGCPIntegration(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func integrationGCPRead(d *schema.ResourceData, meta any) error {

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -184,7 +184,6 @@ func heatmapChartResource() *schema.Resource {
 		Read:   heatmapchartRead,
 		Update: heatmapchartUpdate,
 		Delete: heatmapchartDelete,
-		Exists: chartExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/signalfx/resource_signalfx_jira_integration.go
+++ b/signalfx/resource_signalfx_jira_integration.go
@@ -94,23 +94,10 @@ func integrationJiraResource() *schema.Resource {
 		Read:   integrationJiraRead,
 		Update: integrationJiraUpdate,
 		Delete: integrationJiraDelete,
-		Exists: integrationJiraExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 	}
-}
-
-func integrationJiraExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetJiraIntegration(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func integrationJiraRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -246,7 +246,6 @@ func listChartResource() *schema.Resource {
 		Read:   listchartRead,
 		Update: listchartUpdate,
 		Delete: listchartDelete,
-		Exists: chartExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/signalfx/resource_signalfx_log_timeline.go
+++ b/signalfx/resource_signalfx_log_timeline.go
@@ -75,7 +75,6 @@ func logTimelineResource() *schema.Resource {
 		Read:   logTimelineRead,
 		Update: logTimelineUpdate,
 		Delete: logTimelineDelete,
-		Exists: chartExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/signalfx/resource_signalfx_log_view.go
+++ b/signalfx/resource_signalfx_log_view.go
@@ -109,7 +109,6 @@ func logViewResource() *schema.Resource {
 		Read:   logViewRead,
 		Update: logViewUpdate,
 		Delete: logViewDelete,
-		Exists: chartExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/signalfx/resource_signalfx_metric_ruleset.go
+++ b/signalfx/resource_signalfx_metric_ruleset.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -263,7 +262,6 @@ func metricRulesetResource() *schema.Resource {
 		Read:   metricRulesetRead,
 		Update: metricRulesetUpdate,
 		Delete: metricRulesetDelete,
-		Exists: metricRulesetExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -387,18 +385,6 @@ func metricRulesetDelete(d *schema.ResourceData, meta interface{}) error {
 
 	err := config.Client.DeleteMetricRuleset(context.TODO(), d.Id())
 	return err
-}
-
-func metricRulesetExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetMetricRuleset(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func metricRulesetAPIToTF(d *schema.ResourceData, metricRuleset *metric_ruleset.MetricRuleset) error {

--- a/signalfx/resource_signalfx_opsgenie_integration.go
+++ b/signalfx/resource_signalfx_opsgenie_integration.go
@@ -44,23 +44,10 @@ func integrationOpsgenieResource() *schema.Resource {
 		Read:   integrationOpsgenieRead,
 		Update: integrationOpsgenieUpdate,
 		Delete: integrationOpsgenieDelete,
-		Exists: integrationOpsgenieExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 	}
-}
-
-func integrationOpsgenieExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetOpsgenieIntegration(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func getOpsgeniePayloadIntegration(d *schema.ResourceData) *integration.OpsgenieIntegration {

--- a/signalfx/resource_signalfx_org_token.go
+++ b/signalfx/resource_signalfx_org_token.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/signalfx/signalfx-go/orgtoken"
@@ -154,7 +153,6 @@ func orgTokenResource() *schema.Resource {
 		Read:   orgTokenRead,
 		Update: orgTokenUpdate,
 		Delete: orgTokenDelete,
-		Exists: orgTokenExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -390,16 +388,4 @@ func orgTokenDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
 	return config.Client.DeleteOrgToken(context.TODO(), d.Id())
-}
-
-func orgTokenExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetOrgToken(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }

--- a/signalfx/resource_signalfx_pagerduty_integration.go
+++ b/signalfx/resource_signalfx_pagerduty_integration.go
@@ -39,23 +39,10 @@ func integrationPagerDutyResource() *schema.Resource {
 		Read:   integrationPagerDutyRead,
 		Update: integrationPagerDutyUpdate,
 		Delete: integrationPagerDutyDelete,
-		Exists: integrationPagerDutyExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 	}
-}
-
-func integrationPagerDutyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetPagerDutyIntegration(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func integrationPagerDutyRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_service_now_integration.go
+++ b/signalfx/resource_signalfx_service_now_integration.go
@@ -76,7 +76,6 @@ func integrationServiceNowResource() *schema.Resource {
 		Read:   integrationServiceNowRead,
 		Update: integrationServiceNowUpdate,
 		Delete: integrationServiceNowDelete,
-		Exists: integrationServiceNowExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -127,13 +126,6 @@ func setServiceNowIntegration(d *schema.ResourceData, snow *integration.ServiceN
 		}
 	}
 	return nil
-}
-
-func integrationServiceNowExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-
-	_, err := config.Client.GetServiceNowIntegration(context.TODO(), d.Id())
-	return handleIntegrationExists(err)
 }
 
 func integrationServiceNowRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/resource_signalfx_single_value_chart.go
+++ b/signalfx/resource_signalfx_single_value_chart.go
@@ -192,7 +192,6 @@ func singleValueChartResource() *schema.Resource {
 		Read:   singlevaluechartRead,
 		Update: singlevaluechartUpdate,
 		Delete: singlevaluechartDelete,
-		Exists: chartExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/signalfx/resource_signalfx_slack_integration.go
+++ b/signalfx/resource_signalfx_slack_integration.go
@@ -39,23 +39,10 @@ func integrationSlackResource() *schema.Resource {
 		Read:   integrationSlackRead,
 		Update: integrationSlackUpdate,
 		Delete: integrationSlackDelete,
-		Exists: integrationSlackExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 	}
-}
-
-func integrationSlackExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetSlackIntegration(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func getSlackPayloadIntegration(d *schema.ResourceData) *integration.SlackIntegration {

--- a/signalfx/resource_signalfx_table_chart.go
+++ b/signalfx/resource_signalfx_table_chart.go
@@ -144,7 +144,6 @@ func tableChartResource() *schema.Resource {
 		Read:   tablechartRead,
 		Update: tablechartUpdate,
 		Delete: tablechartDelete,
-		Exists: chartExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/signalfx/resource_signalfx_text_chart.go
+++ b/signalfx/resource_signalfx_text_chart.go
@@ -50,7 +50,6 @@ func textChartResource() *schema.Resource {
 		Read:   textchartRead,
 		Update: textchartUpdate,
 		Delete: textchartDelete,
-		Exists: chartExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -508,7 +508,6 @@ func timeChartResource() *schema.Resource {
 		Read:   timechartRead,
 		Update: timechartUpdate,
 		Delete: timechartDelete,
-		Exists: chartExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/signalfx/resource_signalfx_victor_ops_integration.go
+++ b/signalfx/resource_signalfx_victor_ops_integration.go
@@ -38,23 +38,10 @@ func integrationVictorOpsResource() *schema.Resource {
 		Read:   integrationVictorOpsRead,
 		Update: integrationVictorOpsUpdate,
 		Delete: integrationVictorOpsDelete,
-		Exists: integrationVictorOpsExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 	}
-}
-
-func integrationVictorOpsExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetVictorOpsIntegration(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func getVictorOpsPayloadIntegration(d *schema.ResourceData) *integration.VictorOpsIntegration {

--- a/signalfx/resource_signalfx_webhook_integration.go
+++ b/signalfx/resource_signalfx_webhook_integration.go
@@ -73,23 +73,10 @@ func integrationWebhookResource() *schema.Resource {
 		Read:   integrationWebhookRead,
 		Update: integrationWebhookUpdate,
 		Delete: integrationWebhookDelete,
-		Exists: integrationWebhookExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 	}
-}
-
-func integrationWebhookExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetWebhookIntegration(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func getWebhookPayloadIntegration(d *schema.ResourceData) *integration.WebhookIntegration {

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -4,7 +4,6 @@
 package signalfx
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"net/url"
@@ -59,18 +58,6 @@ func buildAppURL(appURL string, fragment string) (string, error) {
 	// The URL is actually a fragment, so use that instead of Path
 	u.Fragment = fragment
 	return u.String(), nil
-}
-
-func chartExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*signalfxConfig)
-	_, err := config.Client.GetChart(context.TODO(), d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func expandStringSetToSlice(set *schema.Set) []string {


### PR DESCRIPTION
## Context

The plugin has marked `Exists` functionality deprecated due to it being a copy of Read

## Changes 

- Removed exists functions for all existing resources.