### PR TITLE
fix(docs): correct generated provider references

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,4 +30,4 @@ jobs:
             key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
   
         - name: Validate docs
-          run: make check-docs
+          run: make check-docs test-docs check-schema-docs

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -98,4 +98,7 @@ gen-docs:
 test-docs:
 	$(WEBSITE_PLUGIN) validate 
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck gen-docs check-docs
+check-schema-docs:
+	./scripts/check-schema-docs.sh
+
+.PHONY: build test testacc vet fmt fmtcheck errcheck gen-docs check-docs test-docs check-schema-docs

--- a/docs/data-sources/apm_service_topology.md
+++ b/docs/data-sources/apm_service_topology.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_apm_service_topology
+page_title: "Splunk Observability Cloud - signalfx_apm_service_topology"
 description: |-
     Service Topology allows you to gather data about the service dependencies based on their APM tracing data.
 ---

--- a/docs/data-sources/auto_detector.md
+++ b/docs/data-sources/auto_detector.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_auto_detector
+page_title: "Splunk Observability Cloud - signalfx_auto_detector"
 description: |-
     This data source is used to fetch the existing auto detectors in the organization.
 ---

--- a/docs/data-sources/builtin_dashboards.md
+++ b/docs/data-sources/builtin_dashboards.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_builtin_dashboards
+page_title: "Splunk Observability Cloud - signalfx_builtin_dashboards"
 description: |-
     This data source is responsible for capturing all the built in content available for the user so that they can be used within their own dashboard groups.
 ---

--- a/docs/data-sources/dimension_values.md
+++ b/docs/data-sources/dimension_values.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_dimension_values
+page_title: "Splunk Observability Cloud - signalfx_dimension_values"
 description: |-
     This data sources allows for obtaining a list of dimension values by on query provided.
 ---

--- a/docs/data-sources/organization_members.md
+++ b/docs/data-sources/organization_members.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_organization_members
+page_title: "Splunk Observability Cloud - signalfx_organization_members"
 description: |-
     Allows for members to be queried and used as part of other resources. Requires the supplied token to have Admin priviledges.
 ---

--- a/docs/data-sources/pagerduty_integration.md
+++ b/docs/data-sources/pagerduty_integration.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_pagerduty_integration
+page_title: "Splunk Observability Cloud - signalfx_pagerduty_integration"
 description: |-
     Use this data source to fetch the PagerDuty integration details.
 ---

--- a/docs/guides/version-10-migration.md
+++ b/docs/guides/version-10-migration.md
@@ -1,0 +1,13 @@
+---
+page_title: "Migrating to version 10 of the Splunk Observability Cloud provider"
+description: |-
+  Instructions for configuration or state changes required when migrating resources and data sources to Terraform Plugin Framework in provider version 10.
+---
+
+# Migrating to provider version 10
+
+Version 10 migrates provider resources and data sources to Terraform Plugin Framework. Most migrations preserve the existing Terraform type name, configuration, and state. This guide records only changes that require user action.
+
+Each breaking-change section will include old and replacement configuration, automatic state-upgrade behavior, and any required state, import, or recreation commands. Resource and data-source field reference remains generated from the provider schema in the corresponding reference page.
+
+No user-actionable breaking changes have been introduced by the completed checkpoints yet.

--- a/docs/resources/automated_archival_exempt_metric.md
+++ b/docs/resources/automated_archival_exempt_metric.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_automated_archival_exempt_metric
+page_title: "Splunk Observability Cloud - signalfx_automated_archival_exempt_metric"
 description: |-
     
 ---

--- a/docs/resources/automated_archival_settings.md
+++ b/docs/resources/automated_archival_settings.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_automated_archival_settings
+page_title: "Splunk Observability Cloud - signalfx_automated_archival_settings"
 description: |-
     
 ---

--- a/docs/resources/customized_auto_detector.md
+++ b/docs/resources/customized_auto_detector.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_customized_auto_detector
+page_title: "Splunk Observability Cloud - signalfx_customized_auto_detector"
 description: |-
     This resources allows for users to customize existing auto detectors by providing various inputs.
 ---

