### PR TITLE
Feature: Adding TimeRange as a new supported framework type

### DIFF
--- a/internal/framework/function/relative_time.go
+++ b/internal/framework/function/relative_time.go
@@ -51,7 +51,7 @@ func (TimeRangeParser) Run(ctx context.Context, req function.RunRequest, resp *f
 	if val, err := tr.ParseDuration(); err != nil {
 		resp.Error = function.ConcatFuncErrors(resp.Error, function.NewFuncError(err.Error()))
 	} else {
-		resp.Result.Set(ctx, val.Milliseconds())
+		resp.Error = function.ConcatFuncErrors(resp.Error, resp.Result.Set(ctx, val.Milliseconds()))
 	}
 
 }

--- a/internal/framework/function/relative_time_test.go
+++ b/internal/framework/function/relative_time_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwtypes "github.com/splunk-terraform/terraform-provider-signalfx/internal/framework/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,6 +34,7 @@ func TestTimeRangeParser_Definition(t *testing.T) {
 	assert.Equal(t,
 		function.StringParameter{
 			AllowNullValue: false,
+			CustomType:     fwtypes.TimeRangeType{},
 			Name:           "time_range",
 			Description:    "Used to parse the given relative time string into a the amount of milliseconds.",
 		},
@@ -57,8 +59,8 @@ func TestTimeRangeParser_Run(t *testing.T) {
 				}),
 			},
 			expect: &function.RunResponse{
-				Result: function.NewResultData(types.Int64Unknown()),
-				Error:  function.NewFuncError(`invalid timerange "0": no negative prefix`),
+				Result: function.NewResultData(types.Int64Value(0)),
+				Error:  nil,
 			},
 		},
 		{
@@ -69,8 +71,8 @@ func TestTimeRangeParser_Run(t *testing.T) {
 				}),
 			},
 			expect: &function.RunResponse{
-				Result: function.NewResultData(types.Int64Unknown()),
-				Error:  function.NewFuncError(`invalid timerange "1h": no negative prefix`),
+				Result: function.NewResultData(types.Int64Value(3600000)),
+				Error:  nil,
 			},
 		},
 		{
@@ -81,7 +83,7 @@ func TestTimeRangeParser_Run(t *testing.T) {
 				}),
 			},
 			expect: &function.RunResponse{
-				Result: function.NewResultData(types.Int64Value(3600000)),
+				Result: function.NewResultData(types.Int64Value(-3600000)),
 			},
 		},
 	} {

--- a/internal/framework/function/relative_time_test.go
+++ b/internal/framework/function/relative_time_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	fwtypes "github.com/splunk-terraform/terraform-provider-signalfx/internal/framework/types"
 	"github.com/stretchr/testify/assert"
+
+	fwtypes "github.com/splunk-terraform/terraform-provider-signalfx/internal/framework/types"
 )
 
 func TestTimeRangeParser_Metadata(t *testing.T) {

--- a/internal/framework/types/time_range_type.go
+++ b/internal/framework/types/time_range_type.go
@@ -1,0 +1,62 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwtypes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TimeRangeType is a custom duration types that is analogous to the TimeRange picker that is used with the UI.
+// This is to be used within the Schema definitions that users can provide a custom string type that
+// is able to be converted into the expected values.
+
+type TimeRangeType struct {
+	basetypes.StringType
+}
+
+var _ basetypes.StringTypable = (*TimeRangeType)(nil)
+
+func (t TimeRangeType) String() string {
+	return "fwtypes.TimeRangeType"
+}
+
+func (t TimeRangeType) ValueType(ctx context.Context) attr.Value {
+	return TimeRange{}
+}
+
+func (t TimeRangeType) Equal(o attr.Type) bool {
+	other, ok := o.(TimeRangeType)
+	return ok && t.StringType.Equal(other.StringType)
+}
+
+func (t TimeRangeType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return TimeRange{
+		StringValue: in,
+	}, nil
+}
+
+func (t TimeRangeType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	strVal, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("expected basetypes.StringValue, got %T", attrValue)
+	}
+
+	valuable, diags := t.ValueFromString(ctx, strVal)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return valuable, nil
+}

