### PR TITLE
Add an optional flag to skip saving the org token to state

### DIFF
--- a/docs/resources/org_token.md
+++ b/docs/resources/org_token.md
@@ -39,6 +39,7 @@ The following arguments are supported in the resource block:
 * `description` - (Optional) Description of the token.
 * `disabled` - (Optional) Flag that controls enabling the token. If set to `true`, the token is disabled, and you can't use it for authentication. Defaults to `false`.
 * `secret` - The secret token created by the API. You cannot set this value.
+* `store_secret` - (Optional) Whether to store the token's secret in the terraform state. Defaults to `true` for backward compatibility.
 * `notifications` - (Optional) Where to send notifications about this token's limits. See the [Notification Format](https://www.terraform.io/docs/providers/signalfx/r/detector.html#notification-format) laid out in detectors.
 * `host_or_usage_limits` - (Optional) Specify Usage-based limits for this token.
   * `host_limit` - (Optional) Max number of hosts that can use this token

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -140,6 +140,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"signalfx_dimension_values":      dataSourceDimensionValues(),
 			"signalfx_pagerduty_integration": dataSourcePagerDutyIntegration(),
+			"signalfx_org_token_lookup":      orgTokenLookupDataSource(),
 			organization.DataSourceName:      organization.NewDataSource(),
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/signalfx/resource_signalfx_org_token.go
+++ b/signalfx/resource_signalfx_org_token.go
@@ -151,7 +151,7 @@ func orgTokenResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Whether to store the token's secret in the terraform state. Set to false for improved security. Defaults to true for backward compatibility.",
+				Description: "Whether to store the token's secret in the terraform state. Defaults to true.",
 			},
 		},
 

