### PR TITLE
Update data_source.go | Use id (member ID) instead of userId as per SignalFx API documentation

### DIFF
--- a/internal/definition/organization/data_source.go
+++ b/internal/definition/organization/data_source.go
@@ -50,7 +50,7 @@ func datasourceRead(ctx context.Context, rd *schema.ResourceData, meta any) diag
 
 			for _, u := range results.Results {
 				tflog.Debug(ctx, "Retrieved user details", tfext.NewLogFields().JSON("user", u))
-				users = append(users, u.UserId)
+				users = append(users, u.Id)
 			}
 
 			if offset >= int(results.Count) {

--- a/internal/definition/organization/data_source_test.go
+++ b/internal/definition/organization/data_source_test.go
@@ -85,7 +85,7 @@ func TestDataSourceRead(t *testing.T) {
 					_ = json.NewEncoder(w).Encode(&organization.MemberSearchResults{
 						Count: 1,
 						Results: []*organization.Member{
-							{FullName: "user 01", UserId: "AAAAAAAA", Email: "user-01@example.com"},
+							{FullName: "user 01", Id: "AAAAAAAA", Email: "user-01@example.com"},
 						},
 					})
 				},


### PR DESCRIPTION

Updated the code to use id (member ID) instead of userId in accordance with the SignalFx Observability API documentation. The id field uniquely identifies a member and should be used in all references. This ensures consistency and aligns with the latest API expectations. Reference: 
https://dev.splunk.com/observability/reference/api/organizations/latest