--- a/internal/framework/types/time_range_type_test.go
+++ b/internal/framework/types/time_range_type_test.go
@@ -1,0 +1,123 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwtypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeRangeTypeString(t *testing.T) {
+	t.Parallel()
+
+	trp := TimeRangeType{}
+	assert.Equal(t, "fwtypes.TimeRangeType", trp.String(), "Must match the expected string representation")
+}
+
+func TestTimeRangeTypeValueType(t *testing.T) {
+	t.Parallel()
+
+	trp := TimeRangeType{}
+	assert.Equal(t, TimeRange{}, trp.ValueType(context.Background()), "Must match the expected value type")
+}
+
+func TestTimeRangeTypeEqual(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		match attr.Type
+		equal bool
+	}{
+		{
+			name:  "nil typed value",
+			match: attr.Type(nil),
+			equal: false,
+		},
+		{
+			name:  "exact same type",
+			match: TimeRangeType{},
+			equal: true,
+		},
+		{
+			name:  "different type",
+			match: basetypes.StringType{},
+			equal: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			trp := TimeRangeType{}
+			assert.Equal(t, tc.equal, trp.Equal(tc.match), "Must match the expected equality result")
+		})
+	}
+}
+
+func TestTimeRangeTypeValueFromString(t *testing.T) {
+	t.Parallel()
+
+	var (
+		trp = TimeRangeType{}
+		in  = basetypes.NewStringValue("5m")
+	)
+
+	out, diags := trp.ValueFromString(context.Background(), in)
+
+	assert.Equal(t, TimeRange{StringValue: in}, out, "Must match the expected value")
+	assert.Empty(t, diags, "There must not be any diagnostics")
+}
+
+func TestTimeRangeTypeValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		in     tftypes.Value
+		expect attr.Value
+		errVal string
+	}{
+		{
+			name:   "wrong value type provided",
+			in:     tftypes.NewValue(tftypes.Bool, false),
+			expect: nil,
+			errVal: "can't unmarshal tftypes.Bool into *string, expected string",
+		},
+		{
+			name: "unknown value provided",
+			in:   tftypes.Value{},
+			expect: TimeRange{
+				StringValue: basetypes.NewStringNull(),
+			},
+			errVal: "",
+		},
+		{
+			name: "expected string value",
+			in:   tftypes.NewValue(tftypes.String, "5m"),
+			expect: TimeRange{
+				StringValue: basetypes.NewStringValue("5m"),
+			},
+			errVal: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			trp := TimeRangeType{}
+			out, err := trp.ValueFromTerraform(context.Background(), tc.in)
+			if tc.errVal != "" {
+				assert.EqualError(t, err, tc.errVal, "Must match the expected error")
+				assert.Nil(t, out, "The output value must be nil")
+			} else {
+				assert.NoError(t, err, "There must not be an error")
+				assert.Equal(t, tc.expect, out, "Must match the expected value")
+			}
+		})
+	}
+}

