### PR TITLE
Fix: Include API details when using deprecated resource methods

### DIFF
--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -183,6 +183,14 @@ func Provider() *schema.Provider {
 		ConfigureFunc: signalfxConfigure,
 	}
 
+	for _, res := range sfxProvider.ResourcesMap {
+		res = deprecatedMethodDecorator(res)
+	}
+
+	for _, ds := range sfxProvider.DataSourcesMap {
+		ds = deprecatedMethodDecorator(ds)
+	}
+
 	return sfxProvider
 }
 

--- a/signalfx/provider_decorator.go
+++ b/signalfx/provider_decorator.go
@@ -1,0 +1,53 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package signalfx
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/signalfx/signalfx-go"
+)
+
+func deprecatedMethodDecorator(res *schema.Resource) *schema.Resource {
+	if res == nil {
+		return nil
+	}
+
+	if res.Create != nil {
+		res.Create = wrapDeprecatedMethod(res.Create)
+	}
+
+	if res.Read != nil {
+		res.Read = wrapDeprecatedMethod(res.Read)
+	}
+
+	if res.Update != nil {
+		res.Update = wrapDeprecatedMethod(res.Update)
+	}
+
+	if res.Delete != nil {
+		res.Delete = wrapDeprecatedMethod(res.Delete)
+	}
+
+	return res
+}
+
+func wrapDeprecatedMethod[Func schema.CreateFunc | schema.UpdateFunc | schema.ReadFunc | schema.DeleteFunc](fn Func) Func {
+	return func(data *schema.ResourceData, meta any) error {
+		err := fn(data, meta)
+		if err == nil {
+			return nil
+		}
+
+		rerr, ok := signalfx.AsResponseError(err)
+		if !ok {
+			return err
+		}
+
+		// Include the API response details as a part of the returned error
+		// TODO: Remove this once the deprecated methods are removed
+		return fmt.Errorf("%w\nAPI response: %s", err, rerr.Details())
+	}
+}

--- a/signalfx/provider_decorator_test.go
+++ b/signalfx/provider_decorator_test.go
@@ -1,0 +1,134 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package signalfx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/signalfx/signalfx-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func HelperValidateMethodCalled[Func schema.CreateFunc | schema.ReadFunc | schema.UpdateFunc | schema.DeleteFunc](tb testing.TB) Func {
+	var called bool
+	return func(data *schema.ResourceData, meta any) error {
+		tb.Helper()
+
+		called = true
+
+		tb.Cleanup(func() {
+			assert.True(tb, called, "Expected method to be called")
+		})
+
+		return nil
+	}
+}
+
+func TestDeprecatedMethodDecorator(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		createSet bool
+		readSet   bool
+		updateSet bool
+		deleteSet bool
+	}{
+		{
+			name:      "Create method set",
+			createSet: true,
+		},
+		{
+			name:    "Read method set",
+			readSet: true,
+		},
+		{
+			name:      "Update method set",
+			updateSet: true,
+		},
+		{
+			name:      "Delete method set",
+			deleteSet: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := &schema.Resource{}
+			if tc.createSet {
+				res.Create = HelperValidateMethodCalled[schema.CreateFunc](t)
+
+			}
+			if tc.readSet {
+				res.Read = HelperValidateMethodCalled[schema.ReadFunc](t)
+			}
+			if tc.updateSet {
+				res.Update = HelperValidateMethodCalled[schema.UpdateFunc](t)
+			}
+			if tc.deleteSet {
+				res.Delete = HelperValidateMethodCalled[schema.DeleteFunc](t)
+			}
+
+			res = deprecatedMethodDecorator(res)
+
+			if tc.createSet {
+				assert.NoError(t, res.Create(&schema.ResourceData{}, nil))
+			}
+
+			if tc.readSet {
+				assert.NoError(t, res.Read(&schema.ResourceData{}, nil))
+			}
+			if tc.updateSet {
+				assert.NoError(t, res.Update(&schema.ResourceData{}, nil))
+			}
+			if tc.deleteSet {
+				assert.NoError(t, res.Delete(&schema.ResourceData{}, nil))
+			}
+		})
+	}
+}
+
+func TestWrapDeprecatedMethod(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		method schema.CreateFunc
+		errVal string
+	}{
+		{
+			name:   "No error",
+			method: HelperValidateMethodCalled[schema.CreateFunc](t),
+			errVal: "",
+		},
+		{
+			name: "With error",
+			method: func(data *schema.ResourceData, meta any) error {
+				return &signalfx.ResponseError{}
+			},
+			errVal: "route \"\" had issues with status code 0\nAPI response: ",
+		},
+		{
+			name: "With non-ResponseError",
+			method: func(data *schema.ResourceData, meta any) error {
+				return fmt.Errorf("some error")
+			},
+			errVal: "some error",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := wrapDeprecatedMethod(tc.method)(&schema.ResourceData{}, nil)
+			if tc.errVal != "" {
+				assert.EqualError(t, err, tc.errVal, "Must return the expected error")
+			} else {
+				assert.NoError(t, err, "Must not return an error")
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
# Context

At the moment, the signalfx go code hides the API detail and requires explicit extraction to avoid overly verbose errors. 
However, a lot of the provider is not migrated to use this practice yet and to help handle this as we transition to the new framework, this will wrap the methods and decorate returned error message.

## Changes

-  Added provider error handler for deprecated methods.