### PR TITLE
Chore: Improve framework support

### DIFF
--- a/internal/framework/fwtest/mock_provider_test.go
+++ b/internal/framework/fwtest/mock_provider_test.go
@@ -65,7 +65,7 @@ func TestNewMockProviderFactory_WithOptions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			factory := NewMockProviderFactory(t, endpoints, tc.options...)
+			factory := NewMockProto5Server(t, endpoints, tc.options...)
 			providerFunc, ok := factory["signalfx"]
 			require.True(t, ok, "Provider function should exist in factory")
 

--- a/internal/framework/fwtest/resource_schema.go
+++ b/internal/framework/fwtest/resource_schema.go
@@ -1,0 +1,43 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwtest
+
+import (
+	"container/list"
+	"iter"
+	"maps"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+func WalkResourceSchema(schema map[string]rschema.Attribute) iter.Seq2[path.Path, rschema.Attribute] {
+	return func(yield func(path.Path, rschema.Attribute) bool) {
+		queue := list.New()
+		queue.PushBack(WalkedValue{p: path.Empty(), v: schema})
+		for queue.Len() > 0 {
+			var (
+				elem = queue.Remove(queue.Front()).(WalkedValue)
+				keys = slices.Sorted(maps.Keys(elem.v.(map[string]rschema.Attribute)))
+			)
+			for _, k := range keys {
+				v := elem.v.(map[string]rschema.Attribute)[k]
+				switch v := v.(type) {
+				case rschema.MapNestedAttribute:
+					queue.PushBack(WalkedValue{p: elem.Path().AtMapKey(k), v: v.NestedObject.Attributes})
+				case rschema.SetNestedAttribute:
+					queue.PushBack(WalkedValue{p: elem.Path().AtName(k), v: v.NestedObject.Attributes})
+				case rschema.SingleNestedAttribute:
+					queue.PushBack(WalkedValue{p: elem.Path().AtName(k), v: v.Attributes})
+				case rschema.ListNestedAttribute:
+					queue.PushBack(WalkedValue{p: elem.Path().AtName(k).AtListIndex(0), v: v.NestedObject.Attributes})
+				}
+				if !yield(elem.Path().AtName(k), v) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/framework/fwtest/resource_schema_test.go
+++ b/internal/framework/fwtest/resource_schema_test.go
@@ -1,0 +1,103 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwtest
+
+import (
+	"testing"
+
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWalkResourceSchema(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		input  map[string]rschema.Attribute
+		expect map[string]rschema.Attribute
+	}{
+		{
+			name:   "basic",
+			input:  map[string]rschema.Attribute{"foo": rschema.StringAttribute{}},
+			expect: map[string]rschema.Attribute{"foo": rschema.StringAttribute{}},
+		},
+		{
+			name: "nested value",
+			input: map[string]rschema.Attribute{
+				"feature": rschema.SingleNestedAttribute{
+					Attributes: map[string]rschema.Attribute{
+						"enabled": rschema.BoolAttribute{},
+					},
+				},
+				"items": rschema.ListNestedAttribute{
+					NestedObject: rschema.NestedAttributeObject{
+						Attributes: map[string]rschema.Attribute{
+							"item": rschema.StringAttribute{},
+						},
+					},
+				},
+				"sets": rschema.SetNestedAttribute{
+					NestedObject: rschema.NestedAttributeObject{
+						Attributes: map[string]rschema.Attribute{
+							"item": rschema.StringAttribute{},
+						},
+					},
+				},
+				"maps": rschema.MapNestedAttribute{
+					NestedObject: rschema.NestedAttributeObject{
+						Attributes: map[string]rschema.Attribute{
+							"key":   rschema.StringAttribute{},
+							"value": rschema.StringAttribute{},
+						},
+					},
+				},
+			},
+			expect: map[string]rschema.Attribute{
+				"feature": rschema.SingleNestedAttribute{
+					Attributes: map[string]rschema.Attribute{
+						"enabled": rschema.BoolAttribute{},
+					},
+				},
+				"feature.enabled": rschema.BoolAttribute{},
+				"items": rschema.ListNestedAttribute{
+					NestedObject: rschema.NestedAttributeObject{
+						Attributes: map[string]rschema.Attribute{
+							"item": rschema.StringAttribute{},
+						},
+					},
+				},
+				"items[0].item": rschema.StringAttribute{},
+				"sets": rschema.SetNestedAttribute{
+					NestedObject: rschema.NestedAttributeObject{
+						Attributes: map[string]rschema.Attribute{
+							"item": rschema.StringAttribute{},
+						},
+					},
+				},
+				"sets.item": rschema.StringAttribute{},
+				"maps": rschema.MapNestedAttribute{
+					NestedObject: rschema.NestedAttributeObject{
+						Attributes: map[string]rschema.Attribute{
+							"key":   rschema.StringAttribute{},
+							"value": rschema.StringAttribute{},
+						},
+					},
+				},
+				"[\"maps\"].key":   rschema.StringAttribute{},
+				"[\"maps\"].value": rschema.StringAttribute{},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := make(map[string]rschema.Attribute)
+			for p, v := range WalkResourceSchema(tc.input) {
+				actual[p.String()] = v
+			}
+			assert.Equal(t, tc.expect, actual, "Must match the expected value")
+		})
+	}
+}

--- a/internal/framework/fwtest/struct_walk.go
+++ b/internal/framework/fwtest/struct_walk.go
@@ -1,0 +1,143 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwtest
+
+import (
+	"container/list"
+	"fmt"
+	"iter"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+type WalkedValue struct {
+	v   any
+	p   path.Path
+	err error
+}
+
+func NewWalkedValue(p path.Path, v any) WalkedValue {
+	return WalkedValue{
+		v: v,
+		p: p,
+	}
+}
+
+func NewWalkedValueError(msg string, args ...any) WalkedValue {
+	return NewWalkedValueErrorWithPath(path.Empty(), msg, args...)
+}
+
+func NewWalkedValueErrorWithPath(p path.Path, msg string, args ...any) WalkedValue {
+	return WalkedValue{
+		p:   p,
+		err: fmt.Errorf(msg, args...),
+	}
+}
+
+func (wv WalkedValue) Any() any {
+	return wv.v
+}
+
+func (w WalkedValue) Attr() attr.Value {
+	if cast, ok := w.v.(attr.Value); ok {
+		return cast
+	}
+	return nil
+}
+
+func (w WalkedValue) Err() error {
+	return w.err
+}
+
+func (w WalkedValue) Path() path.Path {
+	return w.p
+}
+
+func (wv WalkedValue) String() string {
+	return fmt.Sprintf("path:%s value:%v error:%v", wv.Path(), wv.Any(), wv.Err())
+}
+
+func WalkStruct(orig any) iter.Seq[WalkedValue] {
+	return func(yield func(WalkedValue) bool) {
+		v := reflect.ValueOf(orig)
+		if v.Kind() == reflect.Pointer {
+			v = v.Elem()
+		}
+		// Ensure the initial value is a struct so it can be explored
+		if v.Kind() != reflect.Struct {
+			yield(NewWalkedValueError("model must be a struct, provided: %T", orig))
+			return
+		}
+		var (
+			queue = list.New()
+		)
+		queue.PushBack(WalkedValue{p: path.Empty(), v: v.Interface()})
+		for queue.Len() > 0 {
+			var (
+				elem = queue.Remove(queue.Front()).(WalkedValue)
+				v    = reflect.ValueOf(elem.Any())
+			)
+			if v.Kind() == reflect.Pointer {
+				v = v.Elem()
+			}
+			switch v.Kind() {
+			case reflect.Struct:
+				for i := range v.Type().NumField() {
+					var (
+						field = v.Type().Field(i)
+						named = v.Type().Field(i).Tag.Get("tfsdk")
+					)
+					if named == "" {
+						continue
+					}
+					if !field.IsExported() {
+						queue.PushBack(NewWalkedValueErrorWithPath(
+							elem.Path().AtName(named),
+							"framework requires field exported %q", named),
+						)
+						continue
+					}
+
+					// If there is a value set within the model, then use
+					// the provided value, otherwise use a zero value
+					if value := v.Field(i); !value.IsZero() {
+						queue.PushBack(NewWalkedValue(
+							elem.Path().AtName(named),
+							value.Interface()),
+						)
+						continue
+					}
+
+					zero := reflect.Zero(field.Type)
+					if zero.Kind() == reflect.Pointer {
+						zero = reflect.Zero(field.Type.Elem())
+					}
+					queue.PushBack(NewWalkedValue(
+						elem.Path().AtName(named),
+						zero.Interface()),
+					)
+				}
+			case reflect.Slice, reflect.Array:
+				zero := reflect.MakeSlice(v.Type(), 1, 1)
+				vv := reflect.Zero(zero.Index(0).Type())
+				if vv.Kind() == reflect.Pointer {
+					vv = reflect.Zero(vv.Type().Elem())
+				}
+				queue.PushBack(NewWalkedValue(
+					elem.Path().AtListIndex(0),
+					vv.Interface()),
+				)
+				continue
+			}
+
+			// Ignore the parent value
+			if !elem.Path().Equal(path.Empty()) && !yield(elem) {
+				return
+			}
+
+		}
+	}
+}

--- a/internal/framework/fwtest/struct_walk_test.go
+++ b/internal/framework/fwtest/struct_walk_test.go
@@ -1,0 +1,84 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwtest
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
+)
+
+func TestWalkedValue(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		value  WalkedValue
+		expect string
+	}{
+		{
+			name:   "zero value",
+			value:  WalkedValue{},
+			expect: "path: value:<nil> error:<nil>",
+		},
+		{
+			name:   "has value set",
+			value:  NewWalkedValue(path.Empty(), "hehe"),
+			expect: "path: value:hehe error:<nil>",
+		},
+		{
+			name:   "has error set",
+			value:  NewWalkedValueErrorWithPath(path.Root("root"), "this has gone on for %d long", 2),
+			expect: "path:root value:<nil> error:this has gone on for 2 long",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expect, tc.value.String(), "WalkedValue String representation should match expected")
+		})
+	}
+}
+
+func TestWalkStruct(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non trivial type", func(t *testing.T) {
+		t.Parallel()
+
+		type inlined struct {
+			Value types.String `tfsdk:"value"`
+			Count types.Number `tfsdk:"count"`
+		}
+		type ComplexType struct {
+			List   []*inlined   `tfsdk:"list"`
+			Nested *inlined     `tfsdk:"nested"`
+			Scaler types.Number `tfsdk:"scalar"`
+		}
+		var (
+			errs   error
+			expect = map[string]struct{}{
+				"list[0]":       {},
+				"list[0].value": {},
+				"list[0].count": {},
+				"nested":        {},
+				"nested.value":  {},
+				"nested.count":  {},
+				"scalar":        {},
+			}
+		)
+		for wv := range WalkStruct(&ComplexType{Nested: &inlined{}}) {
+			p := wv.Path().String()
+			_, ok := expect[p]
+			assert.True(t, ok, "Must only see expected fields, got unexpected %q", p)
+			delete(expect, wv.Path().String())
+			errs = multierr.Append(errs, wv.Err())
+		}
+		assert.Empty(t, expect, "Must have seen all expected fields")
+		assert.NoError(t, errs, "Must not have any errors")
+	})
+}

--- a/internal/framework/integration/resource_splunk_oncall_test.go
+++ b/internal/framework/integration/resource_splunk_oncall_test.go
@@ -354,7 +354,7 @@ func TestResourceSplunkOncallUnitTest(t *testing.T) {
 					TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 						tfversion.RequireAbove(tfversion.Version0_12_26),
 					},
-					ProtoV5ProviderFactories: fwtest.NewMockProviderFactory(
+					ProtoV5ProviderFactories: fwtest.NewMockProto5Server(
 						t,
 						tc.endpoints,
 						fwtest.WithMockResources(NewResourceSplunkOncall),


### PR DESCRIPTION
## Context

This is to make it easier to validate changes within the framework and identify issues before they are released.

## Changes

- Adding support for tfproto5 and tfproto6 factory mocks
- Add support for exploring all details in a schema to allow for easy validation.