--- a/internal/framework/types/time_range_value.go
+++ b/internal/framework/types/time_range_value.go
@@ -1,0 +1,130 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwtypes
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// TimeRange is a custom duration types that is analogous to the TimeRange picker that is used with the UI.
+// Use this within the model definitions for an associated usage of TimeRangeType.
+type TimeRange struct {
+	basetypes.StringValue
+}
+
+var (
+	_ basetypes.StringValuableWithSemanticEquals = (*TimeRange)(nil)
+	_ xattr.ValidateableAttribute                = (*TimeRange)(nil)
+	_ function.ValidateableParameter             = (*TimeRange)(nil)
+)
+
+func (tr TimeRange) Type(_ context.Context) attr.Type {
+	return TimeRangeType{}
+}
+
+func (tr TimeRange) Equal(o attr.Value) bool {
+	other, ok := o.(TimeRange)
+	return ok && tr.StringValue.Equal(other.StringValue)
+}
+
+func (tr TimeRange) ValidateAttribute(ctx context.Context, req xattr.ValidateAttributeRequest, resp *xattr.ValidateAttributeResponse) {
+	if tr.IsUnknown() || tr.IsNull() {
+		return
+	}
+
+	if _, err := tr.ParseDuration(); err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Time Range", err.Error())
+	}
+}
+
+func (tr TimeRange) ValidateParameter(ctx context.Context, req function.ValidateParameterRequest, resp *function.ValidateParameterResponse) {
+	if tr.IsUnknown() || tr.IsNull() {
+		return
+	}
+
+	if _, err := tr.ParseDuration(); err != nil {
+		resp.Error = function.NewArgumentFuncError(req.Position, err.Error())
+	}
+}
+
+func (tr TimeRange) ParseDuration() (time.Duration, error) {
+	var (
+		units = map[rune]time.Duration{
+			's': 1 * time.Second,
+			'm': 1 * time.Minute,
+			'h': 1 * time.Hour,
+			'd': 24 * time.Hour,
+			'w': 7 * 24 * time.Hour,
+		}
+		raw     = tr.StringValue.ValueString()
+		partial time.Duration
+		total   time.Duration
+	)
+
+	if raw == "" {
+		return 0, fmt.Errorf("invalid timerange: empty string")
+	}
+
+	for _, r := range strings.TrimPrefix(raw, "-") {
+		_, isUnit := units[r]
+		switch {
+		case unicode.IsDigit(r):
+			partial = partial*10 + time.Duration(r-'0')
+		case isUnit:
+			if partial == 0 {
+				return 0, fmt.Errorf("invalid timerange: %q", raw)
+			}
+			total, partial = (total + partial*units[r]), 0
+		default:
+			return 0, fmt.Errorf("invalid timerange: unexpected character: %q", r)
+		}
+	}
+
+	if partial != 0 {
+		// Ensure the keys are shown in asscending order of unit size
+		var keys []string
+		for k := range units {
+			keys = append(keys, string(k))
+		}
+		slices.SortFunc(keys, func(a, b string) int {
+			ar, br := []rune(a)[0], []rune(b)[0]
+			return int(units[ar] - units[br])
+		})
+		return 0, fmt.Errorf("invalid timerange: expected unit %v", keys)
+	}
+
+	if strings.HasPrefix(raw, "-") {
+		total *= -1
+	}
+
+	return total, nil
+}
+
+func (tr TimeRange) StringSemanticEquals(ctx context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	nv, ok := newValuable.(TimeRange)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An expected value type was received while comparing semantic values",
+		)
+	}
+
+	old, _ := tr.ParseDuration()
+	new, _ := nv.ParseDuration()
+
+	return old == new, diags
+}

--- a/internal/framework/types/time_range_value.go
+++ b/internal/framework/types/time_range_value.go
@@ -68,7 +68,7 @@ func (tr TimeRange) ParseDuration() (time.Duration, error) {
 			'd': 24 * time.Hour,
 			'w': 7 * 24 * time.Hour,
 		}
-		raw     = tr.StringValue.ValueString()
+		raw     = tr.ValueString()
 		partial time.Duration
 		total   time.Duration
 	)
@@ -124,7 +124,7 @@ func (tr TimeRange) StringSemanticEquals(ctx context.Context, newValuable basety
 	}
 
 	old, _ := tr.ParseDuration()
-	new, _ := nv.ParseDuration()
+	n, _ := nv.ParseDuration()
 
-	return old == new, diags
+	return old == n, diags
 }

