### PR TITLE
Fix: Ensure that the provider loads envvars

### DIFF
--- a/internal/framework/provider_model.go
+++ b/internal/framework/provider_model.go
@@ -3,7 +3,11 @@
 
 package internalframework
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
 type OllyProviderModel struct {
 	APIURL              types.String `tfsdk:"api_url"`
@@ -23,8 +27,8 @@ type OllyProviderModel struct {
 
 func newDefaultOllyProviderModel() *OllyProviderModel {
 	return &OllyProviderModel{
-		AuthToken:           types.StringNull(),
-		APIURL:              types.StringNull(),
+		AuthToken:           NewStringFromEnvironment("SFX_AUTH_TOKEN"),
+		APIURL:              NewStringFromEnvironment("SFX_API_URL"),
 		CustomAppURL:        types.StringNull(),
 		TimeoutSeconds:      types.Int64Value(60),
 		RetryMaxAttempts:    types.Int32Value(5),
@@ -37,4 +41,11 @@ func newDefaultOllyProviderModel() *OllyProviderModel {
 		Tags:                types.ListNull(types.StringType),
 		Teams:               types.ListNull(types.StringType),
 	}
+}
+
+func NewStringFromEnvironment(envvar string) types.String {
+	if val, ok := os.LookupEnv(envvar); ok {
+		return types.StringValue(val)
+	}
+	return types.StringNull()
 }

--- a/internal/framework/provider_model_test.go
+++ b/internal/framework/provider_model_test.go
@@ -2,3 +2,43 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package internalframework
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewStringFromEnvironment(t *testing.T) {
+
+	for _, tc := range []struct {
+		name   string
+		env    map[string]string
+		expect types.String
+	}{
+		{
+			name:   "missing env var",
+			env:    map[string]string{},
+			expect: types.StringNull(),
+		},
+		{
+			name:   "empty env var",
+			env:    map[string]string{"TEST_ENVVAR": ""},
+			expect: types.StringValue(""),
+		},
+		{
+			name:   "set env var",
+			env:    map[string]string{"TEST_ENVVAR": "some-value"},
+			expect: types.StringValue("some-value"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			actual := NewStringFromEnvironment("TEST_ENVVAR")
+			assert.Equal(t, tc.expect, actual, "Must match the expected value")
+		})
+	}
+}


### PR DESCRIPTION
## Context

This is to ensure that we are loading the expected env vars that previous where used in the original provider. 

## Changes

- Added env var check for creating model.