### PR TITLE
[chore] Refactoring chart util functionality

### DIFF
--- a/internal/convert/convert_secondary_visualizations.go
+++ b/internal/convert/convert_secondary_visualizations.go
@@ -1,0 +1,50 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package convert
+
+import (
+	"math"
+
+	"github.com/signalfx/signalfx-go/chart"
+
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/visual"
+)
+
+func ToChartSecondaryVisualization(in any) *chart.SecondaryVisualization {
+	var (
+		opt = in.(map[string]any)
+		viz = &chart.SecondaryVisualization{}
+	)
+
+	cond := func(v float64) bool {
+		// Ensure that the value is within the bounds of a 32 bit float.
+		return math.Abs(v) < math.MaxFloat32
+	}
+
+	if v, ok := opt["gt"].(float64); ok {
+		viz.Gt = common.AsPointerOnCondition(v, cond)
+	}
+
+	if v, ok := opt["gte"].(float64); ok {
+		viz.Gte = common.AsPointerOnCondition(v, cond)
+	}
+
+	if v, ok := opt["lt"].(float64); ok {
+		viz.Lt = common.AsPointerOnCondition(v, cond)
+	}
+
+	if v, ok := opt["lte"].(float64); ok {
+		viz.Lte = common.AsPointerOnCondition(v, cond)
+	}
+
+	if c, ok := opt["color"].(string); ok {
+		idx, ok := visual.NewColorPalette().ColorIndex(c)
+		if ok {
+			viz.PaletteIndex = common.AsPointer(idx)
+		}
+	}
+
+	return viz
+}

--- a/internal/convert/convert_secondary_visualizations_test.go
+++ b/internal/convert/convert_secondary_visualizations_test.go
@@ -1,0 +1,91 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package convert
+
+import (
+	"math"
+	"testing"
+
+	"github.com/signalfx/signalfx-go/chart"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
+)
+
+func TestToChartSecondaryVisualization(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		input  any
+		expect *chart.SecondaryVisualization
+	}{
+		{
+			name:   "empty",
+			input:  map[string]any{},
+			expect: &chart.SecondaryVisualization{},
+		},
+		{
+			name: "set color value",
+			input: map[string]any{
+				"color": "purple",
+			},
+			expect: &chart.SecondaryVisualization{
+				PaletteIndex: common.AsPointer[int32](16),
+			},
+		},
+		{
+			name: "setting gt value",
+			input: map[string]any{
+				"gt": 3.14,
+			},
+			expect: &chart.SecondaryVisualization{
+				Gt: common.AsPointer(3.14),
+			},
+		},
+		{
+			name: "setting gte",
+			input: map[string]any{
+				"gte": 13.37,
+			},
+			expect: &chart.SecondaryVisualization{
+				Gte: common.AsPointer(13.37),
+			},
+		},
+		{
+			name: "setting lt",
+			input: map[string]any{
+				"lt": 1.089,
+			},
+			expect: &chart.SecondaryVisualization{
+				Lt: common.AsPointer(1.089),
+			},
+		},
+		{
+			name: "setting lte",
+			input: map[string]any{
+				"lte": 47.09,
+			},
+			expect: &chart.SecondaryVisualization{
+				Lte: common.AsPointer(47.09),
+			},
+		},
+		{
+			name: "each value exceeds bounds",
+			input: map[string]any{
+				"lt":  math.MaxFloat32 + 4,
+				"lte": math.MaxFloat32,
+				"gt":  -math.MaxFloat32,
+				"gte": -math.MaxFloat32 - 4,
+			},
+			expect: &chart.SecondaryVisualization{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expect, ToChartSecondaryVisualization(tc.input))
+		})
+	}
+}

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	chart "github.com/signalfx/signalfx-go/chart"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
 )
 
 const (
@@ -119,12 +120,9 @@ func getNameFromChartColorsByIndex(index int) (string, error) {
 	return "", fmt.Errorf("Unknown color index %d", index)
 }
 
-/*
-Get Color Scale Options
-*/
+// Deprecated: Use `convert.SchemaListAll(d.Get("color_scale"), convert.ToChartSecondaryVisualization)` instead
 func getColorScaleOptions(d *schema.ResourceData) []*chart.SecondaryVisualization {
-	colorScale := d.Get("color_scale").(*schema.Set).List()
-	return getColorScaleOptionsFromSlice(colorScale)
+	return convert.SchemaListAll(d.Get("color_scale"), convert.ToChartSecondaryVisualization)
 }
 
 func getValueUsingMaxFloatAsDefault(v float64) *float64 {
@@ -133,35 +131,6 @@ func getValueUsingMaxFloatAsDefault(v float64) *float64 {
 	}
 	vf := float64(v)
 	return &vf
-}
-
-func getColorScaleOptionsFromSlice(colorScale []interface{}) []*chart.SecondaryVisualization {
-	item := make([]*chart.SecondaryVisualization, len(colorScale))
-	if len(colorScale) == 0 {
-		return item
-	}
-	for i := range colorScale {
-		options := &chart.SecondaryVisualization{}
-		scale := colorScale[i].(map[string]interface{})
-		options.Gt = getValueUsingMaxFloatAsDefault(scale["gt"].(float64))
-		options.Gte = getValueUsingMaxFloatAsDefault(scale["gte"].(float64))
-		options.Lt = getValueUsingMaxFloatAsDefault(scale["lt"].(float64))
-		options.Lte = getValueUsingMaxFloatAsDefault(scale["lte"].(float64))
-
-		var paletteIndex *int32
-		for index, thing := range ChartColorsSlice {
-			if scale["color"] == thing.name {
-				i := int32(index)
-				paletteIndex = &i
-				break
-			}
-		}
-		if paletteIndex != nil {
-			options.PaletteIndex = paletteIndex
-		}
-		item[i] = options
-	}
-	return item
 }
 
 /*


### PR DESCRIPTION
## Context

I am currently trying to improve the code base and this was next on my list. This basically moves the functionality and makes it safe for any future changes.

## Changes

- Deprecate `signalfx/getColorScaleFrom...` and moves it to a convert package.