--- a/signalfx/resource_signalfx_org_token_test.go
+++ b/signalfx/resource_signalfx_org_token_test.go
@@ -74,6 +74,284 @@ resource "signalfx_org_token" "mylimitorgtokenTOK1" {
 }
 `
 
+const orgTokenSecureConfig = `
+resource "signalfx_org_token" "secure_token" {
+  name = "SecureToken"
+  description = "Token with no secret storage"
+  store_secret = false
+  auth_scopes = ["INGEST", "API"]
+  disabled = false
+}
+`
+
+const orgTokenSecureWithLimitsConfig = `
+resource "signalfx_org_token" "secure_token_limits" {
+  name = "SecureTokenWithLimits"
+  description = "Token with limits and no secret storage"
+  store_secret = false
+  auth_scopes = ["INGEST"]
+  disabled = false
+  
+  host_or_usage_limits {
+    host_limit = 100
+    host_notification_threshold = 80
+    container_limit = 200
+    container_notification_threshold = 150
+    custom_metrics_limit = 1000
+    custom_metrics_notification_threshold = 800
+  }
+}
+`
+
+const orgTokenSecureWithDPMLimitsConfig = `
+resource "signalfx_org_token" "secure_token_dpm" {
+  name = "SecureTokenWithDPM"
+  description = "Token with DPM limits and no secret storage"
+  store_secret = false
+  auth_scopes = ["INGEST"]
+  
+  dpm_limits {
+    dpm_limit = 5000
+    dpm_notification_threshold = 4000
+  }
+}
+`
+
+const orgTokenSecureUpdatedConfig = `
+resource "signalfx_org_token" "secure_token" {
+  name = "SecureToken"
+  description = "Token with updated description and no secret storage"
+  store_secret = false
+  auth_scopes = ["INGEST", "API", "RUM"]
+  disabled = true
+}
+`
+
+const orgTokenBackwardCompatConfig = `
+resource "signalfx_org_token" "backward_compat_token" {
+  name = "BackwardCompatToken"
+  description = "Token with default behavior"
+  auth_scopes = ["INGEST"]
+}
+`
+
+const orgTokenExplicitStoreConfig = `
+resource "signalfx_org_token" "explicit_store_token" {
+  name = "ExplicitStoreToken"
+  description = "Token with explicit secret storage"
+  store_secret = true
+  auth_scopes = ["INGEST", "API"]
+}
+`
+
+func TestAccOrgTokenSecureStorage(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrgTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: orgTokenSecureConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "name", "SecureToken"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "description", "Token with no secret storage"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "store_secret", "false"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "disabled", "false"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "auth_scopes.#", "2"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "auth_scopes.0", "API"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "auth_scopes.1", "INGEST"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "secret", ""),
+				),
+			},
+			{
+				ResourceName:      "signalfx_org_token.secure_token",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_org_token.secure_token"),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccOrgTokenSecureStorageUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrgTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: orgTokenSecureConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "description", "Token with no secret storage"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "disabled", "false"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "secret", ""),
+				),
+			},
+			{
+				Config: orgTokenSecureUpdatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "description", "Token with updated description and no secret storage"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "disabled", "true"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "auth_scopes.#", "3"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token", "secret", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOrgTokenBackwardCompatibility(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrgTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: orgTokenBackwardCompatConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.backward_compat_token", "name", "BackwardCompatToken"),
+					resource.TestCheckResourceAttr("signalfx_org_token.backward_compat_token", "description", "Token with default behavior"),
+					resource.TestCheckResourceAttr("signalfx_org_token.backward_compat_token", "store_secret", "true"),
+					resource.TestCheckResourceAttrSet("signalfx_org_token.backward_compat_token", "secret"),
+				),
+			},
+			{
+				ResourceName:      "signalfx_org_token.backward_compat_token",
+				ImportState:       true,
+				ImportStateIdFunc: testAccStateIdFunc("signalfx_org_token.backward_compat_token"),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccOrgTokenSecureStorageWithDPMLimits(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrgTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: orgTokenSecureWithDPMLimitsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_dpm", "name", "SecureTokenWithDPM"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_dpm", "store_secret", "false"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_dpm", "dpm_limits.#", "1"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_dpm", "dpm_limits.0.dpm_limit", "5000"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_dpm", "dpm_limits.0.dpm_notification_threshold", "4000"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_dpm", "secret", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOrgTokenSecureStorageWithLimits(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrgTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: orgTokenSecureWithLimitsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "name", "SecureTokenWithLimits"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "store_secret", "false"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "host_or_usage_limits.#", "1"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "host_or_usage_limits.0.host_limit", "100"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "host_or_usage_limits.0.host_notification_threshold", "80"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "host_or_usage_limits.0.container_limit", "200"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "host_or_usage_limits.0.container_notification_threshold", "150"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "host_or_usage_limits.0.custom_metrics_limit", "1000"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "host_or_usage_limits.0.custom_metrics_notification_threshold", "800"),
+					resource.TestCheckResourceAttr("signalfx_org_token.secure_token_limits", "secret", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOrgTokenExplicitSecretStorage(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrgTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: orgTokenExplicitStoreConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.explicit_store_token", "name", "ExplicitStoreToken"),
+					resource.TestCheckResourceAttr("signalfx_org_token.explicit_store_token", "description", "Token with explicit secret storage"),
+					resource.TestCheckResourceAttr("signalfx_org_token.explicit_store_token", "store_secret", "true"),
+					resource.TestCheckResourceAttrSet("signalfx_org_token.explicit_store_token", "secret"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOrgTokenStoreSecretToggle(t *testing.T) {
+	const initialConfig = `
+resource "signalfx_org_token" "toggle_token" {
+  name = "ToggleToken"
+  description = "Token to test store_secret toggle"
+  store_secret = true
+  auth_scopes = ["INGEST"]
+}
+`
+
+	const updatedConfig = `
+resource "signalfx_org_token" "toggle_token" {
+  name = "ToggleToken"
+  description = "Token to test store_secret toggle"
+  store_secret = false
+  auth_scopes = ["INGEST"]
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrgTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.toggle_token", "store_secret", "true"),
+					// secret should be stored initially
+					resource.TestCheckResourceAttrSet("signalfx_org_token.toggle_token", "secret"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.toggle_token", "store_secret", "false"),
+					// secret should no longer be stored after toggle
+					resource.TestCheckResourceAttr("signalfx_org_token.toggle_token", "secret", ""),
+				),
+			},
+			{
+				Config: initialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgTokenResourceExists,
+					resource.TestCheckResourceAttr("signalfx_org_token.toggle_token", "store_secret", "true"),
+					// secret should be stored again after toggling back
+					resource.TestCheckResourceAttrSet("signalfx_org_token.toggle_token", "secret"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCreateUpdateOrgToken(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
## Summary

This PR introduces a feature for SignalFx organization tokens by adding:

- Optional secret storage control - A new store_secret parameter that allows users to prevent token secrets from being stored in Terraform state
- Token lookup data source - A new signalfx_org_token_lookup data source for retrieving existing token secrets

## Changes
### Functionality Enhancement - `store_secret` Parameter:
- Added a new optional `store_secret` boolean parameter to the signalfx_org_token resource
- Defaults to `true` for backward compatibility
- When set to`false`, the token secret is not stored in Terraform state, allowing the resource to be used for org token settings alone (e.g. per token limits)
- Modified `orgTokenAPIToTF` function to conditionally store the secret based on this setting

### New Data Source - `signalfx_org_token_lookup`
- Added signalfx_org_token_lookup data source to allow lookup of existing token secrets
- Provides a way to retrieve token secrets when store_secret is set to false on the resource
- Registered the new data source in the provider configuration

### Test Coverage

- `TestAccOrgTokenSecureStorage` - Tests tokens with store_secret = false
- `TestAccOrgTokenBackwardCompatibility` - Ensures existing behaviour is preserved
- `TestAccOrgTokenSecureStorageWithDPMLimits` - Tests secure storage with DPM limits
- `TestAccOrgTokenSecureStorageWithLimits` - Tests secure storage with usage limits
- `TestAccOrgTokenExplicitSecretStorage` - Tests explicit store_secret = true
- `TestAccOrgTokenStoreSecretToggle` - Tests toggling the store_secret parameter

### Inconsistency Check
- Replaced `fmt` with `log` for one of the debug logs to be consistent with the other logging.

## Benefits
- Enhanced Security - Users can now prevent token secrets from being stored in Terraform state files
- Backward Compatibility - Existing configurations continue to work without changes

## Examples
```terraform
# Secure token without secret storage
resource "signalfx_org_token" "secure_token" {
  name         = "MySecureToken"
  description  = "Token with no secret storage"
  store_secret = false
  auth_scopes  = ["API"]
}

# Lookup token secret when needed
data "signalfx_org_token_lookup" "my_token" {
  name = "MySecureToken"
}
```