--- a/docs/resources/integration_splunk_oncall.md
+++ b/docs/resources/integration_splunk_oncall.md
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - signalfx_integration_splunk_oncall
+page_title: "Splunk Observability Cloud - signalfx_integration_splunk_oncall"
 description: |-
     Use this resource to manage a Splunk Oncall Integration
 ---

--- a/scripts/check-schema-docs.sh
+++ b/scripts/check-schema-docs.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+manifest="$root/scripts/migrated-schema-docs.txt"
+
+while read -r kind name; do
+	case "$kind" in
+	""|'#'*) continue ;;
+	resource)
+		template="$root/templates/resources/$name.md.tmpl"
+		fallback="$root/templates/resources.md.tmpl"
+		;;
+	data-source)
+		template="$root/templates/data-sources/$name.md.tmpl"
+		fallback="$root/templates/data-sources.md.tmpl"
+		;;
+	*)
+		echo "Unknown schema documentation kind '$kind' for '$name'" >&2
+		exit 1
+		;;
+	esac
+
+	if [ ! -f "$template" ]; then
+		template="$fallback"
+	fi
+
+	count=$(rg -c '\{\{[[:space:]]*\.SchemaMarkdown' "$template" || true)
+	if [ "$count" -ne 1 ]; then
+		echo "$kind '$name' must use exactly one generated SchemaMarkdown section in $template" >&2
+		exit 1
+	fi
+
+	if rg -n '^#{1,6}[[:space:]]+(Arguments?|Attributes?)([[:space:]]+Reference)?[[:space:]]*$' "$template" >/dev/null; then
+		echo "$kind '$name' manually documents schema fields in $template" >&2
+		exit 1
+	fi
+done < "$manifest"

--- a/scripts/migrated-schema-docs.txt
+++ b/scripts/migrated-schema-docs.txt
@@ -1,0 +1,2 @@
+# Add one entry when its SDK registration is migrated to Framework.
+# Format: resource|data-source <documentation short name>

--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - {{.Name}}
+page_title: "Splunk Observability Cloud - {{ .Name }}"
 description: |-
   {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/guides/version-10-migration.md.tmpl
+++ b/templates/guides/version-10-migration.md.tmpl
@@ -1,0 +1,13 @@
+---
+page_title: "Migrating to version 10 of the Splunk Observability Cloud provider"
+description: |-
+  Instructions for configuration or state changes required when migrating resources and data sources to Terraform Plugin Framework in provider version 10.
+---
+
+# Migrating to provider version 10
+
+Version 10 migrates provider resources and data sources to Terraform Plugin Framework. Most migrations preserve the existing Terraform type name, configuration, and state. This guide records only changes that require user action.
+
+Each breaking-change section will include old and replacement configuration, automatic state-upgrade behavior, and any required state, import, or recreation commands. Resource and data-source field reference remains generated from the provider schema in the corresponding reference page.
+
+No user-actionable breaking changes have been introduced by the completed checkpoints yet.

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -1,5 +1,5 @@
 ---
-page_tile: "Splunk Observability Cloud - {{.Name}}
+page_title: "Splunk Observability Cloud - {{ .Name }}"
 description: |-
   {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---


### PR DESCRIPTION
## Summary

Splits the documentation work previously bundled into #760 into a standalone review unit.

- corrects malformed generated page titles;
- adds the version 10 migration guide scaffold;
- enforces schema-generated field references for migrated types;
- expands documentation CI validation.

The `builtin_dashboards` change is only the generated one-line page-title correction produced by the shared data-source template. No chart or dashboard schema, implementation, or migration is included.

## Validation

- `make gen-docs`
- `make test-docs`
- `make check-schema-docs`
- generated documentation leaves the worktree clean

## Stack

Targets `release/v10` directly. The test-suite and individual integration migration PRs are stacked after this change.
