### PR TITLE
Feature: Enable auto detect custom domains

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ provider "signalfx" {
 
 - `api_url` (String) API URL for your Splunk Observability Cloud org, may include a realm
 - `auth_token` (String) Splunk Observability Cloud auth token
-- `custom_app_url` (String) Application URL for your Splunk Observability Cloud org, often customized for organizations using SSO
+- `custom_app_url` (String, Deprecated) Application URL for your Splunk Observability Cloud org, often customized for organizations using SSO
 - `email` (String) Used to create a session token instead of an API token, it requires the account to be configured to login with Email and Password
 - `feature_preview` (Map of Boolean) Allows for users to opt-in to new features that are considered experimental or not ready for general availabilty yet.
 - `organization_id` (String) Required if the user is configured to be part of multiple organizations

--- a/internal/providermeta/meta.go
+++ b/internal/providermeta/meta.go
@@ -5,7 +5,10 @@ package pmeta
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"net/url"
 	"path"
 	"slices"
@@ -166,4 +169,50 @@ func (m *Meta) Validate() (errs error) {
 		errs = multierr.Append(errs, errors.New("api url is not set"))
 	}
 	return errs
+}
+
+func (m *Meta) DetectCustomAPPURL(ctx context.Context) (string, error) {
+	// Note(MovieStoreGuy):
+	//
+	// This is a temporary solution to auto-detect the custom app URL.
+	// Once the changes are added into the go-sdk, this method can adopt the sfx client directly.
+
+	u, err := url.ParseRequestURI(m.APIURL)
+	if err != nil {
+		return "", err
+	}
+	u.Path = "/v2/organization"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-SF-Token", m.AuthToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		tflog.Error(ctx, "Failed to auto-detect custom app URL", map[string]any{
+			"status_code": resp.StatusCode,
+			"body":        string(body),
+		})
+		return "", errors.New("failed fetching organization details")
+	}
+
+	var content map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&content); err != nil {
+		return "", err
+	}
+
+	if site, ok := content["url"].(string); ok {
+		return site, nil
+	}
+	// Failover to the provided value
+	return m.CustomAppURL, nil
 }

--- a/internal/providermeta/meta_test.go
+++ b/internal/providermeta/meta_test.go
@@ -381,7 +381,7 @@ func TestMergeProviderTeams(t *testing.T) {
 	}
 }
 
-func TestDetectCustomAPPULR(t *testing.T) {
+func TestDetectCustomAPPURL(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -456,4 +456,17 @@ func TestDetectCustomAPPULR(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMetaDetectorCustomAppURL_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid api name", func(t *testing.T) {
+		m := &Meta{
+			APIURL: "\tinvalid",
+		}
+
+		_, err := m.DetectCustomAPPURL(context.Background())
+		assert.Error(t, err, "Must return an error when api URL is invalid")
+	})
 }

--- a/internal/providermeta/meta_test.go
+++ b/internal/providermeta/meta_test.go
@@ -391,12 +391,12 @@ func TestDetectCustomAPPULR(t *testing.T) {
 		errVal  string
 	}{
 		{
-			name: "not authorised",
+			name: "not authorized",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				_, _ = io.Copy(io.Discard, r.Body)
 				_ = r.Body.Close()
 
-				http.Error(w, "not authorised", http.StatusUnauthorized)
+				http.Error(w, "not authorized", http.StatusUnauthorized)
 			},
 			expect: "",
 			errVal: "failed fetching organization details",
@@ -424,6 +424,17 @@ func TestDetectCustomAPPULR(t *testing.T) {
 			},
 			expect: "https://custom.signalfx.com",
 			errVal: "",
+		},
+		{
+			name: "invalid json content suppplied",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				_ = r.Body.Close()
+
+				_, _ = w.Write([]byte("{"))
+			},
+			expect: "",
+			errVal: "unexpected EOF",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -61,6 +61,7 @@ func Provider() *schema.Provider {
 			"custom_app_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Deprecated:  "Remove the definition, the provider will automatically populate the custom app URL as needed",
 				DefaultFunc: schema.EnvDefaultFunc("SFX_CUSTOM_APP_URL", "https://app.signalfx.com"),
 				Description: "Application URL for your Splunk Observability Cloud org, often customized for organizations using SSO",
 			},
@@ -232,12 +233,17 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 	if url, ok := data.GetOk("api_url"); ok {
 		config.APIURL = url.(string)
 	}
-	if customAppURL, ok := data.GetOk("custom_app_url"); ok {
-		config.CustomAppURL = customAppURL.(string)
-	}
 
 	if err = config.Validate(); err != nil {
 		return nil, err
+	}
+
+	if site, err := config.DetectCustomAPPURL(context.TODO()); err != nil {
+		if app, ok := data.GetOk("custom_app_url"); ok {
+			config.CustomAppURL = app.(string)
+		}
+	} else {
+		config.CustomAppURL = site
 	}
 
 	netTransport := logging.NewTransport("SignalFx", &http.Transport{


### PR DESCRIPTION
# Context

This will allow for the provider to infer the custom domain that is used for our customers instead of requiring a user to set it.

## Changes

- Deprecates `custom_app_url` within the provider
- Adds support for detecting the custom domain for the organization settings.