### PR TITLE
ALEN-2622

### DIFF
--- a/docs/resources/detector.md
+++ b/docs/resources/detector.md
@@ -221,7 +221,7 @@ notifications = ["Webhook,,secret,url"]
   * `severity` - (Required) The severity of the rule, must be one of: `"Critical"`, `"Major"`, `"Minor"`, `"Warning"`, `"Info"`.
   * `description` - (Optional) Description for the rule. Displays as the alert condition in the Alert Rules tab of the detector editor in the web UI.
   * `disabled` - (Optional) When true, notifications and events will not be generated for the detect label. `false` by default.
-  * `notifications` - (Optional) List of strings specifying where notifications will be sent when an incident occurs. See [Create A Single Detector](https://dev.splunk.com/observability/reference/api/detectors/latest) for more info.
+  * `notifications` - (Optional) List of strings specifying where notifications will be sent when an alert occurs. See [Create A Single Detector](https://dev.splunk.com/observability/reference/api/detectors/latest) for more info.
   * `parameterized_body` - (Optional) Custom notification message body when an alert is triggered. See [Set Up Detectors to Trigger Alerts](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html) for more info.
   * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See [Set Up Detectors to Trigger Alerts](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html) for more info.
   * `runbook_url` - (Optional) URL of page to consult when an alert is triggered. This can be used with custom notification messages.

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -152,7 +152,7 @@ notifications = ["Webhook,,secret,url"]
       * `severity` - (Required) The severity of the rule, must be one of: `"Critical"`, `"Major"`, `"Minor"`, `"Warning"`, `"Info"`.
       * `description` - (Optional) Description for the rule. Displays as the alert condition in the Alert Rules tab of the detector editor in the web UI.
       * `disabled` - (Optional) When true, notifications and events will not be generated for the detect label. `false` by default.
-      * `notifications` - (Optional) List of strings specifying where notifications will be sent when an incident occurs. See [Create SLO](https://dev.splunk.com/observability/reference/api/slo/latest#endpoint-create-new-slo) for more info.
+      * `notifications` - (Optional) List of strings specifying where notifications will be sent when an alert occurs. See [Create SLO](https://dev.splunk.com/observability/reference/api/slo/latest#endpoint-create-new-slo) for more info.
       * `parameterized_body` - (Optional) Custom notification message body when an alert is triggered. See [Alert message](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html#alert-messages) for more info.
       * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See [Alert message](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html#alert-messages) for more info.
       * `runbook_url` - (Optional) URL of page to consult when an alert is triggered. This can be used with custom notification messages.

--- a/internal/definition/orgtoken/schema.go
+++ b/internal/definition/orgtoken/schema.go
@@ -52,7 +52,7 @@ func newSchema() map[string]*schema.Schema {
 				Type:             schema.TypeString,
 				ValidateDiagFunc: check.Notification(),
 			},
-			Description: "List of strings specifying where notifications will be sent when an incident occurs. See https://developers.signalfx.com/v2/docs/detector-model#notifications-models for more info",
+			Description: "List of strings specifying where notifications will be sent when an alert occurs. See https://developers.signalfx.com/v2/docs/detector-model#notifications-models for more info",
 		},
 		"host_or_usage_limits": {
 			Type:          schema.TypeSet,

--- a/internal/definition/rule/schema.go
+++ b/internal/definition/rule/schema.go
@@ -40,7 +40,7 @@ func NewSchema() map[string]*schema.Schema {
 				Type:             schema.TypeString,
 				ValidateDiagFunc: check.Notification(),
 			},
-			Description: "List of strings specifying where notifications will be sent when an incident occurs. See https://developers.signalfx.com/v2/docs/detector-model#notifications-models for more info",
+			Description: "List of strings specifying where notifications will be sent when an alert occurs. See https://developers.signalfx.com/v2/docs/detector-model#notifications-models for more info",
 		},
 		"disabled": {
 			Type:        schema.TypeBool,

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -54,7 +54,7 @@ var (
 				Type:             schema.TypeString,
 				ValidateDiagFunc: check.Notification(),
 			},
-			Description: "List of strings specifying where notifications will be sent when an incident occurs. See https://developers.signalfx.com/v2/docs/detector-model#notifications-models for more info",
+			Description: "List of strings specifying where notifications will be sent when an alert occurs. See https://developers.signalfx.com/v2/docs/detector-model#notifications-models for more info",
 		},
 		"disabled": {
 			Type:        schema.TypeBool,

--- a/signalfx/resource_signalfx_org_token.go
+++ b/signalfx/resource_signalfx_org_token.go
@@ -140,7 +140,7 @@ func orgTokenResource() *schema.Resource {
 					Type:             schema.TypeString,
 					ValidateDiagFunc: check.Notification(),
 				},
-				Description: "List of strings specifying where notifications will be sent when an incident occurs. See https://developers.signalfx.com/v2/docs/detector-model#notifications-models for more info",
+				Description: "List of strings specifying where notifications will be sent when an alert occurs. See https://developers.signalfx.com/v2/docs/detector-model#notifications-models for more info",
 			},
 			"secret": &schema.Schema{
 				Type:      schema.TypeString,

--- a/templates/resources/detector.md.tmpl
+++ b/templates/resources/detector.md.tmpl
@@ -144,7 +144,7 @@ notifications = ["Webhook,,secret,url"]
   * `severity` - (Required) The severity of the rule, must be one of: `"Critical"`, `"Major"`, `"Minor"`, `"Warning"`, `"Info"`.
   * `description` - (Optional) Description for the rule. Displays as the alert condition in the Alert Rules tab of the detector editor in the web UI.
   * `disabled` - (Optional) When true, notifications and events will not be generated for the detect label. `false` by default.
-  * `notifications` - (Optional) List of strings specifying where notifications will be sent when an incident occurs. See [Create A Single Detector](https://dev.splunk.com/observability/reference/api/detectors/latest) for more info.
+  * `notifications` - (Optional) List of strings specifying where notifications will be sent when an alert occurs. See [Create A Single Detector](https://dev.splunk.com/observability/reference/api/detectors/latest) for more info.
   * `parameterized_body` - (Optional) Custom notification message body when an alert is triggered. See [Set Up Detectors to Trigger Alerts](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html) for more info.
   * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See [Set Up Detectors to Trigger Alerts](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html) for more info.
   * `runbook_url` - (Optional) URL of page to consult when an alert is triggered. This can be used with custom notification messages.

--- a/templates/resources/slo.md.tmpl
+++ b/templates/resources/slo.md.tmpl
@@ -127,7 +127,7 @@ notifications = ["Webhook,,secret,url"]
       * `severity` - (Required) The severity of the rule, must be one of: `"Critical"`, `"Major"`, `"Minor"`, `"Warning"`, `"Info"`.
       * `description` - (Optional) Description for the rule. Displays as the alert condition in the Alert Rules tab of the detector editor in the web UI.
       * `disabled` - (Optional) When true, notifications and events will not be generated for the detect label. `false` by default.
-      * `notifications` - (Optional) List of strings specifying where notifications will be sent when an incident occurs. See [Create SLO](https://dev.splunk.com/observability/reference/api/slo/latest#endpoint-create-new-slo) for more info.
+      * `notifications` - (Optional) List of strings specifying where notifications will be sent when an alert occurs. See [Create SLO](https://dev.splunk.com/observability/reference/api/slo/latest#endpoint-create-new-slo) for more info.
       * `parameterized_body` - (Optional) Custom notification message body when an alert is triggered. See [Alert message](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html#alert-messages) for more info.
       * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See [Alert message](https://docs.splunk.com/observability/en/alerts-detectors-notifications/create-detectors-for-alerts.html#alert-messages) for more info.
       * `runbook_url` - (Optional) URL of page to consult when an alert is triggered. This can be used with custom notification messages.


### PR DESCRIPTION
* change occurrences of 'incident' in docs to 'alerts'
* change occurrences of 'incident' in doc strings in code to 'alerts'
    
Trivial change in the same exact phrase in 4 places in the docs and 4 places in document strings in the code, the change keeps
the text consistent with its surroundings, which already refer to the events produced by detectors as 'alerts'.

All of the code changes are in static struct member initializers of the form 'Description: "...text...".'
