### PR TITLE
Feature: Adding Splunk platform notification support

### DIFF
--- a/internal/common/notification_api.go
+++ b/internal/common/notification_api.go
@@ -32,6 +32,8 @@ func NewNotificationStringFromAPI(n *notification.Notification) (string, error) 
 		return fmt.Sprintf("%s,%s", n.Type, v.CredentialId), nil
 	case *notification.SlackNotification:
 		return fmt.Sprintf("%s,%s,%s", n.Type, v.CredentialId, v.Channel), nil
+	case *notification.SplunkPlatformNotification:
+		return fmt.Sprintf("%s,%s", n.Type, v.CredentialId), nil
 	case *notification.TeamNotification:
 		return fmt.Sprintf("%s,%s", n.Type, v.Team), nil
 	case *notification.TeamEmailNotification:

--- a/internal/common/notification_api_test.go
+++ b/internal/common/notification_api_test.go
@@ -147,6 +147,18 @@ func TestNewStringFromAPI(t *testing.T) {
 			errVal: "",
 		},
 		{
+			name: "splunk platform",
+			nt: &notification.Notification{
+				Type: SplunkPlatformNotificationType,
+				Value: &notification.SplunkPlatformNotification{
+					Type:         SplunkPlatformNotificationType,
+					CredentialId: "iii",
+				},
+			},
+			expect: "SplunkPlatform,iii",
+			errVal: "",
+		},
+		{
 			name: "team",
 			nt: &notification.Notification{
 				Type: TeamNotificationType,

--- a/internal/common/notification_string.go
+++ b/internal/common/notification_string.go
@@ -22,6 +22,7 @@ const (
 	PagerDutyNotificationType        string = "PagerDuty"
 	ServiceNowNotificationType       string = "ServiceNow"
 	SlackNotificationType            string = "Slack"
+	SplunkPlatformNotificationType   string = "SplunkPlatform"
 	TeamNotificationType             string = "Team"
 	TeamEmailNotificationType        string = "TeamEmail"
 	VictorOpsNotificationType        string = "VictorOps"
@@ -100,6 +101,11 @@ func NewNotificationFromString(str string) (*notification.Notification, error) {
 			Type:         values[0],
 			CredentialId: values[1],
 			Channel:      values[2],
+		}
+	case SplunkPlatformNotificationType:
+		value = &notification.SplunkPlatformNotification{
+			Type:         values[0],
+			CredentialId: values[1],
 		}
 	case TeamNotificationType:
 		value = &notification.TeamNotification{

--- a/internal/common/notification_string_test.go
+++ b/internal/common/notification_string_test.go
@@ -267,6 +267,18 @@ func TestNewNotificationFromString(t *testing.T) {
 			errVal: "",
 		},
 		{
+			name: "splunk platform",
+			str:  "SplunkPlatform,creds",
+			expect: &notification.Notification{
+				Type: SplunkPlatformNotificationType,
+				Value: &notification.SplunkPlatformNotification{
+					Type:         SplunkPlatformNotificationType,
+					CredentialId: "creds",
+				},
+			},
+			errVal: "",
+		},
+		{
 			name:   "invalid provider",
 			str:    "invalid,creds",
 			expect: nil,


### PR DESCRIPTION
# Context

This adds in support including support for splunk platform as part of the notification types.

## Changes

- Add in supported notification string