### PR TITLE
Enhancement: Remove regions from being required

### DIFF
--- a/internal/definition/awsintegration/schema_integration.go
+++ b/internal/definition/awsintegration/schema_integration.go
@@ -131,7 +131,7 @@ func newIntegrationSchema() map[string]*schema.Schema {
 		},
 		"regions": {
 			Type:     schema.TypeSet,
-			Required: true,
+			Optional: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
@@ -287,10 +287,6 @@ func decodeTerraform(rd *schema.ResourceData) (*integration.AwsCloudWatchIntegra
 		cwi.Key = rd.Get("key").(string)
 	} else {
 		return nil, fmt.Errorf("requires either `external_id` or `token` and `key`")
-	}
-
-	if cwi.Regions == nil {
-		return nil, fmt.Errorf("regions should be defined explicitly, see https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-prereqs.html#supported-aws-regions")
 	}
 
 	if val, ok := rd.GetOk("poll_rate"); ok {

--- a/signalfx/resource_signalfx_aws_integration.go
+++ b/signalfx/resource_signalfx_aws_integration.go
@@ -147,7 +147,7 @@ func integrationAWSResource() *schema.Resource {
 			},
 			"regions": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -492,8 +492,6 @@ func getPayloadAWSIntegration(d *schema.ResourceData) (*integration.AwsCloudWatc
 			}
 			aws.Regions = regions
 		}
-	} else {
-		return nil, fmt.Errorf("regions should be defined explicitly, see https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-prereqs.html#supported-aws-regions")
 	}
 
 	if val, ok := d.GetOk("services"); ok {


### PR DESCRIPTION
## Context

Reading the API docs, it states if that regions are not defined that all regions are added. 
https://dev.splunk.com/observability/reference/api/integrations/latest#endpoint-create-integration

Wanting to align to the documentation, removing the strict requirement of the region.

## Changes

- Moving aws integration regions to be optional instead of required.