### PR TITLE
Chore: Use terraform v1.0+ provider servers

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,9 +9,10 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 
 	internalframework "github.com/splunk-terraform/terraform-provider-signalfx/internal/framework"
 	"github.com/splunk-terraform/terraform-provider-signalfx/signalfx"
@@ -30,22 +31,33 @@ var (
 func main() {
 	flag.Parse()
 
-	providers := []func() tfprotov5.ProviderServer{
-		providerserver.NewProtocol5(internalframework.NewProvider(Version)),
+	upgrader, err := tf5to6server.UpgradeServer(
+		context.Background(),
 		signalfx.Provider().GRPCProvider, // Provider to be sunset during the migration of 10.x
-	}
+	)
 
-	mux, err := tf5muxserver.NewMuxServer(context.Background(), providers...)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	var opts []tf5server.ServeOpt
-	if *debug {
-		opts = append(opts, tf5server.WithManagedDebug())
+	providers := []func() tfprotov6.ProviderServer{
+		providerserver.NewProtocol6(internalframework.NewProvider(Version)),
+		func() tfprotov6.ProviderServer {
+			return upgrader
+		},
 	}
 
-	if err = tf5server.Serve(ProviderRegistry, mux.ProviderServer, opts...); err != nil {
+	mux, err := tf6muxserver.NewMuxServer(context.Background(), providers...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var opts []tf6server.ServeOpt
+	if *debug {
+		opts = append(opts, tf6server.WithManagedDebug())
+	}
+
+	if err = tf6server.Serve(ProviderRegistry, mux.ProviderServer, opts...); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
# Context

A lot of the changes require that provider use the tf6 protocol version when using nested blocks and definitions.
This will allow us to keep the old version of the SDK while also supporting newer features inside the framework.

## Changes

- Min supported terraform version is now v1+ (technically it will be 1.11.0+)