### PR TITLE
Enhancement: Make api_key WriteOnly

### DIFF
--- a/signalfx/resource_signalfx_pagerduty_integration.go
+++ b/signalfx/resource_signalfx_pagerduty_integration.go
@@ -32,6 +32,7 @@ func integrationPagerDutyResource() *schema.Resource {
 				Optional:    true,
 				Description: "PagerDuty API key",
 				Sensitive:   true,
+				WriteOnly:   true,
 			},
 		},
 


### PR DESCRIPTION
## Context

Since Terraform 1.11 there are write only arguments that do not get stored in the state https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only

This is a perfect usecase for this to not leak the API keys in the state file. There are other places this could/should be used but I want to go small. This also means that Terraform 1.11 is required for this functionality.

## Changes

- Enable WriteOnly for PageDuty API key