### PR TITLE
Fix: Ensure that validation doesn't fail for external authentication

### DIFF
--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -307,15 +307,10 @@ func (op *ollyProvider) ValidateConfig(ctx context.Context, req provider.Validat
 		!model.OrganizationID.IsNull():
 		tflog.Debug(ctx, "Using email and password for authentication")
 	default:
-		p := path.Empty().
-			AtName("auth_token").
-			AtName("email").
-			AtName("password").
-			AtName("organization_id")
-		resp.Diagnostics.AddAttributeError(
-			p,
+		resp.Diagnostics.AddWarning(
 			"Missing Authentication Method",
-			"Either 'auth_token' or both 'email' and 'password' must be set for authentication.",
+			"Either 'auth_token' or both 'email' and 'password' must be set for authentication as part of the terraform configuration."+
+				"Using external configuration methods will be deprecated in a future major release.",
 		)
 	}
 }

--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -309,7 +309,7 @@ func (op *ollyProvider) ValidateConfig(ctx context.Context, req provider.Validat
 	default:
 		resp.Diagnostics.AddWarning(
 			"Missing Authentication Method",
-			"Either 'auth_token' or both 'email' and 'password' must be set for authentication as part of the terraform configuration."+
+			"Either 'auth_token' or both 'email' and 'password' must be set for authentication as part of the terraform configuration. "+
 				"Using external configuration methods will be deprecated in a future major release.",
 		)
 	}

--- a/internal/framework/provider_test.go
+++ b/internal/framework/provider_test.go
@@ -473,14 +473,9 @@ func TestProviderValidateConfig(t *testing.T) {
 					"Missing API Endpoint",
 					"Field must be set to a valid endpoint for the Splunk Observability Cloud provider.",
 				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Empty().
-						AtName("auth_token").
-						AtName("email").
-						AtName("password").
-						AtName("organization_id"),
+				diag.NewWarningDiagnostic(
 					"Missing Authentication Method",
-					"Either 'auth_token' or both 'email' and 'password' must be set for authentication.",
+					"Either 'auth_token' or both 'email' and 'password' must be set for authentication as part of the terraform configuration. Using external configuration methods will be deprecated in a future major release.",
 				),
 			},
 		},


### PR DESCRIPTION
# Context

If a service owner has adopted using external means of providing auth, it will currently cause the provider to fail.

## Changes

- Ensure that users of external auth are warned and the functionality will be removed in future releases.