--- a/internal/framework/types/time_range_value_test.go
+++ b/internal/framework/types/time_range_value_test.go
@@ -1,0 +1,259 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwtypes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeRangeType(t *testing.T) {
+	t.Parallel()
+
+	tr := TimeRange{}
+	assert.Equal(t, TimeRangeType{}, tr.Type(context.Background()), "Must match the expected type")
+}
+
+func TestTimeRangeEqual(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		val   attr.Value
+		equal bool
+	}{
+		{
+			name:  "nil typed value",
+			val:   attr.Value(nil),
+			equal: false,
+		},
+		{
+			name:  "unmatched type",
+			val:   basetypes.StringValue{},
+			equal: false,
+		},
+		{
+			name:  "same value",
+			val:   TimeRange{},
+			equal: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tr := TimeRange{}
+			assert.Equal(t, tc.equal, tr.Equal(tc.val), "Must match the expected equality result")
+		})
+	}
+}
+
+func TestTimeRangeValidateAttribute(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		val    string
+		expect diag.Diagnostics
+	}{
+		{
+			name: "unknown value",
+			val:  "",
+			expect: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test_case"),
+					"Invalid Time Range",
+					"invalid timerange: empty string",
+				),
+			},
+		},
+		{
+			name: "not a time range",
+			val:  "abc",
+			expect: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test_case"),
+					"Invalid Time Range",
+					"invalid timerange: unexpected character: 'a'",
+				),
+			},
+		},
+		{
+			name:   "valid time range",
+			val:    "10w5d2h30m15s",
+			expect: nil,
+		},
+		{
+			name:   "negative valid time range",
+			val:    "-10w5d2h30m15s",
+			expect: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				req = xattr.ValidateAttributeRequest{
+					Path: path.Root("test_case"),
+				}
+
+				resp xattr.ValidateAttributeResponse
+			)
+			tr := TimeRange{
+				StringValue: basetypes.NewStringValue(tc.val),
+			}
+			tr.ValidateAttribute(context.Background(), req, &resp)
+			assert.Equal(t, tc.expect, resp.Diagnostics, "Must match the expected diagnostics")
+		})
+	}
+}
+
+func TestTimeRangeValidateParamter(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		val    string
+		expect *function.FuncError
+	}{
+		{
+			name: "unknown value",
+			val:  "",
+			expect: function.NewArgumentFuncError(
+				1,
+				"invalid timerange: empty string",
+			),
+		},
+		{
+			name: "not a time range",
+			val:  "abc",
+			expect: function.NewArgumentFuncError(
+				1,
+				"invalid timerange: unexpected character: 'a'",
+			),
+		},
+		{
+			name:   "valid time range",
+			val:    "10w5d2h30m15s",
+			expect: nil,
+		},
+		{
+			name:   "negative valid time range",
+			val:    "-10w5d2h30m15s",
+			expect: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				req = function.ValidateParameterRequest{
+					Position: 1,
+				}
+				resp function.ValidateParameterResponse
+			)
+			tr := TimeRange{
+				StringValue: basetypes.NewStringValue(tc.val),
+			}
+			tr.ValidateParameter(context.Background(), req, &resp)
+			assert.Equal(t, tc.expect, resp.Error, "Must match the expected error")
+		})
+	}
+}
+
+func TestTimeRangeParseDuration(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		val    string
+		expect time.Duration
+		errVal string
+	}{
+		{
+			name:   "valid time range",
+			val:    "10w5d2h30m15s",
+			expect: 10*7*24*time.Hour + 5*24*time.Hour + 2*time.Hour + 30*time.Minute + 15*time.Second,
+			errVal: "",
+		},
+		{
+			name:   "negative valid time range",
+			val:    "-10w5d2h30m15s",
+			expect: -(10*7*24*time.Hour + 5*24*time.Hour + 2*time.Hour + 30*time.Minute + 15*time.Second),
+			errVal: "",
+		},
+		{
+			name:   "missing units",
+			val:    "10",
+			expect: 0,
+			errVal: "invalid timerange: expected unit [s m h d w]",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tr := TimeRange{
+				StringValue: basetypes.NewStringValue(tc.val),
+			}
+			actual, err := tr.ParseDuration()
+			if tc.errVal != "" {
+				assert.EqualError(t, err, tc.errVal, "Must match the expected error")
+				assert.Equal(t, time.Duration(0), actual, "The duration must be zero")
+			} else {
+				assert.NoError(t, err, "There must not be an error")
+				assert.Equal(t, tc.expect, actual, "Must match the expected duration")
+			}
+		})
+	}
+}
+
+func TestTimeRangeStringSemanticEquals(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		other  basetypes.StringValuable
+		equal  bool
+		issues diag.Diagnostics
+	}{
+		{
+			name:  "nil other value",
+			other: basetypes.NewStringNull(),
+			equal: false,
+			issues: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Semantic Equality Check Error",
+					"An expected value type was received while comparing semantic values",
+				),
+			},
+		},
+		{
+			name: "unequal values",
+			other: TimeRange{
+				StringValue: basetypes.NewStringValue("10m"),
+			},
+			issues: nil,
+			equal:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tr := TimeRange{
+				StringValue: basetypes.NewStringValue("5m"),
+			}
+			equal, issues := tr.StringSemanticEquals(context.Background(), tc.other)
+			assert.Equal(t, tc.equal, equal, "Must match the expected equality result")
+			assert.Equal(t, tc.issues, issues, "Must match the expected diagnostics")
+		})
+	}
+}


### PR DESCRIPTION
# Context

This will allow users to copy over their existing configurations from the UI into the terraform configuration.

## Changes

- Added new package `types`
- Added new type `TimeRange`
- Added new type `TimeRangeType`