### PR TITLE
Fix: Ensure that we are reading write only data

### DIFF
--- a/internal/definition/provider/provider.go
+++ b/internal/definition/provider/provider.go
@@ -120,9 +120,8 @@ func New() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			team.ResourceName:           team.NewResource(),
-			detector.ResourceName:       detector.NewResource(),
-			organization.DataSourceName: organization.NewDataSource(),
+			team.ResourceName:     team.NewResource(),
+			detector.ResourceName: detector.NewResource(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			dimension.DataSourceName:    dimension.NewDataSource(),

--- a/internal/definition/provider/provider.go
+++ b/internal/definition/provider/provider.go
@@ -120,8 +120,9 @@ func New() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			team.ResourceName:     team.NewResource(),
-			detector.ResourceName: detector.NewResource(),
+			team.ResourceName:           team.NewResource(),
+			detector.ResourceName:       detector.NewResource(),
+			organization.DataSourceName: organization.NewDataSource(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			dimension.DataSourceName:    dimension.NewDataSource(),


### PR DESCRIPTION
## Context

The schema type was changed to write only, and it removes the default config fetch semantics.
This uses the recommendation https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/write-only-arguments

## Changes

- Fix pager duty integration