### PR TITLE
Feature: using emeddables to reduce code duplication

### DIFF
--- a/internal/framework/embed/datasource_data.go
+++ b/internal/framework/embed/datasource_data.go
@@ -1,0 +1,35 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwembed
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
+)
+
+// DatasourceData is an embeddable struct that provides common functionality for Datasource,
+// since it implements the extended method required for [Datasource.DatasourceWithConfigure].
+type DatasourceData struct {
+	meta *pmeta.Meta
+}
+
+func (dd *DatasourceData) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if meta, ok := req.ProviderData.(*pmeta.Meta); !ok {
+		resp.Diagnostics.AddAttributeError(
+			path.Empty(),
+			"Missing Provider Data",
+			"Provider data must be configured before using the datasource.",
+		)
+	} else {
+		dd.meta = meta
+	}
+}
+
+func (dd *DatasourceData) Details() *pmeta.Meta {
+	return dd.meta
+}

--- a/internal/framework/embed/datasource_data_test.go
+++ b/internal/framework/embed/datasource_data_test.go
@@ -1,0 +1,70 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwembed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/assert"
+
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
+)
+
+func TestDatasource_Configure(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		providerData      any
+		expectDiagnostics bool
+		expectedMeta      *pmeta.Meta
+	}{
+		{
+			name:              "valid provider data",
+			providerData:      &pmeta.Meta{},
+			expectDiagnostics: false,
+			expectedMeta:      &pmeta.Meta{},
+		},
+		{
+			name:              "invalid provider data - wrong type",
+			providerData:      "invalid",
+			expectDiagnostics: true,
+			expectedMeta:      nil,
+		},
+		{
+			name:              "nil provider data",
+			providerData:      nil,
+			expectDiagnostics: true,
+			expectedMeta:      nil,
+		},
+		{
+			name:              "invalid provider data - int type",
+			providerData:      42,
+			expectDiagnostics: true,
+			expectedMeta:      nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ds := &DatasourceData{}
+			req := datasource.ConfigureRequest{
+				ProviderData: tc.providerData,
+			}
+			resp := &datasource.ConfigureResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			ds.Configure(context.Background(), req, resp)
+
+			assert.Equal(t, tc.expectDiagnostics, resp.Diagnostics.HasError(), "Expected diagnostics to match")
+			assert.Equal(t, tc.expectedMeta, ds.Details(), "Expected meta to match")
+		})
+	}
+}

--- a/internal/framework/embed/resource_data.go
+++ b/internal/framework/embed/resource_data.go
@@ -1,0 +1,35 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwembed
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
+)
+
+// ResourceData is an embeddable struct that provides common functionality for resources,
+// since it implements the extended method required for [resource.ResourceWithConfigure].
+type ResourceData struct {
+	meta *pmeta.Meta
+}
+
+func (rd *ResourceData) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if meta, ok := req.ProviderData.(*pmeta.Meta); !ok {
+		resp.Diagnostics.AddAttributeError(
+			path.Empty(),
+			"Missing Provider Data",
+			"Provider data must be configured before using the resource.",
+		)
+	} else {
+		rd.meta = meta
+	}
+}
+
+func (rd *ResourceData) Details() *pmeta.Meta {
+	return rd.meta
+}

--- a/internal/framework/embed/resource_data_test.go
+++ b/internal/framework/embed/resource_data_test.go
@@ -1,0 +1,70 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwembed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/stretchr/testify/assert"
+
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
+)
+
+func TestResource_Configure(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		providerData      any
+		expectDiagnostics bool
+		expectedMeta      *pmeta.Meta
+	}{
+		{
+			name:              "valid provider data",
+			providerData:      &pmeta.Meta{},
+			expectDiagnostics: false,
+			expectedMeta:      &pmeta.Meta{},
+		},
+		{
+			name:              "invalid provider data - wrong type",
+			providerData:      "invalid",
+			expectDiagnostics: true,
+			expectedMeta:      nil,
+		},
+		{
+			name:              "nil provider data",
+			providerData:      nil,
+			expectDiagnostics: true,
+			expectedMeta:      nil,
+		},
+		{
+			name:              "invalid provider data - int type",
+			providerData:      42,
+			expectDiagnostics: true,
+			expectedMeta:      nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &ResourceData{}
+			req := resource.ConfigureRequest{
+				ProviderData: tc.providerData,
+			}
+			resp := &resource.ConfigureResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			r.Configure(context.Background(), req, resp)
+
+			assert.Equal(t, tc.expectDiagnostics, resp.Diagnostics.HasError(), "Expected diagnostics to match")
+			assert.Equal(t, tc.expectedMeta, r.Details(), "Expected meta to match")
+		})
+	}
+}


### PR DESCRIPTION
## Context

In order to simplify a part of what is being considered migrated across, this will allow for types to embed these into structs, to then provide the configuration needed.

## Change

- Adding framework embed types.