### PR TITLE
Fix: Unifying color usage within provider

### DIFF
--- a/internal/check/color.go
+++ b/internal/check/color.go
@@ -44,7 +44,7 @@ func ColorHexValue() schema.SchemaValidateDiagFunc {
 				p,
 			)
 		}
-		if matched, _ := regexp.MatchString(`"^#[A-Fa-f0-9]{6}"`, s); !matched {
+		if matched, _ := regexp.MatchString(`^#[A-Fa-f0-9]{6}$`, s); !matched {
 			return tfext.AsErrorDiagnostics(
 				fmt.Errorf("value %q is not a valid hex color code", s),
 				p,

--- a/internal/check/color.go
+++ b/internal/check/color.go
@@ -5,6 +5,7 @@ package check
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -43,7 +44,7 @@ func ColorHexValue() schema.SchemaValidateDiagFunc {
 				p,
 			)
 		}
-		if len(s) != 7 || s[0] != '#' {
+		if matched, _ := regexp.MatchString(`"^#[A-Fa-f0-9]{6}"`, s); !matched {
 			return tfext.AsErrorDiagnostics(
 				fmt.Errorf("value %q is not a valid hex color code", s),
 				p,

--- a/internal/check/color.go
+++ b/internal/check/color.go
@@ -33,3 +33,22 @@ func ColorName() schema.SchemaValidateDiagFunc {
 		)
 	}
 }
+
+func ColorHexValue() schema.SchemaValidateDiagFunc {
+	return func(i any, p cty.Path) diag.Diagnostics {
+		s, ok := i.(string)
+		if !ok {
+			return tfext.AsErrorDiagnostics(
+				fmt.Errorf("expected %v to be of type string", i),
+				p,
+			)
+		}
+		if len(s) != 7 || s[0] != '#' {
+			return tfext.AsErrorDiagnostics(
+				fmt.Errorf("value %q is not a valid hex color code", s),
+				p,
+			)
+		}
+		return nil
+	}
+}

--- a/internal/check/color_test.go
+++ b/internal/check/color_test.go
@@ -52,3 +52,40 @@ func TestColorName(t *testing.T) {
 		})
 	}
 }
+
+func TestColorHexValue(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		val   any
+		diags diag.Diagnostics
+	}{
+		{
+			name: "no values provided",
+			val:  nil,
+			diags: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "expected <nil> to be of type string"},
+			},
+		},
+		{
+			name: "not a valid hex color code",
+			val:  "nop",
+			diags: diag.Diagnostics{
+				{Severity: diag.Error, Summary: "value \"nop\" is not a valid hex color code"},
+			},
+		},
+		{
+			name:  "valid hex color code",
+			val:   "#123456",
+			diags: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := ColorHexValue()(tc.val, cty.Path{})
+			assert.Equal(t, tc.diags, diags, "Must match the expected values")
+		})
+	}
+}

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	chart "github.com/signalfx/signalfx-go/chart"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
 	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
@@ -129,10 +130,10 @@ func heatmapChartResource() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"color": &schema.Schema{
-							Type:         schema.TypeString,
-							Required:     true,
-							Description:  "The color to use. Must be one of gray, blue, light_blue, navy, dark_orange, orange, dark_yellow, magenta, cerise, pink, violet, purple, gray_blue, dark_green, green, aquamarine, red, yellow, vivid_yellow, light_green, or lime_green.",
-							ValidateFunc: validateHeatmapChartColor,
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The color to use. Must be one of gray, blue, light_blue, navy, dark_orange, orange, dark_yellow, magenta, cerise, pink, violet, purple, gray_blue, dark_green, green, aquamarine, red, yellow, vivid_yellow, light_green, or lime_green.",
+							ValidateDiagFunc: check.ColorName(),
 						},
 						"gt": &schema.Schema{
 							Type:        schema.TypeFloat,
@@ -480,24 +481,4 @@ func heatmapchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
 	return config.Client.DeleteChart(context.TODO(), d.Id())
-}
-
-/*
-Validates the color_range field against a list of allowed words.
-*/
-func validateHeatmapChartColor(v interface{}, k string) (we []string, errors []error) {
-	value := v.(string)
-	keys := make([]string, 0, len(ChartColorsSlice))
-	found := false
-	for _, item := range ChartColorsSlice {
-		if value == item.name {
-			found = true
-		}
-		keys = append(keys, item.name)
-	}
-	if !found {
-		joinedColors := strings.Join(keys, ",")
-		errors = append(errors, fmt.Errorf("%s not allowed; must be either %s", value, joinedColors))
-	}
-	return
 }

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -20,8 +19,6 @@ import (
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
 	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
 )
