### PR TITLE
Feature: Add datasource for organization members

### DIFF
--- a/internal/check/email.go
+++ b/internal/check/email.go
@@ -1,0 +1,26 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package check
+
+import (
+	"fmt"
+	"net/mail"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+func Email(i any, p cty.Path) diag.Diagnostics {
+	v, ok := i.(string)
+	if !ok {
+		return tfext.AsErrorDiagnostics(
+			fmt.Errorf("expected %v to be of type string", i),
+			p,
+		)
+	}
+	_, err := mail.ParseAddress(v)
+	return tfext.AsErrorDiagnostics(err, p)
+}

--- a/internal/check/email_test.go
+++ b/internal/check/email_test.go
@@ -1,0 +1,48 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package check
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmail(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		in     any
+		expect diag.Diagnostics
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "expected <nil> to be of type string"},
+			},
+		},
+		{
+			name: "incomplete email",
+			in:   "example",
+			expect: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "mail: missing '@' or angle-addr"},
+			},
+		},
+		{
+			name:   "complete email",
+			in:     "user@example.com",
+			expect: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expect, Email(tc.in, cty.Path{}))
+		})
+	}
+}

--- a/internal/definition/organization/data_source.go
+++ b/internal/definition/organization/data_source.go
@@ -45,7 +45,7 @@ func datasourceRead(ctx context.Context, rd *schema.ResourceData, meta any) diag
 			}
 
 			for _, u := range results.Results {
-				tflog.Debug(ctx, "Retrived user details", tfext.NewLogFields().JSON("user", u))
+				tflog.Debug(ctx, "Retrieved user details", tfext.NewLogFields().JSON("user", u))
 				users = append(users, u.UserId)
 			}
 

--- a/internal/definition/organization/data_source.go
+++ b/internal/definition/organization/data_source.go
@@ -1,0 +1,59 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package organization
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+const DataSourceName = "signalfx_organization_members"
+
+func NewDataSource() *schema.Resource {
+	return &schema.Resource{
+		Description: "Allows for members to be queried and used as part of other resources. Requires the supplied token to have Admin priviledges.",
+		SchemaFunc:  newSchema,
+		ReadContext: datasourceRead,
+	}
+}
+
+func datasourceRead(ctx context.Context, rd *schema.ResourceData, meta any) diag.Diagnostics {
+	sfx, err := pmeta.LoadClient(ctx, meta)
+	if err != nil {
+		return tfext.AsErrorDiagnostics(err)
+	}
+
+	var (
+		users []any
+		limit = 1000
+	)
+	for _, email := range convert.SliceAll(rd.Get("emails").([]any), convert.ToString) {
+		for offset := 0; ; offset += limit {
+			results, err := sfx.GetOrganizationMembers(ctx, limit, fmt.Sprintf("email:%s", email), offset, "")
+			if err != nil {
+				return tfext.AsErrorDiagnostics(err)
+			}
+
+			for _, u := range results.Results {
+				tflog.Debug(ctx, "Retrived user details", tfext.NewLogFields().JSON("user", u))
+				users = append(users, u.UserId)
+			}
+
+			if offset >= int(results.Count) {
+				break
+			}
+		}
+
+	}
+
+	return tfext.AsErrorDiagnostics(rd.Set("users", users))
+}

--- a/internal/definition/organization/data_source.go
+++ b/internal/definition/organization/data_source.go
@@ -36,6 +36,7 @@ func datasourceRead(ctx context.Context, rd *schema.ResourceData, meta any) diag
 		users []any
 		limit = 1000
 	)
+
 	for _, email := range convert.SliceAll(rd.Get("emails").([]any), convert.ToString) {
 		for offset := 0; ; offset += limit {
 			results, err := sfx.GetOrganizationMembers(ctx, limit, fmt.Sprintf("email:%s", email), offset, "")
@@ -52,7 +53,6 @@ func datasourceRead(ctx context.Context, rd *schema.ResourceData, meta any) diag
 				break
 			}
 		}
-
 	}
 
 	return tfext.AsErrorDiagnostics(rd.Set("users", users))

--- a/internal/definition/organization/data_source_acceptance_test.go
+++ b/internal/definition/organization/data_source_acceptance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/tftest"
 )
 

--- a/internal/definition/organization/data_source_acceptance_test.go
+++ b/internal/definition/organization/data_source_acceptance_test.go
@@ -1,0 +1,4 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package organization

