### PR TITLE
Chore: Adding warnings about milestone 10 release

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,11 @@ The [Splunk Observability Cloud](https://www.splunk.com/en_us/products/observabi
 
 Use the navigation to learn more about the available resources.
 
+-> The next major release of the provider (v10) is will require a minimum Terraform version of 1.11.0. 
+Please prepare to migrate to a newer version of Terraform soon.
+This will allow the provider to handle secrets more securely and take advantage of new features in the Terraform Plugin Framework.
+
+
 # Learn about Splunk Observability Cloud
 
 To learn more about Splunk Observability Cloud and its features, see [the official documentation](https://docs.splunk.com/observability/en/).

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -14,6 +14,11 @@ The [Splunk Observability Cloud](https://www.splunk.com/en_us/products/observabi
 
 Use the navigation to learn more about the available resources.
 
+-> The next major release of the provider (v10) is will require a minimum Terraform version of 1.11.0. 
+Please prepare to migrate to a newer version of Terraform soon.
+This will allow the provider to handle secrets more securely and take advantage of new features in the Terraform Plugin Framework.
+
+
 # Learn about Splunk Observability Cloud
 
 To learn more about Splunk Observability Cloud and its features, see [the official documentation](https://docs.splunk.com/observability/en/).


### PR DESCRIPTION
## Context

In the upcoming changes for v10, it will require users to have a min terraform version and some users will need time to migrate. 

## Changes

- This will validate the current version and  will output a warning 
- Added changes to the docs.