### PR TITLE
Fix: Ensure provider defaults are respected (#664)

### DIFF
--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -147,6 +147,8 @@ func (op *ollyProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
+	model.init()
+
 	meta := &pmeta.Meta{
 		Registry:       op.features,
 		Email:          model.Email.ValueString(),
@@ -290,6 +292,8 @@ func (op *ollyProvider) ValidateConfig(ctx context.Context, req provider.Validat
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	model.init()
 
 	if model.APIURL.IsNull() {
 		resp.Diagnostics.AddAttributeError(

--- a/internal/framework/provider_model.go
+++ b/internal/framework/provider_model.go
@@ -3,7 +3,11 @@
 
 package internalframework
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
 type OllyProviderModel struct {
 	APIURL              types.String `tfsdk:"api_url"`
@@ -36,5 +40,28 @@ func newDefaultOllyProviderModel() *OllyProviderModel {
 		FeaturePreview:      types.MapNull(types.BoolType),
 		Tags:                types.ListNull(types.StringType),
 		Teams:               types.ListNull(types.StringType),
+	}
+}
+
+// init sets the default values for the provider model fields if they are not already set.
+// This is due to the fact that the Terraform Framework does not support default values for provider schema attributes.
+func (model *OllyProviderModel) init() {
+	if data, ok := os.LookupEnv("SFX_AUTH_TOKEN"); ok && model.AuthToken.IsNull() {
+		model.AuthToken = types.StringValue(data)
+	}
+	if data, ok := os.LookupEnv("SFX_API_URL"); ok && model.APIURL.IsNull() {
+		model.APIURL = types.StringValue(data)
+	}
+	if model.TimeoutSeconds.IsNull() {
+		model.TimeoutSeconds = types.Int64Value(60)
+	}
+	if model.RetryMaxAttempts.IsNull() {
+		model.RetryMaxAttempts = types.Int32Value(5)
+	}
+	if model.RetryWaitMinSeconds.IsNull() {
+		model.RetryWaitMinSeconds = types.Int64Value(1)
+	}
+	if model.RetryWaitMaxSeconds.IsNull() {
+		model.RetryWaitMaxSeconds = types.Int64Value(10)
 	}
 }

--- a/internal/framework/provider_model_test.go
+++ b/internal/framework/provider_model_test.go
@@ -2,3 +2,82 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package internalframework
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelEnsureDefaults(t *testing.T) {
+
+	for _, tc := range []struct {
+		name     string
+		model    *OllyProviderModel
+		env      map[string]string
+		expected *OllyProviderModel
+	}{
+		{
+			name:  "no env, no defaults set",
+			model: &OllyProviderModel{},
+			env:   map[string]string{},
+			expected: &OllyProviderModel{
+				AuthToken:           types.StringNull(),
+				APIURL:              types.StringNull(),
+				TimeoutSeconds:      types.Int64Value(60),
+				RetryMaxAttempts:    types.Int32Value(5),
+				RetryWaitMinSeconds: types.Int64Value(1),
+				RetryWaitMaxSeconds: types.Int64Value(10),
+			},
+		},
+		{
+			name:  "environment variables set, no defaults set",
+			model: &OllyProviderModel{},
+			env: map[string]string{
+				"SFX_AUTH_TOKEN": "test-auth-token",
+				"SFX_API_URL":    "https://example.com",
+			},
+			expected: &OllyProviderModel{
+				AuthToken:           types.StringValue("test-auth-token"),
+				APIURL:              types.StringValue("https://example.com"),
+				TimeoutSeconds:      types.Int64Value(60),
+				RetryMaxAttempts:    types.Int32Value(5),
+				RetryWaitMinSeconds: types.Int64Value(1),
+				RetryWaitMaxSeconds: types.Int64Value(10),
+			},
+		},
+		{
+			name: "values are defined",
+			model: &OllyProviderModel{
+				AuthToken:           types.StringValue("defined-auth-token"),
+				APIURL:              types.StringValue("https://example.com"),
+				TimeoutSeconds:      types.Int64Value(120),
+				RetryMaxAttempts:    types.Int32Value(10),
+				RetryWaitMinSeconds: types.Int64Value(2),
+				RetryWaitMaxSeconds: types.Int64Value(20),
+			},
+			env: map[string]string{
+				"SFX_AUTH_TOKEN": "test-auth-token",
+				"SFX_API_URL":    "https://example.com/v2",
+			},
+			expected: &OllyProviderModel{
+				AuthToken:           types.StringValue("defined-auth-token"),
+				APIURL:              types.StringValue("https://example.com"),
+				TimeoutSeconds:      types.Int64Value(120),
+				RetryMaxAttempts:    types.Int32Value(10),
+				RetryWaitMinSeconds: types.Int64Value(2),
+				RetryWaitMaxSeconds: types.Int64Value(20),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			tc.model.init()
+			assert.Equal(t, tc.expected, tc.model)
+		})
+	}
+}


### PR DESCRIPTION
* Fixing up framework provider defaults

Unfortunately, in the framework transition, defaults are not support since configuration will revert any changes applied in the existing default values

* Renaming method to align to conventions