### PR TITLE
chore: adopting github teams instead of directed users

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
-* @atoulme @benkeith-splunk
+* @splunk-terraform/terraform-provider-approvers @splunk-terraform/terraform-provider-maintainers
+
 signalfx/resource_signalfx_slo.go @dwalasek
 signalfx/resource_signalfx_slo_test.go @dwalasek
 website/docs/r/slo.html.markdown @dwalasek


### PR DESCRIPTION
# Context

In order to help management around the project, I've opted to use github teams. 

## Changes
- Replace default ownership to being one of the created github teams.