### PR TITLE
QoL: Make dashboard variables orderable

### DIFF
--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -245,7 +245,7 @@ func dashboardResource() *schema.Resource {
 				},
 			},
 			"filter": &schema.Schema{
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Filter to apply to each chart in the dashboard",
 				Elem: &schema.Resource{
@@ -789,7 +789,7 @@ func getDashboardEventOverlayFilters(sources []interface{}) []*dashboard.EventOv
 }
 
 func getDashboardFilters(d *schema.ResourceData) []*dashboard.ChartsSingleFilter {
-	filters := d.Get("filter").([]interface{})
+	filters := d.Get("filter").(*schema.Set).List()
 	filterList := make([]*dashboard.ChartsSingleFilter, len(filters))
 	for i, filter := range filters {
 		filter := filter.(map[string]interface{})

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -185,7 +185,7 @@ func dashboardResource() *schema.Resource {
 				},
 			},
 			"variable": &schema.Schema{
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Dashboard variable to apply to each chart in the dashboard",
 				Elem: &schema.Resource{
@@ -245,7 +245,7 @@ func dashboardResource() *schema.Resource {
 				},
 			},
 			"filter": &schema.Schema{
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Filter to apply to each chart in the dashboard",
 				Elem: &schema.Resource{
@@ -696,7 +696,7 @@ func getDashboardGrids(d *schema.ResourceData) []*dashboard.DashboardChart {
 }
 
 func getDashboardVariables(d *schema.ResourceData) []*dashboard.ChartsWebUiFilter {
-	variables := d.Get("variable").(*schema.Set).List()
+	variables := d.Get("variable").([]interface{})
 	varsList := make([]*dashboard.ChartsWebUiFilter, len(variables))
 	for i, variable := range variables {
 		variable := variable.(map[string]interface{})
@@ -789,7 +789,7 @@ func getDashboardEventOverlayFilters(sources []interface{}) []*dashboard.EventOv
 }
 
 func getDashboardFilters(d *schema.ResourceData) []*dashboard.ChartsSingleFilter {
-	filters := d.Get("filter").(*schema.Set).List()
+	filters := d.Get("filter").([]interface{})
 	filterList := make([]*dashboard.ChartsSingleFilter, len(filters))
 	for i, filter := range filters {
 		filter := filter.(map[string]interface{})


### PR DESCRIPTION
Just changed terraform to use a list for holding these dashboard subresources (during POST/PUT request creation)
Duplicates are rejected by the backend