### PR TITLE
chore: Ensure framework provider is configured

### DIFF
--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -291,13 +291,16 @@ func (op *ollyProvider) ValidateConfig(ctx context.Context, req provider.Validat
 	switch {
 	case !model.AuthToken.IsNull():
 		tflog.Debug(ctx, "Using auth token for authentication")
-	case !model.Email.IsNull() && !model.Password.IsNull():
+	case !model.Email.IsNull() &&
+		!model.Password.IsNull() &&
+		!model.OrganizationID.IsNull():
 		tflog.Debug(ctx, "Using email and password for authentication")
 	default:
 		p := path.Empty().
 			AtName("auth_token").
 			AtName("email").
-			AtName("password")
+			AtName("password").
+			AtName("organization_id")
 		resp.Diagnostics.AddAttributeError(
 			p,
 			"Missing Authentication Method",

--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -5,16 +5,28 @@ package internalframework
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+	"github.com/signalfx/signalfx-go"
 
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/feature"
 	internalfunction "github.com/splunk-terraform/terraform-provider-signalfx/internal/framework/function"
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+	"github.com/splunk-terraform/terraform-provider-signalfx/internal/track"
 )
 
 type ollyProvider struct {
@@ -23,8 +35,9 @@ type ollyProvider struct {
 }
 
 var (
-	_ provider.Provider              = (*ollyProvider)(nil)
-	_ provider.ProviderWithFunctions = (*ollyProvider)(nil)
+	_ provider.Provider                   = (*ollyProvider)(nil)
+	_ provider.ProviderWithFunctions      = (*ollyProvider)(nil)
+	_ provider.ProviderWithValidateConfig = (*ollyProvider)(nil)
 )
 
 func NewProvider(version string, opts ...ProviderOption) provider.Provider {
@@ -111,12 +124,136 @@ func (op *ollyProvider) Schema(ctx context.Context, req provider.SchemaRequest, 
 func (op *ollyProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	model := newDefaultOllyProviderModel()
 
-	diags := req.Config.Get(ctx, model)
-	if diags.HasError() {
-		resp.Diagnostics = diags
+	if errs := req.Config.Get(ctx, model); errs.HasError() {
+		// The original code uses unexposed types that make it hard to validate
+		// however, this path should not be possible to hit in typical usage.
+		resp.Diagnostics.AddAttributeError(
+			path.Empty(),
+			"Internal Provider Error",
+			"An expected error occurred while configuring the provider. Please report this issue to the provider developers.",
+		)
+		tflog.Error(ctx, "Error configuring provider", tfext.NewLogFields().Field("errors", errs))
 		return
 	}
 
+	meta := &pmeta.Meta{
+		Registry:       op.features,
+		Email:          model.Email.ValueString(),
+		Password:       model.Password.ValueString(),
+		OrganizationID: model.OrganizationID.ValueString(),
+	}
+
+	for _, val := range model.Tags.Elements() {
+		if tag, ok := val.(types.String); ok && !tag.IsNull() {
+			meta.Tags = append(meta.Tags, tag.ValueString())
+		}
+	}
+
+	for _, val := range model.Teams.Elements() {
+		if team, ok := val.(types.String); ok && !team.IsNull() {
+			meta.Teams = append(meta.Teams, team.ValueString())
+		}
+	}
+
+	for _, lookup := range pmeta.NewDefaultProviderLookups() {
+		if err := lookup.Do(ctx, meta); err != nil {
+			tflog.Debug(ctx,
+				"Issue trying to load external provider configuration, skipping",
+				tfext.ErrorLogFields(err),
+			)
+		}
+	}
+
+	if !model.AuthToken.IsNull() {
+		meta.AuthToken = model.AuthToken.ValueString()
+	}
+
+	if !model.APIURL.IsNull() {
+		meta.APIURL = model.APIURL.ValueString()
+	}
+
+	if err := meta.Validate(); err != nil {
+		resp.Diagnostics.AddError("Issue configuring provider", err.Error())
+		return
+	}
+
+	var (
+		attempts = int(model.RetryMaxAttempts.ValueInt32())
+		timeout  = time.Duration(model.TimeoutSeconds.ValueInt64()) * time.Second
+		waitmin  = time.Duration(model.RetryWaitMinSeconds.ValueInt64()) * time.Second
+		waitmax  = time.Duration(model.RetryWaitMaxSeconds.ValueInt64()) * time.Second
+	)
+
+	token, err := meta.LoadSessionToken(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Issue loading session token", err.Error())
+		return
+	}
+
+	rc := retryablehttp.NewClient()
+	rc.RetryMax = attempts
+	rc.RetryWaitMin = waitmin
+	rc.RetryWaitMax = waitmax
+	rc.HTTPClient.Timeout = timeout
+	rc.HTTPClient.Transport = logging.NewSubsystemLoggingHTTPTransport("signalfx", &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		DialContext:         (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+		TLSHandshakeTimeout: 5 * time.Second,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
+	})
+
+	meta.Client, err = signalfx.NewClient(
+		token,
+		signalfx.APIUrl(meta.APIURL),
+		signalfx.HTTPClient(rc.StandardClient()),
+		signalfx.UserAgent(fmt.Sprintf("Terraform %s terraform-provider-signalfx/%s", req.TerraformVersion, op.version)),
+	)
+
+	if err != nil {
+		resp.Diagnostics.AddError("Issue creating Signalfx client", err.Error())
+		return
+	}
+
+	tflog.Debug(ctx, "Configured settings for http client", tfext.NewLogFields().
+		Field("attempts", attempts).
+		Duration("timeout", timeout).
+		Duration("wait_min", waitmin).
+		Duration("wait_max", waitmax),
+	)
+
+	if site, err := meta.DetectCustomAPPURL(ctx); err != nil {
+		if !model.CustomAppURL.IsNull() {
+			meta.CustomAppURL = model.CustomAppURL.ValueString()
+		}
+	} else {
+		meta.CustomAppURL = site
+	}
+
+	for name, val := range model.FeaturePreview.Elements() {
+		active := val.Equal(types.BoolValue(true))
+		if err := pmeta.LoadPreviewRegistry(ctx, meta).Configure(ctx, name, active); err != nil {
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("feature_preview").AtMapKey(name),
+				"Failed to load feature preview",
+				err.Error(),
+			)
+		}
+	}
+
+	if gate, ok := pmeta.LoadPreviewRegistry(ctx, meta).Get(feature.PreviewProviderTracking); ok && gate.Enabled() {
+		tracking, err := track.ReadGitDetails(ctx)
+		if err != nil {
+			tflog.Info(ctx, "Unable to load git details, skipping", tfext.ErrorLogFields(err))
+		} else {
+			meta.Tags = append(meta.Tags, tracking.Tags()...)
+		}
+	}
+
+	// Ensure all the data sources are set so they can be consumed by each of the components.
+	resp.DataSourceData = meta
+	resp.ResourceData = meta
+	resp.EphemeralResourceData = meta
 }
 
 func (op *ollyProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
@@ -132,5 +269,39 @@ func (op *ollyProvider) Resources(ctx context.Context) []func() resource.Resourc
 func (op *ollyProvider) Functions(ctx context.Context) []func() function.Function {
 	return []func() function.Function{
 		internalfunction.NewTimeRangeParser,
+	}
+}
+
+func (op *ollyProvider) ValidateConfig(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
+	model := newDefaultOllyProviderModel()
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if model.APIURL.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("api_url"),
+			"Missing API Endpoint",
+			"Field must be set to a valid endpoint for the Splunk Observability Cloud provider.",
+		)
+	}
+
+	switch {
+	case !model.AuthToken.IsNull():
+		tflog.Debug(ctx, "Using auth token for authentication")
+	case !model.Email.IsNull() && !model.Password.IsNull():
+		tflog.Debug(ctx, "Using email and password for authentication")
+	default:
+		p := path.Empty().
+			AtName("auth_token").
+			AtName("email").
+			AtName("password")
+		resp.Diagnostics.AddAttributeError(
+			p,
+			"Missing Authentication Method",
+			"Either 'auth_token' or both 'email' and 'password' must be set for authentication.",
+		)
 	}
 }

--- a/internal/framework/provider_model.go
+++ b/internal/framework/provider_model.go
@@ -5,9 +5,9 @@ package internalframework
 
 import "github.com/hashicorp/terraform-plugin-framework/types"
 
-type ollyProviderModel struct {
-	AuthToken           types.String `tfsdk:"auth_token"`
+type OllyProviderModel struct {
 	APIURL              types.String `tfsdk:"api_url"`
+	AuthToken           types.String `tfsdk:"auth_token"`
 	CustomAppURL        types.String `tfsdk:"custom_app_url"`
 	TimeoutSeconds      types.Int64  `tfsdk:"timeout_seconds"`
 	RetryMaxAttempts    types.Int32  `tfsdk:"retry_max_attempts"`
@@ -21,8 +21,8 @@ type ollyProviderModel struct {
 	Teams               types.List   `tfsdk:"teams"`
 }
 
-func newDefaultOllyProviderModel() *ollyProviderModel {
-	return &ollyProviderModel{
+func newDefaultOllyProviderModel() *OllyProviderModel {
+	return &OllyProviderModel{
 		AuthToken:           types.StringNull(),
 		APIURL:              types.StringNull(),
 		CustomAppURL:        types.StringNull(),

--- a/internal/framework/provider_test.go
+++ b/internal/framework/provider_test.go
@@ -378,7 +378,8 @@ func TestProviderValidateConfig(t *testing.T) {
 					path.Empty().
 						AtName("auth_token").
 						AtName("email").
-						AtName("password"),
+						AtName("password").
+						AtName("organization_id"),
 					"Missing Authentication Method",
 					"Either 'auth_token' or both 'email' and 'password' must be set for authentication.",
 				),

--- a/internal/framework/provider_test.go
+++ b/internal/framework/provider_test.go
@@ -5,14 +5,81 @@ package internalframework
 
 import (
 	"context"
+	"maps"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/feature"
+	pmeta "github.com/splunk-terraform/terraform-provider-signalfx/internal/providermeta"
 )
+
+func NewTestConfig(p provider.Provider, values map[string]tftypes.Value) tfsdk.Config {
+	schema := &provider.SchemaResponse{}
+	p.Schema(context.Background(), provider.SchemaRequest{}, schema)
+	data := map[string]tftypes.Value{
+		"auth_token":             tftypes.NewValue(tftypes.String, nil),
+		"api_url":                tftypes.NewValue(tftypes.String, nil),
+		"custom_app_url":         tftypes.NewValue(tftypes.String, nil),
+		"timeout_seconds":        tftypes.NewValue(tftypes.Number, nil),
+		"retry_max_attempts":     tftypes.NewValue(tftypes.Number, nil),
+		"retry_wait_min_seconds": tftypes.NewValue(tftypes.Number, nil),
+		"retry_wait_max_seconds": tftypes.NewValue(tftypes.Number, nil),
+		"email":                  tftypes.NewValue(tftypes.String, nil),
+		"password":               tftypes.NewValue(tftypes.String, nil),
+		"organization_id":        tftypes.NewValue(tftypes.String, nil),
+		"feature_preview":        tftypes.NewValue(tftypes.Map{ElementType: tftypes.Bool}, nil),
+		"tags":                   tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+		"teams":                  tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+	}
+	maps.Copy(data, values)
+	return tfsdk.Config{
+		Schema: schema.Schema,
+		Raw: tftypes.NewValue(
+			tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"auth_token":             tftypes.String,
+					"api_url":                tftypes.String,
+					"custom_app_url":         tftypes.String,
+					"timeout_seconds":        tftypes.Number,
+					"retry_max_attempts":     tftypes.Number,
+					"retry_wait_min_seconds": tftypes.Number,
+					"retry_wait_max_seconds": tftypes.Number,
+					"email":                  tftypes.String,
+					"password":               tftypes.String,
+					"organization_id":        tftypes.String,
+					"feature_preview":        tftypes.Map{ElementType: tftypes.Bool},
+					"tags":                   tftypes.List{ElementType: tftypes.String},
+					"teams":                  tftypes.List{ElementType: tftypes.String},
+				},
+				OptionalAttributes: map[string]struct{}{
+					"auth_token":             {},
+					"api_url":                {},
+					"custom_app_url":         {},
+					"timeout_seconds":        {},
+					"retry_max_attempts":     {},
+					"retry_wait_min_seconds": {},
+					"retry_wait_max_seconds": {},
+					"email":                  {},
+					"password":               {},
+					"organization_id":        {},
+					"feature_preview":        {},
+					"tags":                   {},
+					"teams":                  {},
+				},
+			},
+			data,
+		),
+	}
+}
 
 func TestNewProvider(t *testing.T) {
 	t.Parallel()
@@ -43,28 +110,6 @@ func TestProviderSchema(t *testing.T) {
 	assert.NotNil(t, resp.Schema, "Schema should not be nil")
 }
 
-func TestProviderConfigure(t *testing.T) {
-	t.Parallel()
-
-	p := NewProvider("1.0.0")
-	schema := &provider.SchemaResponse{}
-	p.Schema(context.Background(), provider.SchemaRequest{}, schema)
-
-	resp := &provider.ConfigureResponse{}
-
-	p.Configure(
-		context.Background(),
-		provider.ConfigureRequest{
-			Config: tfsdk.Config{
-				Schema: schema.Schema,
-			},
-		},
-		resp,
-	)
-
-	assert.NotEmpty(t, resp.Diagnostics, "ConfigureResponse should not have any diagnostics")
-}
-
 func TestProviderDataSources(t *testing.T) {
 	t.Parallel()
 
@@ -89,5 +134,289 @@ func TestProviderFunctions(t *testing.T) {
 		assert.NotNil(t, fp.Functions(context.Background()), "ProviderWithFunctions should return non-nil functions")
 	} else {
 		assert.Fail(t, "Provider does not implement ProviderWithFunctions")
+	}
+}
+
+func TestProviderConfigure(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		data   func(t *testing.T) map[string]tftypes.Value
+		issues diag.Diagnostics
+		expect *pmeta.Meta
+	}{
+		{
+			name: "No data set",
+			data: func(_ *testing.T) map[string]tftypes.Value {
+				return map[string]tftypes.Value{}
+			},
+			issues: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Issue configuring provider",
+					"missing auth token or email and password; api url is not set",
+				),
+			},
+			expect: nil,
+		},
+		{
+			name: "Sets minimal required values",
+			data: func(_ *testing.T) map[string]tftypes.Value {
+				return map[string]tftypes.Value{
+					"api_url":                tftypes.NewValue(tftypes.String, "http://localhost"),
+					"auth_token":             tftypes.NewValue(tftypes.String, "my-secret-token"),
+					"custom_app_url":         tftypes.NewValue(tftypes.String, nil),
+					"timeout_seconds":        tftypes.NewValue(tftypes.Number, nil),
+					"retry_max_attempts":     tftypes.NewValue(tftypes.Number, nil),
+					"retry_wait_min_seconds": tftypes.NewValue(tftypes.Number, nil),
+					"retry_wait_max_seconds": tftypes.NewValue(tftypes.Number, nil),
+					"email":                  tftypes.NewValue(tftypes.String, nil),
+					"password":               tftypes.NewValue(tftypes.String, nil),
+					"organization_id":        tftypes.NewValue(tftypes.String, nil),
+					"feature_preview":        tftypes.NewValue(tftypes.Map{ElementType: tftypes.Bool}, nil),
+					"tags":                   tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+					"teams":                  tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+				}
+			},
+			issues: nil,
+			expect: &pmeta.Meta{
+				APIURL:    "http://localhost",
+				AuthToken: "my-secret-token",
+			},
+		},
+		{
+			name: "Sets operational values",
+			data: func(_ *testing.T) map[string]tftypes.Value {
+				return map[string]tftypes.Value{
+					"api_url":         tftypes.NewValue(tftypes.String, "http://localhost"),
+					"auth_token":      tftypes.NewValue(tftypes.String, "my-secret-token"),
+					"feature_preview": tftypes.NewValue(tftypes.Map{ElementType: tftypes.Bool}, nil),
+					"tags": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "tag1"),
+						tftypes.NewValue(tftypes.String, "tag2"),
+					}),
+					"teams": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "team1"),
+						tftypes.NewValue(tftypes.String, "team2"),
+					}),
+				}
+			},
+			expect: &pmeta.Meta{
+				Registry:  feature.GetGlobalRegistry(),
+				APIURL:    "http://localhost",
+				AuthToken: "my-secret-token",
+				Tags:      []string{"tag1", "tag2"},
+				Teams:     []string{"team1", "team2"},
+			},
+		},
+		{
+			name: "Sets operational values and feature preview",
+			data: func(_ *testing.T) map[string]tftypes.Value {
+				return map[string]tftypes.Value{
+					"api_url":    tftypes.NewValue(tftypes.String, "http://localhost"),
+					"auth_token": tftypes.NewValue(tftypes.String, "my-secret-token"),
+					"feature_preview": tftypes.NewValue(tftypes.Map{ElementType: tftypes.Bool}, map[string]tftypes.Value{
+						"new_feature": tftypes.NewValue(tftypes.Bool, true),
+					}),
+					"tags": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "tag1"),
+						tftypes.NewValue(tftypes.String, "tag2"),
+					}),
+					"teams": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "team1"),
+						tftypes.NewValue(tftypes.String, "team2"),
+					}),
+				}
+			},
+			issues: []diag.Diagnostic{
+				diag.WithPath(
+					path.Root("feature_preview").AtMapKey("new_feature"),
+					diag.NewWarningDiagnostic("Failed to load feature preview", "no preview with id \"new_feature\" found"),
+				),
+			},
+			expect: &pmeta.Meta{
+				Registry:  feature.GetGlobalRegistry(),
+				APIURL:    "http://localhost",
+				AuthToken: "my-secret-token",
+				Tags:      []string{"tag1", "tag2"},
+				Teams:     []string{"team1", "team2"},
+			},
+		},
+		{
+			name: "Custom Domain is set",
+			data: func(_ *testing.T) map[string]tftypes.Value {
+				mux := http.NewServeMux()
+				mux.HandleFunc("GET /v2/organization", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"url": "https://custom-domain.example.com"}`))
+				})
+
+				s := httptest.NewServer(mux)
+				t.Cleanup(s.Close)
+				return map[string]tftypes.Value{
+					"api_url":         tftypes.NewValue(tftypes.String, s.URL),
+					"auth_token":      tftypes.NewValue(tftypes.String, "my-secret-token"),
+					"feature_preview": tftypes.NewValue(tftypes.Map{ElementType: tftypes.Bool}, nil),
+					"tags": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "tag1"),
+						tftypes.NewValue(tftypes.String, "tag2"),
+					}),
+					"teams": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "team1"),
+						tftypes.NewValue(tftypes.String, "team2"),
+					}),
+				}
+			},
+			issues: nil,
+			expect: &pmeta.Meta{
+				Registry:     feature.GetGlobalRegistry(),
+				APIURL:       "http://localhost",
+				AuthToken:    "my-secret-token",
+				CustomAppURL: "https://custom-domain.example.com",
+				Tags:         []string{"tag1", "tag2"},
+				Teams:        []string{"team1", "team2"},
+			},
+		},
+		{
+			name: "Custom Domain is provided from user config",
+			data: func(_ *testing.T) map[string]tftypes.Value {
+				return map[string]tftypes.Value{
+					"api_url":         tftypes.NewValue(tftypes.String, "http://localhost"),
+					"auth_token":      tftypes.NewValue(tftypes.String, "my-secret-token"),
+					"custom_app_url":  tftypes.NewValue(tftypes.String, "https://my-provided.domain.signalfx.com"),
+					"feature_preview": tftypes.NewValue(tftypes.Map{ElementType: tftypes.Bool}, nil),
+					"tags": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "tag1"),
+						tftypes.NewValue(tftypes.String, "tag2"),
+					}),
+					"teams": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "team1"),
+						tftypes.NewValue(tftypes.String, "team2"),
+					}),
+				}
+			},
+			issues: nil,
+			expect: &pmeta.Meta{
+				Registry:     feature.GetGlobalRegistry(),
+				APIURL:       "http://localhost",
+				AuthToken:    "my-secret-token",
+				CustomAppURL: "https://my-provided.domain.signalfx.com",
+				Tags:         []string{"tag1", "tag2"},
+				Teams:        []string{"team1", "team2"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := NewProvider(
+				t.Name(),
+			)
+
+			schema := &provider.SchemaResponse{}
+			p.Schema(context.Background(), provider.SchemaRequest{}, schema)
+			assert.NotNil(t, schema.Schema, "Schema should not be nil")
+
+			resp := &provider.ConfigureResponse{}
+			p.Configure(
+				context.Background(),
+				provider.ConfigureRequest{
+					TerraformVersion: "1.0.0",
+					Config:           NewTestConfig(p, tc.data(t)),
+				},
+				resp,
+			)
+			if !assert.Equal(t, tc.issues, resp.Diagnostics, "Diagnostics should match expected issues") {
+				for _, issue := range resp.Diagnostics {
+					t.Logf("Issue: %s - %s", issue.Summary(), issue.Detail())
+				}
+			}
+			if tc.expect == nil {
+				assert.Nil(t, resp.DataSourceData, "DataSourceData should be nil when expect is nil")
+				assert.Nil(t, resp.ResourceData, "ResourceData should be nil when expect is nil")
+				assert.Nil(t, resp.EphemeralResourceData, "EphemeralResourceData should be nil when expect is nil")
+				return
+			}
+			assert.NotNil(t, resp.DataSourceData, "DataSourceData should not be nil when expect is set")
+			assert.NotNil(t, resp.ResourceData, "ResourceData should not be nil when expect is set")
+			assert.NotNil(t, resp.EphemeralResourceData, "EphemeralResourceData should not be nil when expect is set")
+
+			meta := resp.DataSourceData.(*pmeta.Meta)
+			assert.NotEmpty(t, meta.APIURL, "APIURL should not be empty")
+			assert.Equal(t, tc.expect.AuthToken, meta.AuthToken, "AuthToken should match expected")
+			assert.Equal(t, tc.expect.CustomAppURL, meta.CustomAppURL, "CustomAppURL should match expected")
+			assert.Equal(t, tc.expect.Email, meta.Email, "Email should match expected")
+			assert.Equal(t, tc.expect.Password, meta.Password, "Password should match expected")
+			assert.Equal(t, tc.expect.OrganizationID, meta.OrganizationID, "OrganizationID should match expected")
+			assert.Equal(t, tc.expect.Tags, meta.Tags, "Tags should match expected")
+			assert.Equal(t, tc.expect.Teams, meta.Teams, "Teams should match expected")
+		})
+	}
+}
+
+func TestProviderValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		data   func(t *testing.T) map[string]tftypes.Value
+		issues diag.Diagnostics
+	}{
+		{
+			name: "No data set",
+			data: func(_ *testing.T) map[string]tftypes.Value {
+				return map[string]tftypes.Value{}
+			},
+			issues: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("api_url"),
+					"Missing API Endpoint",
+					"Field must be set to a valid endpoint for the Splunk Observability Cloud provider.",
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Empty().
+						AtName("auth_token").
+						AtName("email").
+						AtName("password"),
+					"Missing Authentication Method",
+					"Either 'auth_token' or both 'email' and 'password' must be set for authentication.",
+				),
+			},
+		},
+		{
+			name: "Minimal required values",
+			data: func(_ *testing.T) map[string]tftypes.Value {
+				return map[string]tftypes.Value{
+					"api_url":    tftypes.NewValue(tftypes.String, "http://localhost"),
+					"auth_token": tftypes.NewValue(tftypes.String, "my-secret-token"),
+				}
+			},
+			issues: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := NewProvider("1.0.0")
+
+			schema := &provider.SchemaResponse{}
+			p.Schema(context.Background(), provider.SchemaRequest{}, schema)
+			assert.NotNil(t, schema.Schema, "Schema should not be nil")
+
+			resp := &provider.ValidateConfigResponse{}
+			validator, ok := p.(provider.ProviderWithValidateConfig)
+			require.True(t, ok, "Provider should implement ProviderWithValidateConfig")
+
+			validator.ValidateConfig(
+				context.Background(),
+				provider.ValidateConfigRequest{
+					Config: NewTestConfig(p, tc.data(t)),
+				},
+				resp,
+			)
+
+			assert.Equal(t, tc.issues, resp.Diagnostics, "Diagnostics should match expected issues")
+		})
 	}
 }

--- a/internal/providermeta/meta.go
+++ b/internal/providermeta/meta.go
@@ -34,8 +34,8 @@ var (
 // It is abstracted out from the provider definition to make it easier
 // to test CRUD operations within unit tests.
 type Meta struct {
-	reg    *feature.Registry `json:"-"`
-	Client *signalfx.Client  `json:"-"`
+	Registry *feature.Registry `json:"-"`
+	Client   *signalfx.Client  `json:"-"`
 
 	AuthToken      string   `json:"auth_token"`
 	APIURL         string   `json:"api_url"`
@@ -85,8 +85,8 @@ func LoadApplicationURL(ctx context.Context, meta any, fragments ...string) stri
 // LoadPreviewRegistry provides an abstraction around loading from either
 // the cached meta provider object or return the global registry.
 func LoadPreviewRegistry(ctx context.Context, meta any) *feature.Registry {
-	if m, ok := meta.(*Meta); ok && m.reg != nil {
-		return m.reg
+	if m, ok := meta.(*Meta); ok && m.Registry != nil {
+		return m.Registry
 	}
 	return feature.GetGlobalRegistry()
 }

--- a/internal/providermeta/meta_test.go
+++ b/internal/providermeta/meta_test.go
@@ -120,7 +120,7 @@ func TestLoadPreviewRegistry(t *testing.T) {
 		{
 			name: "empty local registry",
 			meta: &Meta{
-				reg: &feature.Registry{},
+				Registry: &feature.Registry{},
 			},
 			expect: &feature.Registry{},
 		},
@@ -283,7 +283,7 @@ func TestLoadProviderTags(t *testing.T) {
 		{
 			name: "disabled provider",
 			meta: &Meta{
-				reg: func() *feature.Registry {
+				Registry: func() *feature.Registry {
 					r := feature.NewRegistry()
 					r.MustRegister(feature.PreviewProviderTags)
 					return r
@@ -298,7 +298,7 @@ func TestLoadProviderTags(t *testing.T) {
 		{
 			name: "disabled provider",
 			meta: &Meta{
-				reg: func() *feature.Registry {
+				Registry: func() *feature.Registry {
 					r := feature.NewRegistry()
 					r.MustRegister(feature.PreviewProviderTags, feature.WithPreviewGlobalAvailable())
 					return r
@@ -344,7 +344,7 @@ func TestMergeProviderTeams(t *testing.T) {
 		{
 			name: "provide has details, preview not enabled",
 			meta: &Meta{
-				reg: func() *feature.Registry {
+				Registry: func() *feature.Registry {
 					r := feature.NewRegistry()
 					_ = r.MustRegister(feature.PreviewProviderTeams)
 					return r
@@ -357,7 +357,7 @@ func TestMergeProviderTeams(t *testing.T) {
 		{
 			name: "provider has details, preview enabled",
 			meta: &Meta{
-				reg: func() *feature.Registry {
+				Registry: func() *feature.Registry {
 					r := feature.NewRegistry()
 					_ = r.MustRegister(feature.PreviewProviderTeams, feature.WithPreviewGlobalAvailable())
 					return r


### PR DESCRIPTION
# Context

This will ensure that the provider framework is correctly configured before components start transitioning across to adopt the framework.

Currently this will cause nothing to happen if released, but only provide more detailed configuration validation for our users.

## Changes

- Updated configure provider details
- Updated provider to include definition for configure with validation