### PR TITLE
Fix ColorThemeIndex validation for time chart

### DIFF
--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -849,7 +849,7 @@ func timechartAPIToTF(d *schema.ResourceData, c *chart.Chart) error {
 	}
 	if options.HistogramChartOptions != nil {
 		if options.HistogramChartOptions.ColorThemeIndex != nil {
-			pc := visual.NewColorPalette()
+			pc := visual.NewColorScalePalette()
 			color, ok := pc.IndexColorName(*options.HistogramChartOptions.ColorThemeIndex)
 			if !ok {
 				return fmt.Errorf("invalid color theme index: %d", *options.HistogramChartOptions.ColorThemeIndex)


### PR DESCRIPTION
The wrong color palette is used to validate the HistogramChartOptions returned by the API, resulting in an error when the API returns a ColorThemeIndex higher than 15: `invalid color theme index: 16`