### PR TITLE
Feature: Add reminder notification field for detectors

### DIFF
--- a/docs/resources/detector.md
+++ b/docs/resources/detector.md
@@ -170,6 +170,10 @@ notifications = ["Webhook,,secret,url"]
   * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See [Set Up Detectors to Trigger Alerts](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html) for more info.
   * `runbook_url` - (Optional) URL of page to consult when an alert is triggered. This can be used with custom notification messages.
   * `tip` - (Optional) Plain text suggested first course of action, such as a command line to execute. This can be used with custom notification messages.
+  * `reminder_notification` - (Optional) Reminder notification in a detector rule lets you send multiple notifications for active alerts over a defined period of time. **Note:** This feature is not present in all accounts. Please contact support if you are unsure.
+    * `interval_ms` - (Required) The interval at which you want to receive the notifications, in milliseconds.
+    * `timeout_ms` - (Optional) The duration during which repeat notifications are sent, in milliseconds.
+    * `type` - (Required) Type of reminder notification. Currently, the only supported value is TIMEOUT.
 * `viz_options` - (Optional) Plot-level customization options, associated with a publish statement.
   * `label` - (Required) Label used in the publish statement that displays the plot (metric time series data) you want to customize.
   * `display_name` - (Optional) Specifies an alternate value for the Plot Name column of the Data Table associated with the chart.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/signalfx/signalfx-go v1.47.0
+	github.com/signalfx/signalfx-go v1.48.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/multierr v1.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/rogpeppe/go-internal v1.6.2 h1:aIihoIOHCiLZHxyoNQ+ABL4NKhFTgKLBdMLyEA
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/signalfx/signalfx-go v1.47.0 h1:SZRQPcA9NPVmJGUZjNb4zonNR0Zjeep/eyt1c0qYNUA=
-github.com/signalfx/signalfx-go v1.47.0/go.mod h1:vGUt8DhpIJtzqP7hRD9ZGFPJBDTeCoO0OUsArKJriaY=
+github.com/signalfx/signalfx-go v1.48.0 h1:3s5YHGGVkfIJ/xhsbrjUmgH27w6a4ijGjszMJOAt3Tw=
+github.com/signalfx/signalfx-go v1.48.0/go.mod h1:vGUt8DhpIJtzqP7hRD9ZGFPJBDTeCoO0OUsArKJriaY=
 github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0LY=
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/check/reminder_type.go
+++ b/internal/check/reminder_type.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
 )
 

--- a/internal/check/reminder_type.go
+++ b/internal/check/reminder_type.go
@@ -1,0 +1,39 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package check
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+func NotificationReminderType() schema.SchemaValidateDiagFunc {
+	return func(i any, p cty.Path) diag.Diagnostics {
+		value, ok := i.(string)
+		if !ok {
+			return tfext.AsErrorDiagnostics(
+				fmt.Errorf("expected %v to be of type string", i),
+				p,
+			)
+		}
+
+		types := []string{
+			"TIMEOUT",
+		}
+
+		if slices.Contains(types, value) {
+			return nil
+		}
+
+		return tfext.AsErrorDiagnostics(
+			fmt.Errorf("value %q is not allowed; must be one of: %v", value, types),
+			p,
+		)
+	}
+}

--- a/internal/check/reminder_type_test.go
+++ b/internal/check/reminder_type_test.go
@@ -1,0 +1,50 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package check
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+func TestNotificationReminderType_ValidValue(t *testing.T) {
+	validateFunc := NotificationReminderType()
+	value := "TIMEOUT"
+	diagnostics := validateFunc(value, cty.Path{})
+
+	if len(diagnostics) != 0 {
+		t.Errorf("Expected no diagnostics, got %v", diagnostics)
+	}
+}
+
+func TestNotificationReminderType_InvalidValue(t *testing.T) {
+	validateFunc := NotificationReminderType()
+	value := "INVALID"
+	diagnostics := validateFunc(value, cty.Path{})
+
+	if len(diagnostics) == 0 {
+		t.Errorf("Expected diagnostics, got none")
+	}
+
+	expectedMessage := `value "INVALID" is not allowed; must be one of: [TIMEOUT]`
+	if diagnostics[0].Summary != expectedMessage {
+		t.Errorf("Expected diagnostic message %q, got %q", expectedMessage, diagnostics[0].Summary)
+	}
+}
+
+func TestNotificationReminderType_NonStringValue(t *testing.T) {
+	validateFunc := NotificationReminderType()
+	value := 123 // Non-string value
+	diagnostics := validateFunc(value, cty.Path{})
+
+	if len(diagnostics) == 0 {
+		t.Errorf("Expected diagnostics, got none")
+	}
+
+	expectedMessage := "expected 123 to be of type string"
+	if diagnostics[0].Summary != expectedMessage {
+		t.Errorf("Expected diagnostic message %q, got %q", expectedMessage, diagnostics[0].Summary)
+	}
+}

--- a/internal/convert/convert_reminder_notification.go
+++ b/internal/convert/convert_reminder_notification.go
@@ -7,11 +7,11 @@ import (
 	"github.com/signalfx/signalfx-go/detector"
 )
 
