### PR TITLE
Fix: Ensure provider defaults are respected

### DIFF
--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -148,7 +148,7 @@ func (op *ollyProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
-	model.EnsureDefaults()
+	model.init()
 
 	meta := &pmeta.Meta{
 		Registry:       op.features,
@@ -295,7 +295,7 @@ func (op *ollyProvider) ValidateConfig(ctx context.Context, req provider.Validat
 		return
 	}
 
-	model.EnsureDefaults()
+	model.init()
 
 	if model.APIURL.IsNull() {
 		resp.Diagnostics.AddAttributeError(

--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -148,6 +148,8 @@ func (op *ollyProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
+	model.EnsureDefaults()
+
 	meta := &pmeta.Meta{
 		Registry:       op.features,
 		Email:          model.Email.ValueString(),
@@ -292,6 +294,8 @@ func (op *ollyProvider) ValidateConfig(ctx context.Context, req provider.Validat
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	model.EnsureDefaults()
 
 	if model.APIURL.IsNull() {
 		resp.Diagnostics.AddAttributeError(

--- a/internal/framework/provider_model.go
+++ b/internal/framework/provider_model.go
@@ -43,9 +43,9 @@ func newDefaultOllyProviderModel() *OllyProviderModel {
 	}
 }
 
-// EnsureDefaults sets the default values for the provider model fields if they are not already set.
+// init sets the default values for the provider model fields if they are not already set.
 // This is due to the fact that the Terraform Framework does not support default values for provider schema attributes.
-func (model *OllyProviderModel) EnsureDefaults() {
+func (model *OllyProviderModel) init() {
 	if data, ok := os.LookupEnv("SFX_AUTH_TOKEN"); ok && model.AuthToken.IsNull() {
 		model.AuthToken = types.StringValue(data)
 	}

--- a/internal/framework/provider_model.go
+++ b/internal/framework/provider_model.go
@@ -27,8 +27,8 @@ type OllyProviderModel struct {
 
 func newDefaultOllyProviderModel() *OllyProviderModel {
 	return &OllyProviderModel{
-		AuthToken:           NewStringFromEnvironment("SFX_AUTH_TOKEN"),
-		APIURL:              NewStringFromEnvironment("SFX_API_URL"),
+		AuthToken:           types.StringNull(),
+		APIURL:              types.StringNull(),
 		CustomAppURL:        types.StringNull(),
 		TimeoutSeconds:      types.Int64Value(60),
 		RetryMaxAttempts:    types.Int32Value(5),
@@ -43,9 +43,25 @@ func newDefaultOllyProviderModel() *OllyProviderModel {
 	}
 }
 
-func NewStringFromEnvironment(envvar string) types.String {
-	if val, ok := os.LookupEnv(envvar); ok {
-		return types.StringValue(val)
+// EnsureDefaults sets the default values for the provider model fields if they are not already set.
+// This is due to the fact that the Terraform Framework does not support default values for provider schema attributes.
+func (model *OllyProviderModel) EnsureDefaults() {
+	if data, ok := os.LookupEnv("SFX_AUTH_TOKEN"); ok && model.AuthToken.IsNull() {
+		model.AuthToken = types.StringValue(data)
 	}
-	return types.StringNull()
+	if data, ok := os.LookupEnv("SFX_API_URL"); ok && model.APIURL.IsNull() {
+		model.APIURL = types.StringValue(data)
+	}
+	if model.TimeoutSeconds.IsNull() {
+		model.TimeoutSeconds = types.Int64Value(60)
+	}
+	if model.RetryMaxAttempts.IsNull() {
+		model.RetryMaxAttempts = types.Int32Value(5)
+	}
+	if model.RetryWaitMinSeconds.IsNull() {
+		model.RetryWaitMinSeconds = types.Int64Value(1)
+	}
+	if model.RetryWaitMaxSeconds.IsNull() {
+		model.RetryWaitMaxSeconds = types.Int64Value(10)
+	}
 }

--- a/internal/framework/provider_model_test.go
+++ b/internal/framework/provider_model_test.go
@@ -76,7 +76,7 @@ func TestModelEnsureDefaults(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			tc.model.EnsureDefaults()
+			tc.model.init()
 			assert.Equal(t, tc.expected, tc.model)
 		})
 	}


### PR DESCRIPTION
# Context

This looks at applying sensible defaults and ensure they are set if not present.

# Changes

- Added init method to ensure defaults are present and set as expected.