### PR TITLE
Chore: Adding framework error package handler

### DIFF
--- a/internal/framework/fwerr/handler.go
+++ b/internal/framework/fwerr/handler.go
@@ -1,0 +1,51 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwerr
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/signalfx/signalfx-go"
+
+	tfext "github.com/splunk-terraform/terraform-provider-signalfx/internal/tfextension"
+)
+
+// ErrorHandler abstracts the required error handling logic for the framework API.
+// This will standardize how the error is returned to the user.
+func ErrorHandler(ctx context.Context, state tfsdk.State, err error) diag.Diagnostics {
+	if err == nil {
+		return nil
+	}
+
+	var info diag.Diagnostics
+
+	sfxerr, ok := signalfx.AsResponseError(err)
+	if !ok {
+		info.AddError("Issue handling request", err.Error())
+		return info
+	}
+
+	switch sfxerr.Code() {
+	case http.StatusNotFound:
+		tflog.Info(ctx,
+			"Resource is no longer available, most likely removed manually. "+
+				"Remove the current state for provided resource",
+		)
+		info.AddWarning(err.Error(), sfxerr.Details())
+		state.RemoveResource(ctx)
+	default:
+		info.AddError(err.Error(), sfxerr.Details())
+	}
+
+	tflog.Error(ctx, "There was an issue handling request", tfext.NewLogFields().
+		Error(err).
+		Field("details", sfxerr.Details()),
+	)
+
+	return info
+}

--- a/internal/framework/fwerr/handler_test.go
+++ b/internal/framework/fwerr/handler_test.go
@@ -1,0 +1,49 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwerr
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/signalfx/signalfx-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorHandler(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected diag.Diagnostics
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+		},
+		{
+			name: "non api issue error",
+			err:  fmt.Errorf("issue reaching required host"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Issue handling request", "issue reaching required host"),
+			},
+		},
+		{
+			name: "signalfx response error",
+			err:  &signalfx.ResponseError{},
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(`route "" had issues with status code 0`, ""),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ErrorHandler(context.TODO(), tfsdk.State{}, tt.err)
+			assert.Equal(t, tt.expected, result, "Must match expected diagnostics")
+		})
+	}
+}


### PR DESCRIPTION
# Context

This adds in support for handling errors within the provider in a consistent manor that is abstracted away.
This is to simplify adoption and make it easier handling error.

## Changes

- Adding `fwerr` package