### PR TITLE
Feature: Ensure managed resources removed externally are removed from state file

### DIFF
--- a/signalfx/provider_decorator.go
+++ b/signalfx/provider_decorator.go
@@ -5,6 +5,7 @@ package signalfx
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/signalfx/signalfx-go"
@@ -44,6 +45,15 @@ func wrapDeprecatedMethod[Func schema.CreateFunc | schema.UpdateFunc | schema.Re
 		rerr, ok := signalfx.AsResponseError(err)
 		if !ok {
 			return err
+		}
+		// HACK(MovieStoreGuy):
+		// By default, if a resource is externally deleted,
+		// it should be removed from the state file
+		// Since the deprecated methods treat a returned error as a failures,
+		// the error is suppressed here and should encourage the user to try again.
+		if rerr.Code() == http.StatusNotFound {
+			data.SetId("")
+			return nil
 		}
 
 		// Include the API response details as a part of the returned error


### PR DESCRIPTION
# Context

Current if a resource is removed externally but was managed by terraform, it will fail to perform any follow up actions.
What this will do instead is intercept the returned error message and code saying it was not found, and suppress the error message. 

There is a nicer way to handle this in later version of the provider and methods, however, this works as a nice catch all.

## Changes

- Added removing resource from state if o11y cloud reports it no longer exists automatically.