-
-var validHexColor = regexp.MustCompile("^#[A-Fa-f0-9]{6}")
 
 func heatmapChartResource() *schema.Resource {
 	return &schema.Resource{
@@ -102,10 +99,10 @@ func heatmapChartResource() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"color": &schema.Schema{
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringMatch(validHexColor, "does not look like a hex color, similar to #0000ff"),
-							Description:  "The color range to use. The starting hex color value for data values in a heatmap chart. Specify the value as a 6-character hexadecimal value preceded by the '#' character, for example \"#ea1849\" (grass green).",
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: check.ColorHexValue(),
+							Description:      "The color range to use. The starting hex color value for data values in a heatmap chart. Specify the value as a 6-character hexadecimal value preceded by the '#' character, for example \"#ea1849\" (grass green).",
 						},
 						"min_value": &schema.Schema{
 							Type:        schema.TypeFloat,

--- a/signalfx/resource_signalfx_heatmap_chart_test.go
+++ b/signalfx/resource_signalfx_heatmap_chart_test.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -129,14 +127,4 @@ func testAccHeatmapChartDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func TestValidateHeatmapChartColors(t *testing.T) {
-	_, err := validateHeatmapChartColor("blue", "color")
-	assert.Equal(t, 0, len(err))
-}
-
-func TestValidateHeatmapChartColorsFail(t *testing.T) {
-	_, err := validateHeatmapChartColor("whatever", "color")
-	assert.Equal(t, 1, len(err))
 }

--- a/signalfx/resource_signalfx_list_chart.go
+++ b/signalfx/resource_signalfx_list_chart.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	chart "github.com/signalfx/signalfx-go/chart"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
 	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
@@ -138,10 +139,10 @@ func listChartResource() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"color": &schema.Schema{
-							Type:         schema.TypeString,
-							Required:     true,
-							Description:  "The color to use. Must be one of gray, blue, light_blue, navy, dark_orange, orange, dark_yellow, magenta, cerise, pink, violet, purple, gray_blue, dark_green, green, aquamarine, red, yellow, vivid_yellow, light_green, or lime_green.",
-							ValidateFunc: validateHeatmapChartColor,
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The color to use. Must be one of gray, blue, light_blue, navy, dark_orange, orange, dark_yellow, magenta, cerise, pink, violet, purple, gray_blue, dark_green, green, aquamarine, red, yellow, vivid_yellow, light_green, or lime_green.",
+							ValidateDiagFunc: check.ColorName(),
 						},
 						"gt": &schema.Schema{
 							Type:        schema.TypeFloat,
@@ -182,10 +183,10 @@ func listChartResource() *schema.Resource {
 							Description: "The label used in the publish statement that displays the plot (metric time series data) you want to customize",
 						},
 						"color": &schema.Schema{
-							Type:         schema.TypeString,
-							Optional:     true,
-							Description:  "Color to use",
-							ValidateFunc: validatePerSignalColor,
+							Type:             schema.TypeString,
+							Optional:         true,
+							Description:      "Color to use",
+							ValidateDiagFunc: check.ColorName(),
 						},
 						"display_name": &schema.Schema{
 							Type:        schema.TypeString,

--- a/signalfx/resource_signalfx_table_chart.go
+++ b/signalfx/resource_signalfx_table_chart.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	chart "github.com/signalfx/signalfx-go/chart"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/convert"
 	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
@@ -103,10 +104,10 @@ func tableChartResource() *schema.Resource {
 							Description: "The label used in the publish statement that displays the plot (metric time series data) you want to customize",
 						},
 						"color": &schema.Schema{
-							Type:         schema.TypeString,
-							Optional:     true,
-							Description:  "Color to use",
-							ValidateFunc: validatePerSignalColor,
+							Type:             schema.TypeString,
+							Optional:         true,
+							Description:      "Color to use",
+							ValidateDiagFunc: check.ColorName(),
 						},
 						"display_name": &schema.Schema{
 							Type:        schema.TypeString,

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -21,35 +21,6 @@ const (
 	CHART_APP_PATH = "/chart/"
 )
 
-type chartColor struct {
-	name string
-	hex  string
-}
-
-var ChartColorsSlice = []chartColor{
-	{"gray", "#999999"},
-	{"blue", "#0077c2"},
-	{"light_blue", "#00b9ff"},
-	{"navy", "#6CA2B7"},
-	{"dark_orange", "#b04600"},
-	{"orange", "#f47e00"},
-	{"dark_yellow", "#e5b312"},
-	{"magenta", "#bd468d"},
-	{"cerise", "#e9008a"},
-	{"pink", "#ff8dd1"},
-	{"violet", "#876ff3"},
-	{"purple", "#a747ff"},
-	{"gray_blue", "#ab99bc"},
-	{"dark_green", "#007c1d"},
-	{"green", "#05ce00"},
-	{"aquamarine", "#0dba8f"},
-	{"red", "#ea1849"},
-	{"yellow", "#ea1849"},
-	{"vivid_yellow", "#ea1849"},
-	{"light_green", "#acef7f"},
-	{"lime_green", "#6bd37e"},
-}
-
 func buildAppURL(appURL string, fragment string) (string, error) {
 	// Include a trailing slash, as without this Go doesn't add one for the fragment and that seems to be a required part of the url
 	u, err := url.Parse(appURL + "/")
@@ -83,33 +54,6 @@ func validateSortBy(v interface{}, k string) (we []string, errors []error) {
 		errors = append(errors, fmt.Errorf("%s not allowed; must start either with + or - (ascending or descending)", value))
 	}
 	return
-}
-
-func getNameFromPaletteColorsByIndex(index int) (string, error) {
-	for k, v := range PaletteColors {
-		if v == index {
-			return k, nil
-		}
-	}
-	return "", fmt.Errorf("Unknown color index %d", index)
-}
-
-func getNameFromFullPaletteColorsByIndex(index int) (string, error) {
-	for k, v := range FullPaletteColors {
-		if v == index {
-			return k, nil
-		}
-	}
-	return "", fmt.Errorf("Unknown color index %d", index)
-}
-
-func getNameFromChartColorsByIndex(index int) (string, error) {
-	for i, v := range ChartColorsSlice {
-		if i == index {
-			return v.name, nil
-		}
-	}
-	return "", fmt.Errorf("Unknown color index %d", index)
 }
 
 // Deprecated: Use `convert.SchemaListAll(d.Get("color_scale"), convert.ToChartSecondaryVisualization)` instead
@@ -177,35 +121,6 @@ func getLegendFieldOptions(d *schema.ResourceData) *chart.DataTableOptions {
 		}
 	}
 	return nil
-}
-
-/*
-Validates the color field against a list of allowed words.
-*/
-func validatePerSignalColor(v interface{}, k string) (we []string, errors []error) {
-	value := v.(string)
-	if _, ok := PaletteColors[value]; !ok {
-		keys := make([]string, 0, len(PaletteColors))
-		for k := range PaletteColors {
-			keys = append(keys, k)
-		}
-		joinedColors := strings.Join(keys, ",")
-		errors = append(errors, fmt.Errorf("%s not allowed; must be either %s", value, joinedColors))
-	}
-	return
-}
-
-func validateFullPaletteColors(v interface{}, k string) (we []string, errors []error) {
-	value := v.(string)
-	if _, ok := FullPaletteColors[value]; !ok {
-		keys := make([]string, 0, len(FullPaletteColors))
-		for k := range FullPaletteColors {
-			keys = append(keys, k)
-		}
-		joinedColors := strings.Join(keys, ",")
-		errors = append(errors, fmt.Errorf("%s not allowed; must be either %s", value, joinedColors))
-	}
-	return
 }
 
 func validateSecondaryVisualization(v interface{}, k string) (we []string, errors []error) {

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -9,36 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetNameFromChartColorsByIndex(t *testing.T) {
-	name, err := getNameFromChartColorsByIndex(4)
-	assert.Equal(t, "dark_orange", name, "Expected color name")
-	assert.NoError(t, err, "Expected no error for known color")
-
-	name, err = getNameFromChartColorsByIndex(44)
-	assert.Equal(t, "", name, "Expected empty string for missing index")
-	assert.Error(t, err, "Expected error for missing color index")
-}
-
-func TestGetNameFromPaletteColorsByIndex(t *testing.T) {
-	name, err := getNameFromPaletteColorsByIndex(2)
-	assert.Equal(t, "azure", name, "Expected color name")
-	assert.NoError(t, err, "Expected no error for known color")
-
-	name, err = getNameFromPaletteColorsByIndex(44)
-	assert.Equal(t, "", name, "Expected empty string for missing index")
-	assert.Error(t, err, "Expected error for missing color index")
-}
-
-func TestGetNameFromFullPaletteColorsByIndex(t *testing.T) {
-	name, err := getNameFromFullPaletteColorsByIndex(16)
-	assert.Equal(t, "red", name, "Expected color name")
-	assert.NoError(t, err, "Expected no error for known color")
-
-	name, err = getNameFromPaletteColorsByIndex(44)
-	assert.Equal(t, "", name, "Expected empty string for missing index")
-	assert.Error(t, err, "Expected error for missing color index")
-}
-
 func TestValidateSortByAscending(t *testing.T) {
 	_, errors := validateSortBy("+foo", "sort_by")
 	assert.Equal(t, 0, len(errors))
@@ -47,16 +17,6 @@ func TestValidateSortByAscending(t *testing.T) {
 func TestValidateSortByDescending(t *testing.T) {
 	_, errors := validateSortBy("-foo", "sort_by")
 	assert.Equal(t, 0, len(errors))
-}
-
-func TestValidateFullPaletteColors(t *testing.T) {
-	_, errors := validateFullPaletteColors("chartreuse", "color_theme")
-	assert.Equal(t, 0, len(errors))
-}
-
-func TestValidateFullPaletteColorsFail(t *testing.T) {
-	_, errors := validateFullPaletteColors("color_palette", "color_theme")
-	assert.Equal(t, 1, len(errors))
 }
 
 func TestValidateSortByNoDirection(t *testing.T) {


### PR DESCRIPTION
## Context

This removes all the various usages of different color palates and moves to using only one.

## Changes

- Removed historical values
- Adopting visual package everywhere.