-func ToReminderNotification(tfRule map[string]interface{}) *detector.ReminderNotification {
+func ToReminderNotification(tfRule map[string]any) *detector.ReminderNotification {
 	if reminders, ok := tfRule["reminder_notification"]; ok && reminders != nil {
-		for _, reminder := range reminders.([]interface{}) {
+		for _, reminder := range reminders.([]any) {
 			if reminder != nil {
-				reminder := reminder.(map[string]interface{})
+				reminder := reminder.(map[string]any)
 				reminderNotification := &detector.ReminderNotification{}
 				if interval, ok := reminder["interval"]; ok {
 					reminderNotification.Interval = int64(interval.(int))

--- a/internal/convert/convert_reminder_notification.go
+++ b/internal/convert/convert_reminder_notification.go
@@ -13,11 +13,11 @@ func ToReminderNotification(tfRule map[string]any) *detector.ReminderNotificatio
 			if reminder != nil {
 				reminder := reminder.(map[string]any)
 				reminderNotification := &detector.ReminderNotification{}
-				if interval, ok := reminder["interval"]; ok {
-					reminderNotification.Interval = int64(interval.(int))
+				if interval, ok := reminder["interval_ms"]; ok {
+					reminderNotification.IntervalMs = int64(interval.(int))
 				}
-				if timeout, ok := reminder["timeout"]; ok {
-					reminderNotification.Timeout = int64(timeout.(int))
+				if timeout, ok := reminder["timeout_ms"]; ok {
+					reminderNotification.TimeoutMs = int64(timeout.(int))
 				}
 				if reminderType, ok := reminder["type"]; ok {
 					reminderNotification.Type = reminderType.(string)

--- a/internal/convert/convert_reminder_notification.go
+++ b/internal/convert/convert_reminder_notification.go
@@ -1,0 +1,30 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package convert
+
+import (
+	"github.com/signalfx/signalfx-go/detector"
+)
+
+func ToReminderNotification(tfRule map[string]interface{}) *detector.ReminderNotification {
+	if reminders, ok := tfRule["reminder_notification"]; ok && reminders != nil {
+		for _, reminder := range reminders.([]interface{}) {
+			if reminder != nil {
+				reminder := reminder.(map[string]interface{})
+				reminderNotification := &detector.ReminderNotification{}
+				if interval, ok := reminder["interval"]; ok {
+					reminderNotification.Interval = int64(interval.(int))
+				}
+				if timeout, ok := reminder["timeout"]; ok {
+					reminderNotification.Timeout = int64(timeout.(int))
+				}
+				if reminderType, ok := reminder["type"]; ok {
+					reminderNotification.Type = reminderType.(string)
+				}
+				return reminderNotification
+			}
+		}
+	}
+	return nil
+}

--- a/internal/convert/convert_reminder_notification_test.go
+++ b/internal/convert/convert_reminder_notification_test.go
@@ -22,16 +22,16 @@ func TestToReminderNotificationValidRule(t *testing.T) {
 	rule := map[string]any{
 		"reminder_notification": []any{
 			map[string]any{
-				"interval": 10,
-				"timeout":  20,
-				"type":     "email",
+				"interval_ms": 10,
+				"timeout_ms":  20,
+				"type":        "email",
 			},
 		},
 	}
 	expected := &detector.ReminderNotification{
-		Interval: 10,
-		Timeout:  20,
-		Type:     "email",
+		IntervalMs: 10,
+		TimeoutMs:  20,
+		Type:       "email",
 	}
 	result := ToReminderNotification(rule)
 	if !reflect.DeepEqual(result, expected) {

--- a/internal/convert/convert_reminder_notification_test.go
+++ b/internal/convert/convert_reminder_notification_test.go
@@ -4,10 +4,10 @@
 package convert
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/signalfx/signalfx-go/detector"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToReminderNotificationEmptyRules(t *testing.T) {
@@ -34,7 +34,7 @@ func TestToReminderNotificationValidRule(t *testing.T) {
 		Type:       "email",
 	}
 	result := ToReminderNotification(rule)
-	if !reflect.DeepEqual(result, expected) {
+	if !assert.Equal(t, result, expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
 	}
 }
@@ -57,7 +57,7 @@ func TestToReminderNotificationMissingFields(t *testing.T) {
 	}
 	expected := &detector.ReminderNotification{}
 	result := ToReminderNotification(rule)
-	if !reflect.DeepEqual(result, expected) {
+	if !assert.Equal(t, result, expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
 	}
 }

--- a/internal/convert/convert_reminder_notification_test.go
+++ b/internal/convert/convert_reminder_notification_test.go
@@ -1,0 +1,63 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package convert
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/signalfx/signalfx-go/detector"
+)
+
+func TestToReminderNotificationEmptyRules(t *testing.T) {
+	rule := map[string]interface{}{}
+	result := ToReminderNotification(rule)
+	if result != nil {
+		t.Errorf("Expected nil, got %v", result)
+	}
+}
+
+func TestToReminderNotificationValidRule(t *testing.T) {
+	rule := map[string]interface{}{
+		"reminder_notification": []interface{}{
+			map[string]interface{}{
+				"interval": 10,
+				"timeout":  20,
+				"type":     "email",
+			},
+		},
+	}
+	expected := &detector.ReminderNotification{
+		Interval: 10,
+		Timeout:  20,
+		Type:     "email",
+	}
+	result := ToReminderNotification(rule)
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+func TestToReminderNotificationNilReminder(t *testing.T) {
+	rule := map[string]interface{}{
+		"reminder_notification": []interface{}{nil},
+	}
+	result := ToReminderNotification(rule)
+	if result != nil {
+		t.Errorf("Expected nil, got %v", result)
+	}
+}
+
+func TestToReminderNotificationMissingFields(t *testing.T) {
+	rule := map[string]interface{}{
+		"reminder_notification": []interface{}{
+			map[string]interface{}{},
+		},
+	}
+	expected := &detector.ReminderNotification{}
+	result := ToReminderNotification(rule)
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}

--- a/internal/convert/convert_reminder_notification_test.go
+++ b/internal/convert/convert_reminder_notification_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestToReminderNotificationEmptyRules(t *testing.T) {
-	rule := map[string]interface{}{}
+	rule := map[string]any{}
 	result := ToReminderNotification(rule)
 	if result != nil {
 		t.Errorf("Expected nil, got %v", result)
@@ -19,9 +19,9 @@ func TestToReminderNotificationEmptyRules(t *testing.T) {
 }
 
 func TestToReminderNotificationValidRule(t *testing.T) {
-	rule := map[string]interface{}{
-		"reminder_notification": []interface{}{
-			map[string]interface{}{
+	rule := map[string]any{
+		"reminder_notification": []any{
+			map[string]any{
 				"interval": 10,
 				"timeout":  20,
 				"type":     "email",
@@ -40,8 +40,8 @@ func TestToReminderNotificationValidRule(t *testing.T) {
 }
 
 func TestToReminderNotificationNilReminder(t *testing.T) {
-	rule := map[string]interface{}{
-		"reminder_notification": []interface{}{nil},
+	rule := map[string]any{
+		"reminder_notification": []any{nil},
 	}
 	result := ToReminderNotification(rule)
 	if result != nil {
@@ -50,9 +50,9 @@ func TestToReminderNotificationNilReminder(t *testing.T) {
 }
 
 func TestToReminderNotificationMissingFields(t *testing.T) {
-	rule := map[string]interface{}{
-		"reminder_notification": []interface{}{
-			map[string]interface{}{},
+	rule := map[string]any{
+		"reminder_notification": []any{
+			map[string]any{},
 		},
 	}
 	expected := &detector.ReminderNotification{}

--- a/internal/convert/convert_reminder_notification_test.go
+++ b/internal/convert/convert_reminder_notification_test.go
@@ -34,7 +34,7 @@ func TestToReminderNotificationValidRule(t *testing.T) {
 		Type:       "email",
 	}
 	result := ToReminderNotification(rule)
-	if !assert.Equal(t, result, expected) {
+	if !assert.Equal(t, expected, result) {
 		t.Errorf("Expected %v, got %v", expected, result)
 	}
 }
@@ -57,7 +57,7 @@ func TestToReminderNotificationMissingFields(t *testing.T) {
 	}
 	expected := &detector.ReminderNotification{}
 	result := ToReminderNotification(rule)
-	if !assert.Equal(t, result, expected) {
+	if !assert.Equal(t, expected, result) {
 		t.Errorf("Expected %v, got %v", expected, result)
 	}
 }

--- a/internal/definition/detector/resource.go
+++ b/internal/definition/detector/resource.go
@@ -208,7 +208,7 @@ func resourceValidateFunc(ctx context.Context, diff *schema.ResourceDiff, meta a
 			Tip:                  data["tip"].(string),
 		}
 		if data["reminder_notification"] != nil {
-			reminderNotification := GetReminderNotificationForRule(data)
+			reminderNotification := convert.ToReminderNotification(data)
 			rule.ReminderNotification = reminderNotification
 		}
 		rules = append(rules, rule)
@@ -231,26 +231,4 @@ func resourceValidateFunc(ctx context.Context, diff *schema.ResourceDiff, meta a
 		DetectorOrigin:   diff.Get("detector_origin").(string),
 		ParentDetectorId: diff.Get("parent_detector_id").(string),
 	})
-}
-
-func GetReminderNotificationForRule(tfRule map[string]interface{}) *detector.ReminderNotification {
-	if reminders, ok := tfRule["reminder_notification"]; ok && reminders != nil {
-		for _, reminder := range reminders.([]interface{}) {
-			if reminder != nil {
-				reminder := reminder.(map[string]interface{})
-				reminderNotification := &detector.ReminderNotification{}
-				if interval, ok := reminder["interval"]; ok {
-					reminderNotification.Interval = int64(interval.(int))
-				}
-				if timeout, ok := reminder["timeout"]; ok {
-					reminderNotification.Timeout = int64(timeout.(int))
-				}
-				if reminderType, ok := reminder["type"]; ok {
-					reminderNotification.Type = reminderType.(string)
-				}
-				return reminderNotification
-			}
-		}
-	}
-	return nil
 }

--- a/internal/definition/detector/resource.go
+++ b/internal/definition/detector/resource.go
@@ -197,7 +197,7 @@ func resourceValidateFunc(ctx context.Context, diff *schema.ResourceDiff, meta a
 	var rules []*detector.Rule
 	for _, v := range diff.Get("rule").(*schema.Set).List() {
 		data := v.(map[string]any)
-		rules = append(rules, &detector.Rule{
+		rule := &detector.Rule{
 			Description:          data["description"].(string),
 			DetectLabel:          data["detect_label"].(string),
 			Disabled:             data["disabled"].(bool),
@@ -206,7 +206,12 @@ func resourceValidateFunc(ctx context.Context, diff *schema.ResourceDiff, meta a
 			ParameterizedSubject: data["parameterized_subject"].(string),
 			RunbookUrl:           data["runbook_url"].(string),
 			Tip:                  data["tip"].(string),
-		})
+		}
+		if data["reminder_notification"] != nil {
+			reminderNotification := GetReminderNotificationForRule(data)
+			rule.ReminderNotification = reminderNotification
+		}
+		rules = append(rules, rule)
 	}
 
 	client, err := pmeta.LoadClient(ctx, meta)
@@ -226,4 +231,26 @@ func resourceValidateFunc(ctx context.Context, diff *schema.ResourceDiff, meta a
 		DetectorOrigin:   diff.Get("detector_origin").(string),
 		ParentDetectorId: diff.Get("parent_detector_id").(string),
 	})
+}
+
+func GetReminderNotificationForRule(tfRule map[string]interface{}) *detector.ReminderNotification {
+	if reminders, ok := tfRule["reminder_notification"]; ok && reminders != nil {
+		for _, reminder := range reminders.([]interface{}) {
+			if reminder != nil {
+				reminder := reminder.(map[string]interface{})
+				reminderNotification := &detector.ReminderNotification{}
+				if interval, ok := reminder["interval"]; ok {
+					reminderNotification.Interval = int64(interval.(int))
+				}
+				if timeout, ok := reminder["timeout"]; ok {
+					reminderNotification.Timeout = int64(timeout.(int))
+				}
+				if reminderType, ok := reminder["type"]; ok {
+					reminderNotification.Type = reminderType.(string)
+				}
+				return reminderNotification
+			}
+		}
+	}
+	return nil
 }

--- a/internal/definition/rule/schema.go
+++ b/internal/definition/rule/schema.go
@@ -86,27 +86,15 @@ func NewSchema() map[string]*schema.Schema {
 						Description: "Timeout in milliseconds.",
 					},
 					"type": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: ValidateReminderType,
-						Description:  "Type of the reminder notification",
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: check.NotificationReminderType(),
+						Description:      "Type of the reminder notification",
 					},
 				},
 			},
 		},
 	}
-}
-
-func ValidateReminderType(v interface{}, k string) (we []string, errors []error) {
-	value := v.(string)
-	allowedTypes := []string{"TIMEOUT"}
-	for _, allowedType := range allowedTypes {
-		if value == allowedType {
-			return
-		}
-	}
-	errors = append(errors, fmt.Errorf("%s not allowed; must be one of: %s", value, strings.Join(allowedTypes, ", ")))
-	return
 }
 
 func Hash(v any) int {

--- a/internal/definition/rule/schema.go
+++ b/internal/definition/rule/schema.go
@@ -133,6 +133,15 @@ func Hash(v any) int {
 		}
 	}
 
+	if reminders, ok := rule["reminder_notification"].([]any); ok {
+		if len(reminders) > 0 {
+			reminder := reminders[0].(map[string]any)
+			_, _ = io.WriteString(hash, fmt.Sprintf("%s-", reminder["interval_ms"]))
+			_, _ = io.WriteString(hash, fmt.Sprintf("%s-", reminder["timeout_ms"]))
+			_, _ = io.WriteString(hash, fmt.Sprintf("%s-", reminder["type"]))
+		}
+	}
+
 	// crc32 returns a uint32, but for our use we need
 	// and non negative integer. Here we cast to an integer
 	// and invert it if the result is negative.

--- a/internal/definition/rule/schema.go
+++ b/internal/definition/rule/schema.go
@@ -70,26 +70,26 @@ func NewSchema() map[string]*schema.Schema {
 		},
 		"reminder_notification": {
 			Optional:    true,
-			Description: "Some description about reminder",
+			Description: "Reminder notification in a detector rule lets you send multiple notifications for active alerts over a defined period of time.",
 			Type:        schema.TypeList,
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"interval": {
+					"interval_ms": {
 						Type:        schema.TypeInt,
 						Required:    true,
-						Description: "Interval in milliseconds.",
+						Description: "The interval at which you want to receive the notifications, in milliseconds.",
 					},
-					"timeout": {
+					"timeout_ms": {
 						Type:        schema.TypeInt,
 						Optional:    true,
-						Description: "Timeout in milliseconds.",
+						Description: "The duration during which repeat notifications are sent, in milliseconds.",
 					},
 					"type": {
 						Type:             schema.TypeString,
 						Required:         true,
 						ValidateDiagFunc: check.NotificationReminderType(),
-						Description:      "Type of the reminder notification",
+						Description:      "Type of reminder notification. Currently, the only supported value is TIMEOUT.",
 					},
 				},
 			},

--- a/internal/definition/rule/schema.go
+++ b/internal/definition/rule/schema.go
@@ -68,7 +68,45 @@ func NewSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Plain text suggested first course of action, such as a command to execute.",
 		},
+		"reminder_notification": {
+			Optional:    true,
+			Description: "Some description about reminder",
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"interval": {
+						Type:        schema.TypeInt,
+						Required:    true,
+						Description: "Interval in milliseconds.",
+					},
+					"timeout": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Timeout in milliseconds.",
+					},
+					"type": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: ValidateReminderType,
+						Description:  "Type of the reminder notification",
+					},
+				},
+			},
+		},
 	}
+}
+
+func ValidateReminderType(v interface{}, k string) (we []string, errors []error) {
+	value := v.(string)
+	allowedTypes := []string{"TIMEOUT"}
+	for _, allowedType := range allowedTypes {
+		if value == allowedType {
+			return
+		}
+	}
+	errors = append(errors, fmt.Errorf("%s not allowed; must be one of: %s", value, strings.Join(allowedTypes, ", ")))
+	return
 }
 
 func Hash(v any) int {

--- a/internal/definition/rule/schema_test.go
+++ b/internal/definition/rule/schema_test.go
@@ -51,8 +51,15 @@ func TestHashSchema(t *testing.T) {
 				"runbook_url":           "http://example.com",
 				"tip":                   "login to investigate the issue",
 				"notifications":         []any{"Email,example@com", "Email,foo@bar"},
+				"reminder_notification": []any{
+					map[string]any{
+						"interval_ms": 10,
+						"timeout_ms":  20,
+						"type":        "email",
+					},
+				},
 			},
-			code: 137896672,
+			code: 2915325511,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -20,7 +20,6 @@ import (
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
-	internalrule "github.com/splunk-terraform/terraform-provider-signalfx/internal/definition/rule"
 	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
 )
 
@@ -99,10 +98,10 @@ var (
 						Description: "Timeout in milliseconds.",
 					},
 					"type": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: internalrule.ValidateReminderType,
-						Description:  "Type of the reminder notification",
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: check.NotificationReminderType(),
+						Description:      "Type of the reminder notification",
 					},
 				},
 			},

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -815,6 +815,33 @@ func resourceRuleHash(v interface{}) int {
 		}
 	}
 
+	serializeReminderToString := func(reminder map[string]interface{}) string {
+		var _buf bytes.Buffer
+
+		// Sort keys to ensure consistent hash generation
+		keys := make([]string, 0, len(reminder))
+		for key := range reminder {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		// Serialize each key-value pair
+		for _, key := range keys {
+			value := reminder[key]
+			_buf.WriteString(fmt.Sprintf("%s-%v-", key, value))
+		}
+
+		return _buf.String()
+	}
+
+	// check optional complex rule attributes
+	for _, reminder := range m["reminder_notification"].([]interface{}) {
+		if reminder != nil {
+			serializedReminder := serializeReminderToString(reminder.(map[string]interface{}))
+			buf.WriteString(fmt.Sprintf("%s-", serializedReminder))
+		}
+	}
+
 	// Sort the notifications so that we generate a consistent hash
 	if v, ok := m["notifications"]; ok {
 		notifications := v.([]interface{})

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -742,6 +742,15 @@ func getTfDetectorRule(r *detector.Rule) (map[string]interface{}, error) {
 	rule["parameterized_subject"] = r.ParameterizedSubject
 	rule["runbook_url"] = r.RunbookUrl
 	rule["tip"] = r.Tip
+
+	if r.ReminderNotification != nil {
+		reminder := make(map[string]interface{})
+		reminder["interval"] = r.ReminderNotification.Interval
+		reminder["timeout"] = r.ReminderNotification.Timeout
+		reminder["type"] = r.ReminderNotification.Type
+		rule["reminder_notification"] = []interface{}{reminder}
+	}
+
 	return rule, nil
 }
 

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -452,6 +452,26 @@ func getDetectorRule(tfRule map[string]interface{}) (*detector.Rule, error) {
 		}
 		rule.Notifications = notify
 	}
+
+	if reminders, ok := tfRule["reminder_notification"]; ok && reminders != nil {
+		for _, reminder := range reminders.([]interface{}) {
+			if reminder != nil {
+				reminder := reminder.(map[string]interface{})
+				reminderNotification := &detector.ReminderNotification{}
+				if interval, ok := reminder["interval"]; ok {
+					reminderNotification.Interval = int64(interval.(int))
+				}
+				if timeout, ok := reminder["timeout"]; ok {
+					reminderNotification.Timeout = int64(timeout.(int))
+				}
+				if reminderType, ok := reminder["type"]; ok {
+					reminderNotification.Type = reminderType.(string)
+				}
+				rule.ReminderNotification = reminderNotification
+			}
+		}
+	}
+
 	return rule, nil
 }
 

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -957,6 +957,10 @@ func validateProgramText(ctx context.Context, d *schema.ResourceDiff, meta any) 
 			rule.Tip = val.(string)
 		}
 
+		// due to the problems with sdkv2, nested complex
+		// types are not filled in CustomizeDiff, so it
+		// is ultimately not filled here (and not sent to
+		// the API)
 		reminder := convert.ToReminderNotification(tfRule)
 		if reminder != nil {
 			rule.ReminderNotification = reminder

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -82,26 +82,26 @@ var (
 		},
 		"reminder_notification": {
 			Optional:    true,
-			Description: "Some description about reminder",
+			Description: "Reminder notification in a detector rule lets you send multiple notifications for active alerts over a defined period of time.",
 			Type:        schema.TypeList,
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"interval": {
+					"interval_ms": {
 						Type:        schema.TypeInt,
 						Required:    true,
-						Description: "Interval in milliseconds.",
+						Description: "The interval at which you want to receive the notifications, in milliseconds.",
 					},
-					"timeout": {
+					"timeout_ms": {
 						Type:        schema.TypeInt,
 						Optional:    true,
-						Description: "Timeout in milliseconds.",
+						Description: "The duration during which repeat notifications are sent, in milliseconds.",
 					},
 					"type": {
 						Type:             schema.TypeString,
 						Required:         true,
 						ValidateDiagFunc: check.NotificationReminderType(),
-						Description:      "Type of the reminder notification",
+						Description:      "Type of reminder notification. Currently, the only supported value is TIMEOUT.",
 					},
 				},
 			},
@@ -732,8 +732,8 @@ func getTfDetectorRule(r *detector.Rule) (map[string]any, error) {
 
 	if r.ReminderNotification != nil {
 		reminder := make(map[string]any)
-		reminder["interval"] = r.ReminderNotification.Interval
-		reminder["timeout"] = r.ReminderNotification.Timeout
+		reminder["interval_ms"] = r.ReminderNotification.IntervalMs
+		reminder["timeout_ms"] = r.ReminderNotification.TimeoutMs
 		reminder["type"] = r.ReminderNotification.Type
 		rule["reminder_notification"] = []any{reminder}
 	}

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -79,6 +79,31 @@ var (
 			Optional:    true,
 			Description: "Plain text suggested first course of action, such as a command to execute.",
 		},
+		"reminder_notification": {
+			Optional:    true,
+			Description: "Some description about reminder",
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"interval": {
+						Type:        schema.TypeInt,
+						Required:    true,
+						Description: "Interval in milliseconds.",
+					},
+					"timeout": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Timeout in milliseconds.",
+					},
+					"type": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Type of the reminder notification",
+					},
+				},
+			},
+		},
 	}
 )
 

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -812,6 +812,25 @@ func getPerSignalDetectorVizOptions(d *schema.ResourceData) []*detector.PublishL
 	return vizList
 }
 
+func serializeReminderToString(reminder map[string]any) string {
+	var _buf bytes.Buffer
+
+	// Sort keys to ensure consistent hash generation
+	keys := make([]string, 0, len(reminder))
+	for key := range reminder {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Serialize each key-value pair
+	for _, key := range keys {
+		value := reminder[key]
+		_buf.WriteString(fmt.Sprintf("%s-%v-", key, value))
+	}
+
+	return _buf.String()
+}
+
 /*
 Hashing function for rule substructure of the detector resource, used in determining state changes.
 */
@@ -830,25 +849,6 @@ func resourceRuleHash(v any) int {
 		if val, ok := m[key]; ok {
 			buf.WriteString(fmt.Sprintf("%s-", val))
 		}
-	}
-
-	serializeReminderToString := func(reminder map[string]any) string {
-		var _buf bytes.Buffer
-
-		// Sort keys to ensure consistent hash generation
-		keys := make([]string, 0, len(reminder))
-		for key := range reminder {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-
-		// Serialize each key-value pair
-		for _, key := range keys {
-			value := reminder[key]
-			_buf.WriteString(fmt.Sprintf("%s-%v-", key, value))
-		}
-
-		return _buf.String()
 	}
 
 	// check optional reminder notification

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -834,11 +834,13 @@ func resourceRuleHash(v interface{}) int {
 		return _buf.String()
 	}
 
-	// check optional complex rule attributes
-	for _, reminder := range m["reminder_notification"].([]interface{}) {
-		if reminder != nil {
-			serializedReminder := serializeReminderToString(reminder.(map[string]interface{}))
-			buf.WriteString(fmt.Sprintf("%s-", serializedReminder))
+	// check optional reminder notification
+	if reminders, ok := m["reminder_notification"]; ok && reminders != nil {
+		for _, reminder := range reminders.([]interface{}) {
+			if reminder != nil {
+				serializedReminder := serializeReminderToString(reminder.(map[string]interface{}))
+				buf.WriteString(fmt.Sprintf("%s", serializedReminder))
+			}
 		}
 	}
 

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -19,7 +19,8 @@ import (
 	"github.com/signalfx/signalfx-go/detector"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
-	internaldetector "github.com/splunk-terraform/terraform-provider-signalfx/internal/definition/detector"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
+	internalrule "github.com/splunk-terraform/terraform-provider-signalfx/internal/definition/rule"
 	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
 )
 
@@ -100,7 +101,7 @@ var (
 					"type": {
 						Type:         schema.TypeString,
 						Required:     true,
-						ValidateFunc: validateReminderType,
+						ValidateFunc: internalrule.ValidateReminderType,
 						Description:  "Type of the reminder notification",
 					},
 				},
@@ -454,7 +455,7 @@ func getDetectorRule(tfRule map[string]interface{}) (*detector.Rule, error) {
 		rule.Notifications = notify
 	}
 
-	reminder := internaldetector.GetReminderNotificationForRule(tfRule)
+	reminder := convert.ToReminderNotification(tfRule)
 	if reminder != nil {
 		rule.ReminderNotification = reminder
 	}
@@ -895,18 +896,6 @@ func validateSeverity(v interface{}, k string) (we []string, errors []error) {
 	return
 }
 
-func validateReminderType(v interface{}, k string) (we []string, errors []error) {
-	value := v.(string)
-	allowedTypes := []string{"TIMEOUT"}
-	for _, allowedType := range allowedTypes {
-		if value == allowedType {
-			return
-		}
-	}
-	errors = append(errors, fmt.Errorf("%s not allowed; must be one of: %s", value, strings.Join(allowedTypes, ", ")))
-	return
-}
-
 /*
 Validates the condition to be fulfilled for checking ProgramText.
 */
@@ -969,7 +958,7 @@ func validateProgramText(ctx context.Context, d *schema.ResourceDiff, meta inter
 			rule.Tip = val.(string)
 		}
 
-		reminder := internaldetector.GetReminderNotificationForRule(tfRule)
+		reminder := convert.ToReminderNotification(tfRule)
 		if reminder != nil {
 			rule.ReminderNotification = reminder
 		}

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -97,9 +97,10 @@ var (
 						Description: "Timeout in milliseconds.",
 					},
 					"type": {
-						Type:        schema.TypeString,
-						Required:    true,
-						Description: "Type of the reminder notification",
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validateReminderType,
+						Description:  "Type of the reminder notification",
 					},
 				},
 			},
@@ -875,6 +876,18 @@ func validateSeverity(v interface{}, k string) (we []string, errors []error) {
 		}
 	}
 	errors = append(errors, fmt.Errorf("%s not allowed; must be one of: %s", value, strings.Join(allowedWords, ", ")))
+	return
+}
+
+func validateReminderType(v interface{}, k string) (we []string, errors []error) {
+	value := v.(string)
+	allowedTypes := []string{"TIMEOUT"}
+	for _, allowedType := range allowedTypes {
+		if value == allowedType {
+			return
+		}
+	}
+	errors = append(errors, fmt.Errorf("%s not allowed; must be one of: %s", value, strings.Join(allowedTypes, ", ")))
 	return
 }
 

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -117,6 +117,16 @@ func TestValidateSeverityNotAllowed(t *testing.T) {
 	assert.Equal(t, len(errors), 1)
 }
 
+func TestValidateReminderTypeAllowed(t *testing.T) {
+	_, errors := validateReminderType("TIMEOUT", "reminder_type")
+	assert.Equal(t, len(errors), 0)
+}
+
+func TestValidateReminderTypeNotAllowed(t *testing.T) {
+	_, errors := validateReminderType("TIMEOUTT", "reminder_type")
+	assert.Equal(t, len(errors), 1)
+}
+
 const newDetectorConfig = `
 resource "signalfx_team" "detectorTeam" {
     name = "Splunk Team"

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -559,3 +559,50 @@ func TestTimeRangeStateUpgradeV0(t *testing.T) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
 	}
 }
+
+func TestSerializeReminderToString(t *testing.T) {
+	t.Run("Serialize reminder with all fields", func(t *testing.T) {
+		reminder := map[string]any{
+			"interval": 5000,
+			"timeout":  10000,
+			"type":     "TIMEOUT",
+		}
+		expected := "interval-5000-timeout-10000-type-TIMEOUT-"
+		assert.Equal(t, expected, serializeReminderToString(reminder))
+	})
+
+	t.Run("Serialize reminder with missing optional fields", func(t *testing.T) {
+		reminder := map[string]any{
+			"interval": 5000,
+			"type":     "TIMEOUT",
+		}
+		expected := "interval-5000-type-TIMEOUT-"
+		assert.Equal(t, expected, serializeReminderToString(reminder))
+	})
+
+	t.Run("Serialize empty reminder map", func(t *testing.T) {
+		reminder := map[string]any{}
+		expected := ""
+		assert.Equal(t, expected, serializeReminderToString(reminder))
+	})
+
+	t.Run("Serialize reminder with unordered keys", func(t *testing.T) {
+		reminder := map[string]any{
+			"type":     "TIMEOUT",
+			"timeout":  10000,
+			"interval": 5000,
+		}
+		expected := "interval-5000-timeout-10000-type-TIMEOUT-"
+		assert.Equal(t, expected, serializeReminderToString(reminder))
+	})
+
+	t.Run("Serialize reminder with non-string values", func(t *testing.T) {
+		reminder := map[string]any{
+			"interval": 5000,
+			"timeout":  nil,
+			"type":     true,
+		}
+		expected := "interval-5000-timeout-<nil>-type-true-"
+		assert.Equal(t, expected, serializeReminderToString(reminder))
+	})
+}

--- a/signalfx/resource_signalfx_detector_test.go
+++ b/signalfx/resource_signalfx_detector_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestResourceRuleHash(t *testing.T) {
 	// Tests basic and consistent hashing, keys in the maps are sorted
-	values := map[string]interface{}{
+	values := map[string]any{
 		"description":  "Test Rule Name",
 		"detect_label": "Test Detect Label",
 		"severity":     "Critical",
@@ -29,7 +29,7 @@ func TestResourceRuleHash(t *testing.T) {
 	assert.Equal(t, expected, resourceRuleHash(values))
 
 	// Test new params in rules
-	values = map[string]interface{}{
+	values = map[string]any{
 		"description":           "Test Rule Name",
 		"detect_label":          "Test Detect Label",
 		"severity":              "Critical",
@@ -41,7 +41,7 @@ func TestResourceRuleHash(t *testing.T) {
 	expected = HashCodeString("Test Rule Name-Critical-Test Detect Label-true-Test body-Test subject-")
 	assert.Equal(t, expected, resourceRuleHash(values))
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"description":           "Test Rule Name",
 		"detect_label":          "Test Detect Label",
 		"severity":              "Critical",
@@ -57,13 +57,13 @@ func TestResourceRuleHash(t *testing.T) {
 }
 
 func TestReminderNotificationInRuleHashing(t *testing.T) {
-	values := map[string]interface{}{
+	values := map[string]any{
 		"description":  "Test Rule Name",
 		"detect_label": "Test Detect Label",
 		"severity":     "Critical",
 		"disabled":     "true",
-		"reminder_notification": []interface{}{
-			map[string]interface{}{
+		"reminder_notification": []any{
+			map[string]any{
 				"interval": 5000,
 				"timeout":  10000,
 				"type":     "TIMEOUT",
@@ -76,13 +76,13 @@ func TestReminderNotificationInRuleHashing(t *testing.T) {
 }
 
 func TestChangesInReminderNotificationRuleHashing(t *testing.T) {
-	values := map[string]interface{}{
+	values := map[string]any{
 		"description":  "Test Rule Name",
 		"detect_label": "Test Detect Label",
 		"severity":     "Critical",
 		"disabled":     "true",
-		"reminder_notification": []interface{}{
-			map[string]interface{}{
+		"reminder_notification": []any{
+			map[string]any{
 				"interval": 5000,
 				"timeout":  10000,
 				"type":     "TIMEOUT",
@@ -92,12 +92,12 @@ func TestChangesInReminderNotificationRuleHashing(t *testing.T) {
 	hashWithReminder := resourceRuleHash(values)
 
 	// modify interval
-	values["reminder_notification"].([]interface{})[0].(map[string]interface{})["interval"] = 7000
+	values["reminder_notification"].([]any)[0].(map[string]any)["interval"] = 7000
 	hashWithChangedInterval := resourceRuleHash(values)
 	assert.NotEqual(t, hashWithReminder, hashWithChangedInterval)
 
 	// modify timeout
-	values["reminder_notification"].([]interface{})[0].(map[string]interface{})["timeout"] = 15000
+	values["reminder_notification"].([]any)[0].(map[string]any)["timeout"] = 15000
 	hashWithChangedTimeout := resourceRuleHash(values)
 	assert.NotEqual(t, hashWithChangedInterval, hashWithChangedTimeout)
 
@@ -114,16 +114,6 @@ func TestValidateSeverityAllowed(t *testing.T) {
 
 func TestValidateSeverityNotAllowed(t *testing.T) {
 	_, errors := validateSeverity("foo", "severity")
-	assert.Equal(t, len(errors), 1)
-}
-
-func TestValidateReminderTypeAllowed(t *testing.T) {
-	_, errors := validateReminderType("TIMEOUT", "reminder_type")
-	assert.Equal(t, len(errors), 0)
-}
-
-func TestValidateReminderTypeNotAllowed(t *testing.T) {
-	_, errors := validateReminderType("TIMEOUTT", "reminder_type")
 	assert.Equal(t, len(errors), 1)
 }
 
@@ -546,14 +536,14 @@ func testAccDetectorDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testTimeRangeStateDataV0() map[string]interface{} {
-	return map[string]interface{}{
+func testTimeRangeStateDataV0() map[string]any {
+	return map[string]any{
 		"time_range": "-1h",
 	}
 }
 
-func testTimeRangeStateDataV1() map[string]interface{} {
-	return map[string]interface{}{
+func testTimeRangeStateDataV1() map[string]any {
+	return map[string]any{
 		"time_range": 3600,
 	}
 }

--- a/templates/resources/detector.md.tmpl
+++ b/templates/resources/detector.md.tmpl
@@ -135,6 +135,10 @@ notifications = ["Webhook,,secret,url"]
   * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See [Set Up Detectors to Trigger Alerts](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html) for more info.
   * `runbook_url` - (Optional) URL of page to consult when an alert is triggered. This can be used with custom notification messages.
   * `tip` - (Optional) Plain text suggested first course of action, such as a command line to execute. This can be used with custom notification messages.
+  * `reminder_notification` - (Optional) Reminder notification in a detector rule lets you send multiple notifications for active alerts over a defined period of time. **Note:** This feature is not present in all accounts. Please contact support if you are unsure.
+    * `interval_ms` - (Required) The interval at which you want to receive the notifications, in milliseconds.
+    * `timeout_ms` - (Optional) The duration during which repeat notifications are sent, in milliseconds.
+    * `type` - (Required) Type of reminder notification. Currently, the only supported value is TIMEOUT.
 * `viz_options` - (Optional) Plot-level customization options, associated with a publish statement.
   * `label` - (Required) Label used in the publish statement that displays the plot (metric time series data) you want to customize.
   * `display_name` - (Optional) Specifies an alternate value for the Plot Name column of the Data Table associated with the chart.


### PR DESCRIPTION
# Warning

~It depends on the [changes](https://github.com/signalfx/signalfx-go/pull/243) made in signalfx-go library and it will show problems until the version of the client is bumped.~ It has been merged and I bumped the version manually.

# Context

We are adding a new feature, in closed preview, of defining reminder notification per detector rule.

# Changes

Adds a new `reminderNotification` field to the detector rule which allows for specifying how often the reminder for given notification should fire.