--- a/internal/definition/organization/data_source_acceptance_test.go
+++ b/internal/definition/organization/data_source_acceptance_test.go
@@ -2,3 +2,44 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package organization
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/tftest"
+)
+
+func TestAcceptanceDataSourceMembers(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		steps []resource.TestStep
+	}{
+		{
+			name: "minimal",
+			steps: []resource.TestStep{
+				{
+					Config: tftest.LoadConfig("testdata/data_members.tf"),
+					Check: func(s *terraform.State) error {
+						if !s.Empty() {
+							return errors.New("expected no data returned")
+						}
+						return nil
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tftest.NewAcceptanceHandler(
+				tftest.WithAcceptanceDataSources(map[string]*schema.Resource{
+					DataSourceName: NewDataSource(),
+				}),
+			).
+				Test(t, tc.steps)
+		})
+	}
+}

--- a/internal/definition/organization/data_source_test.go
+++ b/internal/definition/organization/data_source_test.go
@@ -1,0 +1,113 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package organization
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/signalfx/signalfx-go/organization"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/tftest"
+)
+
+func TestNewDataSource(t *testing.T) {
+	t.Parallel()
+
+	assert.NotNil(t, NewDataSource(), "Must have a valid resource returned")
+}
+
+func TestDataSourceRead(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		meta   func(tb testing.TB) any
+		values []any
+		diags  diag.Diagnostics
+	}{
+		{
+			name: "no provider",
+			meta: func(_ testing.TB) any {
+				return nil
+			},
+			values: nil,
+			diags: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "expected to implement type Meta"},
+			},
+		},
+		{
+			name: "not authorized",
+			meta: tftest.NewTestHTTPMockMeta(map[string]http.HandlerFunc{
+				"GET /v2/organization/member": func(w http.ResponseWriter, r *http.Request) {
+					_, _ = io.Copy(io.Discard, r.Body)
+					_ = r.Body.Close()
+
+					http.Error(w, "failed to read", http.StatusUnauthorized)
+				},
+			}),
+			values: []any{
+				"user-01@example.com",
+			},
+			diags: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "route \"/v2/organization/member\" had issues with status code 401"},
+			},
+		},
+		{
+			name: "no emails",
+			meta: tftest.NewTestHTTPMockMeta(map[string]http.HandlerFunc{
+				"GET /v2/organization/member": func(w http.ResponseWriter, r *http.Request) {
+					_, _ = io.Copy(io.Discard, r.Body)
+					_ = r.Body.Close()
+
+					_ = json.NewEncoder(w).Encode(&organization.MemberSearchResults{
+						Count: 0,
+					})
+				},
+			}),
+			values: []any{
+				"user-01@example.com",
+			},
+			diags: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "no returned user for email \"user-01@example.com\""},
+			},
+		},
+		{
+			name: "no emails",
+			meta: tftest.NewTestHTTPMockMeta(map[string]http.HandlerFunc{
+				"GET /v2/organization/member": func(w http.ResponseWriter, r *http.Request) {
+					_, _ = io.Copy(io.Discard, r.Body)
+					_ = r.Body.Close()
+
+					_ = json.NewEncoder(w).Encode(&organization.MemberSearchResults{
+						Count: 1,
+						Results: []*organization.Member{
+							{FullName: "user 01", UserId: "AAAAAAAA", Email: "user-01@example.com"},
+						},
+					})
+				},
+			}),
+			values: []any{
+				"user-01@example.com",
+			},
+			diags: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := NewDataSource()
+
+			rd := data.TestResourceData()
+			assert.NoError(t, rd.Set("emails", tc.values))
+
+			actual := data.ReadContext(t.Context(), rd, tc.meta(t))
+			assert.Equal(t, tc.diags, actual, "Must match the expected results")
+		})
+	}
+}

--- a/internal/definition/organization/data_source_test.go
+++ b/internal/definition/organization/data_source_test.go
@@ -73,9 +73,7 @@ func TestDataSourceRead(t *testing.T) {
 			values: []any{
 				"user-01@example.com",
 			},
-			diags: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "no returned user for email \"user-01@example.com\""},
-			},
+			diags: nil,
 		},
 		{
 			name: "no emails",

--- a/internal/definition/organization/schema.go
+++ b/internal/definition/organization/schema.go
@@ -1,0 +1,30 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package organization
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
+)
+
+func newSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"emails": {
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: check.Email,
+			},
+			Required: true,
+		},
+		"users": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}

--- a/internal/definition/organization/schema_test.go
+++ b/internal/definition/organization/schema_test.go
@@ -1,0 +1,16 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package organization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchema(t *testing.T) {
+	t.Parallel()
+
+	assert.NotNil(t, newSchema(), "Must have a valid schema")
+}

--- a/internal/definition/organization/testdata/data_members.tf
+++ b/internal/definition/organization/testdata/data_members.tf
@@ -1,0 +1,5 @@
+data "signalfx_organization_members" "example" {
+  emails = [
+    "user1@example.com"
+  ]
+}

--- a/internal/tftest/resource.go
+++ b/internal/tftest/resource.go
@@ -46,6 +46,8 @@ type ResourceOperationTestCase[T any] struct {
 }
 
 func (tc ResourceOperationTestCase[T]) TestCreate(t *testing.T) {
+	t.Helper()
+
 	var operation schema.CreateContextFunc = func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
 		return diag.Errorf("no create operation defined")
 	}
@@ -72,6 +74,8 @@ func (tc ResourceOperationTestCase[T]) TestCreate(t *testing.T) {
 }
 
 func (tc ResourceOperationTestCase[T]) TestRead(t *testing.T) {
+	t.Helper()
+
 	var operation schema.ReadContextFunc = func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
 		return diag.Errorf("no read operation defined")
 	}
@@ -98,6 +102,8 @@ func (tc ResourceOperationTestCase[T]) TestRead(t *testing.T) {
 }
 
 func (tc ResourceOperationTestCase[T]) TestUpdate(t *testing.T) {
+	t.Helper()
+
 	var operation schema.UpdateContextFunc = func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
 		return diag.Errorf("no update operation defined")
 	}
@@ -124,6 +130,8 @@ func (tc ResourceOperationTestCase[T]) TestUpdate(t *testing.T) {
 }
 
 func (tc ResourceOperationTestCase[T]) TestDelete(t *testing.T) {
+	t.Helper()
+
 	var operation schema.DeleteContextFunc = func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
 		return diag.Errorf("no delete operation defined")
 	}


### PR DESCRIPTION
## Context
This allows for users to be queried by their email and returns a list of user ids that can be used in other resources.

## Changes

- Add code for `signaflx_organization_members` datasource