### PR TITLE
Fix: Expose the validation reason 

### DIFF
--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/signalfx/signalfx-go"
 	"github.com/signalfx/signalfx-go/detector"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/check"
 	"github.com/splunk-terraform/terraform-provider-signalfx/internal/common"
@@ -982,6 +983,9 @@ func validateProgramText(ctx context.Context, d *schema.ResourceDiff, meta any) 
 		ParentDetectorId: d.Get("parent_detector_id").(string),
 	})
 	if err != nil {
+		if re, ok := signalfx.AsResponseError(err); ok {
+			err = fmt.Errorf("%w: %q", err, re.Details())
+		}
 		return err
 	}
 


### PR DESCRIPTION
# Context

If there is an issue with validation, the provider will currently truncate the error message. This will enforce that any details are correctly captured and returned as part of the error.

## Change

- Ensure details are included as part of the error message.