### PR TITLE
Fix: Allowing empty secret for Webhook Notification

### DIFF
--- a/internal/check/notification_test.go
+++ b/internal/check/notification_test.go
@@ -171,7 +171,7 @@ func TestNotification(t *testing.T) {
 			expect: diag.Diagnostics{
 				{
 					Severity: diag.Error,
-					Summary:  "invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)",
+					Summary:  "invalid Webhook notification string, please consult the documentation (use one of URL or credential id)",
 				},
 			},
 		},
@@ -189,7 +189,7 @@ func TestNotification(t *testing.T) {
 			name: "Webhook url invalid",
 			val:  "Webhook,,verysercretsecret,foo",
 			expect: diag.Diagnostics{
-				{Severity: diag.Error, Summary: "invalid Webhook URL \"verysercretsecret\""},
+				{Severity: diag.Error, Summary: "invalid Webhook URL \"foo\""},
 			},
 		},
 		{

--- a/internal/common/notification_string.go
+++ b/internal/common/notification_string.go
@@ -130,23 +130,17 @@ func NewNotificationFromString(str string) (*notification.Notification, error) {
 		if count != 4 {
 			return nil, fmt.Errorf("invalid Webhook notification string, please consult the documentation (not enough parts)")
 		}
-		if values[1] != "" {
-			// We got a credential ID, so verify we didn't get the other parts
-			if values[2] != "" || values[3] != "" {
-				return nil, fmt.Errorf("invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)")
-			}
-		} else {
-			// We didn't get a credential ID so verify we got the other parts
-			if values[2] == "" || values[3] == "" {
-				return nil, fmt.Errorf("invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)")
-			}
-		}
-		// The URL might be an empty string in the case that the user
-		// only supplied a credential ID
-		if values[3] != "" {
+		switch {
+		case values[1] != "" && values[3] != "":
+			return nil, fmt.Errorf("invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)")
+		case values[1] != "":
+			// Do nothing, credentialId is set
+		case values[3] != "":
 			if _, err := url.ParseRequestURI(values[3]); err != nil {
-				return nil, fmt.Errorf("invalid Webhook URL %q", values[2])
+				return nil, fmt.Errorf("invalid Webhook URL %q", values[3])
 			}
+		default:
+			return nil, fmt.Errorf("invalid Webhook notification string, please consult the documentation (use one of URL or credential id)")
 		}
 		value = &notification.WebhookNotification{
 			Type:         values[0],

--- a/internal/common/notification_string_test.go
+++ b/internal/common/notification_string_test.go
@@ -240,7 +240,7 @@ func TestNewNotificationFromString(t *testing.T) {
 			name:   "webhook no values set",
 			str:    "Webhook,,,",
 			expect: nil,
-			errVal: "invalid Webhook notification string, please consult the documentation (use one of URL and secret or credential id)",
+			errVal: "invalid Webhook notification string, please consult the documentation (use one of URL or credential id)",
 		},
 		{
 			name:   "webhook all values set",
@@ -252,7 +252,7 @@ func TestNewNotificationFromString(t *testing.T) {
 			name:   "webhook invalid url",
 			str:    "Webhook,,secret,zzz",
 			expect: nil,
-			errVal: "invalid Webhook URL \"secret\"",
+			errVal: "invalid Webhook URL \"zzz\"",
 		},
 		{
 			name: "xmatters",


### PR DESCRIPTION
# Context

The API allows for no secret to be set, this is to reflect that change.

## Changes

- Allow no secret to be used for notifications
- Fix up incorrect error reference 