### PR TITLE
Chore: Ensure that local build tools are cached

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,8 +15,12 @@ WEBSITE_PLUGIN := $(GOTOOLS_CMD) tfplugindocs
 
 default: build
 
+.PHONY: tool-cache
+tool-cache:
+	go -C $(shell dirname $(GOTOOLS_MOD_FILE)) mod download
+
 .PHONY: addlicense
-addlicense:
+addlicense: tool-cache
 	@ADDLICENCESEOUT=`$(ADDLICENCESE) -y "" -c 'Splunk, Inc.' -l mpl -s=only $(SRC_GO_FILES) 2>&1`; \
 		if [ "$$ADDLICENCESEOUT" ]; then \
 			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
@@ -27,7 +31,7 @@ addlicense:
 		fi
 
 .PHONY: checklicense
-checklicense: 
+checklicense: tool-cache
 	@ADDLICENCESEOUT=`$(ADDLICENCESE) -check $(SRC_GO_FILES) 2>&1`; \
 		if [ "$$ADDLICENCESEOUT" ]; then \
 			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
@@ -39,15 +43,15 @@ checklicense:
 		fi
 
 .PHONY: govulncheck
-govulncheck:
+govulncheck: tool-cache
 	$(GOVULNCHECK) ./...
 
 .PHONY: lint
-lint:
+lint: tool-cache
 	$(GOLANGCI_LINT) run -v
 
 .PHONY: lint-fix
-lint-fix:
+lint-fix: tool-cache
 	$(GOLANGCI_LINT) run -v --fix
 
 build:


### PR DESCRIPTION
# Context

It appears when swapping to `go tool`, that invoking the tools directly meant that if they were not already cached on disk that they are likely to fail on the first usage.

This ensure that the required tools are downloaded and ready to use 

# Changes 

- Added a tool cache step